### PR TITLE
Move Device ID to a runtime initialization parameter

### DIFF
--- a/examples/toothfairy/Kconfig
+++ b/examples/toothfairy/Kconfig
@@ -1,0 +1,7 @@
+source "$ZEPHYR_BASE/Kconfig"
+
+config EXAMPLE_DEVICE_ID
+    string "Device ID"
+    help
+        The device ID to use for the device in pouches sent to the
+        Golioth cloud.

--- a/examples/toothfairy/src/main.c
+++ b/examples/toothfairy/src/main.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
+#include <pouch/pouch.h>
 #include <pouch/events.h>
 #include <pouch/uplink.h>
 #include <pouch/transport/toothfairy/peripheral.h>
@@ -91,7 +92,7 @@ POUCH_EVENT_HANDLER(pouch_event_handler, NULL);
 int main(void)
 {
     struct toothfairy_peripheral *tf_peripheral =
-        toothfairy_peripheral_create(CONFIG_POUCH_DEVICE_ID);
+        toothfairy_peripheral_create(CONFIG_EXAMPLE_DEVICE_ID);
     if (NULL == tf_peripheral)
     {
         LOG_ERR("Failed to create toothfairy peripheral");
@@ -105,6 +106,20 @@ int main(void)
     }
 
     LOG_DBG("Bluetooth initialized\n");
+
+    struct pouch_config config = {
+        .encryption_type = POUCH_ENCRYPTION_PLAINTEXT,
+        .encryption.plaintext =
+            {
+                .device_id = CONFIG_EXAMPLE_DEVICE_ID,
+            },
+    };
+    err = pouch_init(&config);
+    if (err)
+    {
+        LOG_ERR("Pouch init failed (err %d)", err);
+        return 0;
+    }
 
     err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
     if (err)

--- a/include/pouch/pouch.h
+++ b/include/pouch/pouch.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Golioth, Inc.
+ */
+#pragma once
+
+#include <pouch/types.h>
+
+/**
+ * Initialize Pouch.
+ *
+ * @param config The configuration to use.
+ */
+int pouch_init(const struct pouch_config *config);

--- a/include/pouch/types.h
+++ b/include/pouch/types.h
@@ -17,3 +17,37 @@
 #define POUCH_CONTENT_TYPE_JSON 50
 /** The content is a CBOR encoded object */
 #define POUCH_CONTENT_TYPE_CBOR 60
+
+/** The maximum length of a device ID */
+#define POUCH_DEVICE_ID_MAX_LEN 32
+
+/** Encryption scheme for pouches */
+enum pouch_encryption
+{
+    /** No encryption */
+    POUCH_ENCRYPTION_PLAINTEXT,
+};
+
+/** Pouch configuration for plaintext encryption */
+struct pouch_encryption_config_plaintext
+{
+    /**
+     * The device ID. The length must not exceed @ref POUCH_DEVICE_ID_MAX_LEN.
+     *
+     * The memory pointed to by this field must remain valid while the pouch stack is in use.
+     */
+    const char *device_id;
+};
+
+/** Pouch configuration */
+struct pouch_config
+{
+    /** The encryption mode to use */
+    enum pouch_encryption encryption_type;
+    /** Encryption configuration */
+    union
+    {
+        /** Plaintext configuration */
+        struct pouch_encryption_config_plaintext plaintext;
+    } encryption;
+};

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -27,15 +27,6 @@ config POUCH_ENCRYPTION_NONE
 
 endchoice
 
-if POUCH_ENCRYPTION_NONE
-
-config POUCH_DEVICE_ID
-  string "Device ID"
-  help
-    The device ID to use for Pouch transfers.
-
-endif
-
 choice
   prompt "Pouch transport"
   help

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -5,12 +5,13 @@
 
 #include "cddl/header_encode_types.h"
 #include "buf.h"
+#include <pouch/types.h>
 
 /** Initialize a new pouch in the encryption engine. */
 int crypto_pouch_start(void);
 
 /** Construct the encryption info part of the pouch header */
-int crypto_header_get(struct encryption_info *encryption_info);
+int crypto_header_get(const struct pouch_config *config, struct encryption_info *encryption_info);
 
 /**
  * Encrypt a block of data.

--- a/src/crypto_none.c
+++ b/src/crypto_none.c
@@ -3,20 +3,21 @@
  */
 #include "crypto.h"
 
-#ifndef CONFIG_POUCH_DEVICE_ID
-#error "CONFIG_POUCH_DEVICE_ID must be defined"
-#endif
-
 int crypto_pouch_start(void)
 {
     return 0;
 }
 
-int crypto_header_get(struct encryption_info *encryption_info)
+int crypto_header_get(const struct pouch_config *config, struct encryption_info *encryption_info)
 {
+    if (config->encryption.plaintext.device_id == NULL)
+    {
+        return -EINVAL;
+    }
+
     encryption_info->Union_choice = encryption_info_union_plaintext_info_m_c;
-    encryption_info->plaintext_info_m.id.len = sizeof(CONFIG_POUCH_DEVICE_ID) - 1;
-    encryption_info->plaintext_info_m.id.value = CONFIG_POUCH_DEVICE_ID;
+    encryption_info->plaintext_info_m.id.len = strlen(config->encryption.plaintext.device_id);
+    encryption_info->plaintext_info_m.id.value = config->encryption.plaintext.device_id;
 
     return 0;
 }

--- a/src/header.c
+++ b/src/header.c
@@ -15,19 +15,29 @@
 
 #define POUCH_HEADER_VERSION 1
 
+// CBOR array start + version
+#define POUCH_HEADER_OVERHEAD 2
+
 #if defined(CONFIG_POUCH_ENCRYPTION_NONE)
-#define POUCH_HEADER_MAX_LEN 5 + sizeof(CONFIG_POUCH_DEVICE_ID)
+
+/* CBOR encryption_type + 32 byte string declaration. Assumes that the device ID max length is less
+ * than 256 bytes.
+ */
+#define POUCH_HEADER_OVERHEAD_ENCRYPTION_NONE 3
+
+#define POUCH_HEADER_MAX_LEN \
+    (POUCH_HEADER_OVERHEAD + POUCH_HEADER_OVERHEAD_ENCRYPTION_NONE + POUCH_DEVICE_ID_MAX_LEN)
 #else
 #error "Unsupported encryption type"
 #endif
 
-static int write_header(struct pouch_buf *buf, size_t maxlen)
+static int write_header(const struct pouch_config *config, struct pouch_buf *buf, size_t maxlen)
 {
     struct pouch_header header = {
         .version = POUCH_HEADER_VERSION,
     };
 
-    int err = crypto_header_get(&header.encryption_info_m);
+    int err = crypto_header_get(config, &header.encryption_info_m);
     if (err)
     {
         return err;
@@ -45,16 +55,15 @@ static int write_header(struct pouch_buf *buf, size_t maxlen)
     return 0;
 }
 
-struct pouch_buf *pouch_header_create(void)
+struct pouch_buf *pouch_header_create(const struct pouch_config *config)
 {
-    // Not blocking this call:
     struct pouch_buf *header = buf_alloc(POUCH_HEADER_MAX_LEN);
     if (!header)
     {
         return NULL;
     }
 
-    int err = write_header(header, POUCH_HEADER_MAX_LEN);
+    int err = write_header(config, header, POUCH_HEADER_MAX_LEN);
     if (err)
     {
         buf_free(header);

--- a/src/header.h
+++ b/src/header.h
@@ -4,8 +4,9 @@
 #pragma once
 
 #include "buf.h"
+#include <pouch/types.h>
 
 /**
  * Allocate and encode a pouch header.
  */
-struct pouch_buf *pouch_header_create(void);
+struct pouch_buf *pouch_header_create(const struct pouch_config *config);

--- a/src/pouch.c
+++ b/src/pouch.c
@@ -6,6 +6,7 @@
 #include <pouch/events.h>
 #include <pouch/transport/uplink.h>
 #include <pouch/types.h>
+#include <string.h>
 
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
@@ -21,9 +22,20 @@ void pouch_event_emit(enum pouch_event event)
     }
 }
 
-int pouch_init(void)
+int pouch_init(const struct pouch_config *config)
 {
-    return uplink_init();
-}
+    if (config->encryption_type != POUCH_ENCRYPTION_PLAINTEXT)
+    {
+        return -ENOTSUP;
+    }
+    if (!config->encryption.plaintext.device_id)
+    {
+        return -EINVAL;
+    }
+    if (strlen(config->encryption.plaintext.device_id) > POUCH_DEVICE_ID_MAX_LEN)
+    {
+        return -EINVAL;
+    }
 
-SYS_INIT(pouch_init, APPLICATION, 0);
+    return uplink_init(config);
+}

--- a/src/uplink.c
+++ b/src/uplink.c
@@ -24,6 +24,7 @@ enum flags
 
 struct pouch_uplink
 {
+    struct pouch_config config;
     struct pouch_buf *header;
     atomic_t flags;
     int error;
@@ -102,8 +103,9 @@ int pouch_uplink_close(k_timeout_t timeout)
     return entry_block_close(timeout);
 }
 
-int uplink_init(void)
+int uplink_init(const struct pouch_config *config)
 {
+    uplink.config = *config;
     buf_queue_init(&uplink.processing.queue);
     buf_queue_init(&uplink.transport.queue);
     k_work_init(&uplink.processing.work, process_blocks);
@@ -123,7 +125,7 @@ struct pouch_uplink *pouch_uplink_start(void)
     crypto_pouch_start();
 
     // Create the header, but don't push it to the queue until we have data to send:
-    uplink.header = pouch_header_create();
+    uplink.header = pouch_header_create(&uplink.config);
     if (!uplink.header)
     {
         return NULL;

--- a/src/uplink.h
+++ b/src/uplink.h
@@ -4,8 +4,9 @@
 #pragma once
 
 #include "buf.h"
+#include <pouch/types.h>
 
 /** Initialize the pouch uplink handler */
-int uplink_init(void);
+int uplink_init(const struct pouch_config *config);
 
 void uplink_enqueue(struct pouch_buf *block);

--- a/tests/pouch/uplink/prj.conf
+++ b/tests/pouch/uplink/prj.conf
@@ -2,4 +2,3 @@ CONFIG_ZTEST=y
 CONFIG_POUCH=y
 # Some of the tests require more threads waiting on the same mutex than the basic wait queue can handle
 CONFIG_WAITQ_SCALABLE=y
-CONFIG_POUCH_DEVICE_ID="test-device-id"

--- a/tests/pouch/uplink/src/events.c
+++ b/tests/pouch/uplink/src/events.c
@@ -3,13 +3,26 @@
  */
 #include <zephyr/ztest.h>
 #include <pouch/events.h>
-#include <pouch/events.h>
+#include <pouch/pouch.h>
 #include "mocks/transport.h"
 
 static uint32_t start_events;
 static uint32_t end_events;
 
-ZTEST_SUITE(events, NULL, NULL, NULL, NULL, NULL);
+#define DEVICE_ID "test-device-id"
+
+static const struct pouch_config pouch_config = {
+    .encryption_type = POUCH_ENCRYPTION_PLAINTEXT,
+    .encryption.plaintext.device_id = DEVICE_ID,
+};
+
+static void *init_pouch(void)
+{
+    pouch_init(&pouch_config);
+    return NULL;
+}
+
+ZTEST_SUITE(events, NULL, init_pouch, NULL, NULL, NULL);
 
 static void event_handler(enum pouch_event event, void *ctx)
 {

--- a/tests/pouch/uplink/src/uplink.c
+++ b/tests/pouch/uplink/src/uplink.c
@@ -5,11 +5,26 @@
 #include <zephyr/sys/byteorder.h>
 #include <zcbor_decode.h>
 #include <stdlib.h>
+
 #include "mocks/transport.h"
 
 #include <pouch/uplink.h>
+#include <pouch/pouch.h>
 
-ZTEST_SUITE(uplink, NULL, NULL, NULL, transport_reset, NULL);
+#define DEVICE_ID "test-device-id"
+
+static const struct pouch_config pouch_config = {
+    .encryption_type = POUCH_ENCRYPTION_PLAINTEXT,
+    .encryption.plaintext.device_id = DEVICE_ID,
+};
+
+static void *init_pouch(void)
+{
+    pouch_init(&pouch_config);
+    return NULL;
+}
+
+ZTEST_SUITE(uplink, NULL, init_pouch, NULL, transport_reset, NULL);
 
 K_SEM_DEFINE(write_done, 0, UINT16_MAX);
 
@@ -96,11 +111,8 @@ ZTEST(uplink, test_pouch_header)
 
     struct zcbor_string string = {0};
     zassert_true(zcbor_tstr_decode(zsd, &string));
-    zassert_equal(string.len,
-                  strlen(CONFIG_POUCH_DEVICE_ID),
-                  "Unexpected device ID length %d",
-                  string.len);
-    zassert_str_equal(string.value, CONFIG_POUCH_DEVICE_ID);
+    zassert_equal(string.len, strlen(DEVICE_ID), "Unexpected device ID length %d", string.len);
+    zassert_str_equal(string.value, DEVICE_ID);
 
     zassert_true(zcbor_list_end_decode(zsd));
 


### PR DESCRIPTION
Adds a pouch_init function that takes a configuration object, like golioth_client does. This includes the encryption type (only plaintext for now), and the parameters for the encryption (device ID for now).

The example adds a `CONFIG_EXAMPLE_DEVICE_ID` kconfig entry to give us the same UX when building the example, without enforcing this pattern on all apps.

Example of what this could eventually look like with SAEAD:

<details>
<summary>Expand code snippet</summary>

```c

/** Encryption scheme for pouches */
enum pouch_encryption
{
    /** No encryption */
    POUCH_ENCRYPTION_PLAINTEXT,
    /** Streaming AEAD encryption */
    POUCH_ENCRYPTION_SAEAD,
};

/** SAEAD encryption algorithm */
enum pouch_saead_algorithm
{
    /** AES-CCM */
    POUCH_SAEAD_ALGORITHM_AES_CCM,
    /** ChaCha20-Poly1305 */
    POUCH_SAEAD_ALGORITHM_CHACHA20_POLY1305,
};

/** SAEAD authentication type */
enum pouch_saead_auth_type
{
    /** Pre-shared key */
    POUCH_AUTH_TYPE_PSK,
    /** Certificate */
    POUCH_AUTH_TYPE_CERTIFICATE,
};

/** Pouch pre-shared key data */
struct pouch_psk
{
    /** Pre-shared key identifier */
    const char *id;
    /** Identifier length */
    size_t id_len;
    /** Pre-shared key */
    const char *key;
    /** Key length */
    size_t key_len;
};

/** Pouch public key authentication */
struct pouch_pki
{
    /** Certificate identifier */
    const char *id;
    /** Identifier length */
    size_t id_len;

    /** Device certificate */
    const uint8_t *cert;
    /** Device certificate length */
    size_t cert_len;

    /** Device private key */
    const uint8_t *private_key;
    /** Device private key length */
    size_t private_key_len;
};

/** Pouch configuration for streaming AEAD encryption */
struct pouch_encryption_config_saead
{
    /** The encryption algorithm */
    enum pouch_saead_algorithm algorithm;
    /** The encryption type */
    enum pouch_saead_auth_type auth_type;
    /** Authentication data */
    union
    {
        /** Pre-shared key */
        struct pouch_psk psk;
        /** Public key */
        struct pouch_pki pki;
    } auth;
};

/** Pouch configuration for plaintext */
struct pouch_encryption_config_plaintext
{
    /** The device ID */
    const char *device_id;
};

/** Pouch configuration */
struct pouch_config
{
    /** The encryption mode to use */
    enum pouch_encryption encryption_type;
    union
    {
        /** Plaintext configuration */
        struct pouch_encryption_config_plaintext plaintext;
        /** Streaming AEAD encryption configuration */
        struct pouch_encryption_config_saead saead;
    } encryption;
};
```
</details>