### PR TITLE
Add clang-format linting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,86 @@
+# clang-format configuration file
+#
+# Please seek consensus from the team before modifying this file.
+#
+# To compare these settings with all available clang-format options:
+# diff <(clang-format -dump-config | grep -Ev '^$|^( |BraceWrapping|IncludeCategories)' | sed -Ee 's/: +/: /g' | sort) <(cat .clang-format | grep -Ev '^$|^#' | sort) | colordiff
+#
+---
+DisableFormat: false
+Language: Cpp
+Standard: Cpp11
+
+# Indentation & whitespace
+AccessModifierOffset: -4
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+IndentExternBlock: NoIndent
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+SpacesBeforeTrailingComments: 2
+TabWidth: 4
+UseTab: Never
+
+# Spacing style
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+PointerAlignment: Right
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# Comments
+AlignTrailingComments: true
+CommentPragmas: ''
+FixNamespaceComments: true
+ReflowComments: true
+
+# Pattern-based special behavior
+ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: []
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+SortIncludes: false
+
+# Alignment & breaking
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowAllArgumentsOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakStringLiterals: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+
+# Prevent return type from being on a line of its own
+PenaltyReturnTypeOnItsOwnLine: 1000
+...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: "Lint"
+
+on:
+  push:
+     branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch depth must be greater than the number of commits included in the push in order to
+          # compare against commit prior to merge. 15 is chosen as a reasonable default for the
+          # upper bound of commits in a single PR.
+          fetch-depth: 15
+
+      - name: Install clang-format
+        shell: bash
+        run: pip install clang-format
+
+      - name: Run linter
+        shell: bash
+        run: |
+          git fetch --no-recurse-submodules
+          if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+              BASE=${{ github.event.before }}
+          else
+              BASE=origin/$GITHUB_BASE_REF
+          fi
+          git clang-format --verbose --extensions c,h --diff --diffstat $BASE


### PR DESCRIPTION
Sets up the same .clang-format file and Github action as in pouch.