### PR TITLE
Clang format: Remove CPP language specifier

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,8 +7,6 @@
 #
 ---
 DisableFormat: false
-Language: Cpp
-Standard: Cpp11
 
 # Indentation & whitespace
 AccessModifierOffset: -4


### PR DESCRIPTION
clang-format 20.1.0 adds [C as a language instead of treating it as C++](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#clang-format). This breaks our clang-format configuration, which scopes the configuration to CPP at the start of the config file, making the lint action claim that C isn't supported by the configuration.