### PR TITLE
Add stream blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources(
   src/buf.c
   src/block.c
   src/entry.c
+  src/stream.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_POUCH_ENCRYPTION_NONE src/crypto_none.c)

--- a/include/pouch/types.h
+++ b/include/pouch/types.h
@@ -11,12 +11,19 @@
  * @brief Pouch type definitions
  */
 
+/**
+ * @defgroup content_types Pouch content types
+ * @{
+ */
+
 /** The content is a raw octet stream */
 #define POUCH_CONTENT_TYPE_OCTET_STREAM 42
 /** The content is a JSON encoded object */
 #define POUCH_CONTENT_TYPE_JSON 50
 /** The content is a CBOR encoded object */
 #define POUCH_CONTENT_TYPE_CBOR 60
+
+/** @} */
 
 /** The maximum length of a device ID */
 #define POUCH_DEVICE_ID_MAX_LEN 32

--- a/include/pouch/uplink.h
+++ b/include/pouch/uplink.h
@@ -12,14 +12,24 @@
  * @brief Pouch uplink API for sending data to the cloud
  */
 
+/** Maximum number of streams that can be open simultaneously in the same uplink session */
+#define POUCH_STREAMS_MAX 126
+
+struct pouch_stream;
+
 /**
  * Write an entry to the pouch uplink.
  *
- * @param path The CoAP path to write the entry to.
+ * The content type is defined by the CoAP Content-Formats sub-registry within the IANA CoRE.
+ * See @ref content_types.
+ *
+ * @param path The path to write the entry to.
  * @param content_type The content type of the entry.
  * @param data The data to write.
  * @param len The length of the data.
  * @param timeout The timeout for the operation.
+ *
+ * @return 0 on success or a negative error code on failure.
  */
 int pouch_uplink_entry_write(const char *path,
                              uint16_t content_type,
@@ -29,5 +39,73 @@ int pouch_uplink_entry_write(const char *path,
 
 /**
  * Close the current uplink session by finalizing the open pouch.
+ *
+ * @return 0 on success or a negative error code on failure.
  */
 int pouch_uplink_close(k_timeout_t timeout);
+
+/**
+ * Open a new stream to the uplink.
+ *
+ * Note that the stream must be closed with @ref pouch_stream_close() before the uplink session is
+ * closed with @ref pouch_uplink_close().
+ *
+ * The content type is defined by the CoAP Content-Formats sub-registry within the IANA CoRE.
+ * See @ref content_types.
+ *
+ * @param path The path to write the entry to.
+ * @param content_type The content type of the entry.
+ *
+ * @return A stream handle or NULL on error.
+ */
+struct pouch_stream *pouch_uplink_stream_open(const char *path, uint16_t content_type);
+
+/**
+ * Write data to a stream.
+ *
+ * The stream must be opened with @ref pouch_uplink_stream_open().
+ *
+ * The data is written to the stream in blocks. The number of bytes written may be less than the
+ * requested length if pouch is unable to allocate enough memory to write the data. In this case,
+ * the function will return the number of bytes written before the memory allocation failed.
+ * The caller should retry the write operation with the remaining data once more memory is
+ * available.
+ *
+ * @note This function is not thread-safe. The caller must ensure that only one thread writes to a
+ * stream at a time.
+ *
+ * @param stream The stream to write to.
+ * @param data The data to write.
+ * @param len The length of the data.
+ * @param timeout The timeout for the write operation. If the timeout is reached before the write
+ * operation completes, the function will return the number of bytes written before the timeout.
+ *
+ * @return The number of bytes written.
+ */
+size_t pouch_stream_write(struct pouch_stream *stream,
+                          const void *data,
+                          size_t len,
+                          k_timeout_t timeout);
+
+/**
+ * Close a stream.
+ *
+ * @param stream The stream to close.
+ * @param timeout The timeout for the close operation.
+ *
+ * @return 0 on success or a negative error code on failure.
+ */
+int pouch_stream_close(struct pouch_stream *stream, k_timeout_t timeout);
+
+/**
+ * Check if a stream is valid.
+ *
+ * An invalid stream cannot be written to, and should be closed with @ref pouch_stream_close().
+ * The data in the stream will not be processed in the cloud, but data usage may still be incurred
+ * on stream data that has already been forwarded to the gateway.
+ *
+ * @param stream The stream to check.
+ *
+ * @return true if the stream is valid, false otherwise.
+ */
+bool pouch_stream_is_valid(struct pouch_stream *stream);

--- a/src/block.c
+++ b/src/block.c
@@ -10,33 +10,50 @@
 
 #define BLOCK_SIZE (HEADER_OVERHEAD + CONFIG_POUCH_BLOCK_SIZE)
 
-enum block_type
-{
-    BLOCK_TYPE_ENTRY,
-};
+/** Special block ID for entry blocks */
+#define BLOCK_ID_ENTRY 0x00
 
-static inline void write_block_size(struct pouch_buf *block, size_t size)
+/** Mask for ID field indicating that this is the last block in the stream */
+#define NO_MORE_DATA_MASK 0x80
+
+static void write_block_header(struct pouch_buf *block, size_t size, uint8_t id, bool more_data)
 {
+    if (!more_data)
+    {
+        id |= NO_MORE_DATA_MASK;
+    }
+
     sys_put_be16(size, buf_claim(block, sizeof(uint16_t)));
-}
-
-static void write_block_header(struct pouch_buf *block, enum block_type type, uint8_t stream_id)
-{
-    write_block_size(block, 0);
-    *buf_claim(block, 1) = type;
+    *buf_claim(block, 1) = id;
 }
 
 size_t block_space_get(const struct pouch_buf *block)
 {
-    return BLOCK_SIZE - buf_size_get(block);
+    return CONFIG_POUCH_BLOCK_SIZE - block_size_get(block);
+}
+
+size_t block_size_get(const struct pouch_buf *block)
+{
+    return buf_size_get(block) - HEADER_OVERHEAD;
 }
 
 struct pouch_buf *block_alloc(void)
 {
     struct pouch_buf *block = buf_alloc(BLOCK_SIZE);
-    if (block)
+    if (block != NULL)
     {
-        write_block_header(block, BLOCK_TYPE_ENTRY, 0);
+        write_block_header(block, 0, BLOCK_ID_ENTRY, false);
+    }
+
+    return block;
+}
+
+struct pouch_buf *block_alloc_stream(uint8_t stream_id)
+{
+    struct pouch_buf *block = buf_alloc(BLOCK_SIZE);
+    if (block != NULL)
+    {
+        write_block_header(block, 0, stream_id, true);
     }
 
     return block;
@@ -47,15 +64,26 @@ void block_free(struct pouch_buf *block)
     buf_free(block);
 }
 
-void block_finish(struct pouch_buf *block)
+static void finish(struct pouch_buf *block, uint8_t id, bool more_data)
 {
-    size_t size = buf_size_get(block);
+    size_t size = block_size_get(block);
     pouch_buf_state_t state = buf_state_get(block);
 
     // Temporarily roll back the block to the initial state so we can write the block size:
     buf_restore(block, POUCH_BUF_STATE_INITIAL);
-    write_block_size(block, size - HEADER_OVERHEAD);
+
+    write_block_header(block, size, id, more_data);
 
     // Restore:
     buf_restore(block, state);
+}
+
+void block_finish(struct pouch_buf *block)
+{
+    finish(block, BLOCK_ID_ENTRY, false);
+}
+
+void block_finish_stream(struct pouch_buf *block, uint8_t stream_id, bool more_data)
+{
+    finish(block, stream_id, more_data);
 }

--- a/src/block.h
+++ b/src/block.h
@@ -6,10 +6,16 @@
 #include <zephyr/kernel.h>
 #include "buf.h"
 
+#define BLOCK_ID_MASK 0x7f
+
 struct pouch_buf *block_alloc(void);
+
+struct pouch_buf *block_alloc_stream(uint8_t stream_id);
 
 void block_free(struct pouch_buf *block);
 
 size_t block_space_get(const struct pouch_buf *block);
+size_t block_size_get(const struct pouch_buf *block);
 
 void block_finish(struct pouch_buf *block);
+void block_finish_stream(struct pouch_buf *block, uint8_t stream_id, bool more_data);

--- a/src/entry.c
+++ b/src/entry.c
@@ -121,7 +121,7 @@ int entry_block_close(k_timeout_t timeout)
         return err;
     }
 
-    if (block)
+    if (block && block_size_get(block) > 0)
     {
         block_finish(block);
         uplink_enqueue(block);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025 Golioth, Inc.
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <pouch/uplink.h>
+#include "buf.h"
+#include "block.h"
+#include "uplink.h"
+
+/** Single stream instance */
+struct pouch_stream
+{
+    /** Stream ID */
+    uint8_t id;
+    /** Buffer for stream data */
+    struct pouch_buf *buf;
+    /** Number of bytes written to the stream */
+    size_t bytes;
+    /** Session ID this stream was created for */
+    uint32_t session_id;
+};
+
+/** Next stream ID */
+static atomic_t stream_id = ATOMIC_INIT(1);
+/** Number of open streams */
+static atomic_t open_streams;
+
+static void write_stream_header(struct pouch_buf *block, uint16_t content_type, const char *path)
+{
+    size_t path_len = strlen(path);
+
+    sys_put_be16(content_type, buf_claim(block, sizeof(uint16_t)));
+    *buf_claim(block, 1) = path_len;
+    buf_write(block, path, path_len);
+}
+
+static uint8_t new_stream_id(void)
+{
+    uint8_t id;
+    // ID 0 is reserved:
+    do
+    {
+        id = atomic_inc(&stream_id) & BLOCK_ID_MASK;
+    } while (id == 0);
+
+    return id;
+}
+
+struct pouch_stream *pouch_uplink_stream_open(const char *path, uint16_t content_type)
+{
+    if (atomic_inc(&open_streams) >= POUCH_STREAMS_MAX)
+    {
+        atomic_dec(&open_streams);
+        return NULL;
+    }
+
+    struct pouch_stream *stream = malloc(sizeof(struct pouch_stream));
+    if (stream == NULL)
+    {
+        atomic_dec(&open_streams);
+        return NULL;
+    }
+
+    stream->id = new_stream_id();
+    stream->bytes = 0;
+    stream->session_id = uplink_session_id();
+
+    stream->buf = block_alloc_stream(stream->id);
+    if (stream->buf == NULL)
+    {
+        free(stream);
+        atomic_dec(&open_streams);
+        return NULL;
+    }
+
+    write_stream_header(stream->buf, content_type, path);
+
+    return stream;
+}
+
+size_t pouch_stream_write(struct pouch_stream *stream,
+                          const void *data,
+                          size_t len,
+                          k_timeout_t timeout)
+{
+    const uint8_t *bytes = data;
+    size_t written = 0;
+
+    if (!pouch_stream_is_valid(stream))
+    {
+        return 0;
+    }
+
+    while (written < len)
+    {
+        size_t space = block_space_get(stream->buf);
+        if (space == 0)
+        {
+            /* We need a new buf, but we'll keep the old one around until we're sure a new one is
+             * allocated, to make sure that the stream always has a buffer pointer. This lets us
+             * mark the current block with "no more data" if the app decides to bail out on the
+             * stream as a result of this failed write instead of having to allocate an empty block
+             * for this.
+             */
+            struct pouch_buf *buf = block_alloc_stream(stream->id);
+            if (buf == NULL)
+            {
+                break;
+            }
+
+            block_finish_stream(stream->buf, stream->id, true);
+            uplink_enqueue(stream->buf);
+
+            stream->buf = buf;
+            space = block_space_get(stream->buf);
+        }
+
+        size_t write_len = MIN(space, len - written);
+        buf_write(stream->buf, &bytes[written], write_len);
+        written += write_len;
+    }
+
+    stream->bytes += written;
+
+    return written;
+}
+
+int pouch_stream_close(struct pouch_stream *stream, k_timeout_t timeout)
+{
+    if (stream == NULL)
+    {
+        return -EINVAL;
+    }
+
+    if (pouch_stream_is_valid(stream) && stream->bytes > 0)
+    {
+        block_finish_stream(stream->buf, stream->id, false);
+        uplink_enqueue(stream->buf);
+    }
+    else
+    {
+        block_free(stream->buf);
+    }
+
+    atomic_dec(&open_streams);
+    free(stream);
+
+    return 0;
+}
+
+bool pouch_stream_is_valid(struct pouch_stream *stream)
+{
+    return (stream != NULL) && (stream->session_id == uplink_session_id());
+}

--- a/src/uplink.h
+++ b/src/uplink.h
@@ -10,3 +10,6 @@
 int uplink_init(const struct pouch_config *config);
 
 void uplink_enqueue(struct pouch_buf *block);
+
+/** Get the current uplink session ID */
+uint32_t uplink_session_id(void);

--- a/tests/pouch/common/include/utils.h
+++ b/tests/pouch/common/include/utils.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Golioth, Inc.
+ */
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <zephyr/sys/byteorder.h>
+#include <zcbor_decode.h>
+#include <zephyr/ztest.h>
+
+struct block
+{
+    uint8_t id;
+    bool more_data;
+    size_t data_len;
+    uint8_t *data;
+};
+
+/** Test utility for pulling a block out of the given buffer */
+static inline void pull_block(uint8_t **buf, struct block *block)
+{
+    uint8_t *data = *buf;
+    block->data_len = sys_get_be16(&data[0]) - 1;
+    block->id = data[2] & 0x7f;
+    block->more_data = !(data[2] & 0x80);
+    block->data = &data[3];
+    *buf = &data[3 + block->data_len];
+}
+
+struct stream_block
+{
+    struct block block;
+    uint16_t content_type;
+    size_t path_len;
+    uint8_t *path;
+    uint8_t *data;
+    size_t data_len;
+};
+
+/** Test utility for pulling a stream block out of the given buffer */
+static inline void pull_stream_block(uint8_t **buf, struct stream_block *block)
+{
+    pull_block(buf, &block->block);
+    block->content_type = sys_get_be16(block->block.data);
+    block->path_len = block->block.data[2];
+    block->path = &block->block.data[3];
+    block->data = &block->block.data[3 + block->path_len];
+    block->data_len = block->block.data_len - 3 - block->path_len;
+}
+
+
+static inline uint8_t *skip_pouch_header(const uint8_t *buf, size_t *len)
+{
+    // skip the pouch header:
+    ZCBOR_STATE_D(zsd, 2, buf, *len, 1, 0);
+
+    zassert_true(zcbor_list_start_decode(zsd));
+    while (!zcbor_array_at_end(zsd))
+    {
+        zcbor_any_skip(zsd, NULL);
+    }
+    zassert_true(zcbor_list_end_decode(zsd));
+
+    uint8_t *block = (uint8_t *) zsd->payload;
+    *len -= (block - buf);
+
+    return block;
+}


### PR DESCRIPTION
Adds an API for streaming data over the uplink. The streams are heap allocated, and the application is responsible for their life cycle. The application can write data to the stream through a posix like write API.

Blocks are allocated for the stream as we go, with a single entry header in the first block. The block type has been extended to a 1 + 7 bit field, where the MSb is a flag indicating no more data. and the other bits for indicating a block ID, where block ID 0 is reserved for entry blocks. The no more data flag is always set for the entry blocks.

The streams are only valid for the pouch they were created for, and the application is responsible for finishing the open streams before they close the pouch. Streams that aren't closed before closing a pouch are considered invalid, and will be lost.