### PR TITLE
transport: ble_gatt: packetizer: add packet decode

### DIFF
--- a/src/transport/ble_gatt/packetizer.c
+++ b/src/transport/ble_gatt/packetizer.c
@@ -156,3 +156,19 @@ void golioth_ble_gatt_packetizer_finish(struct golioth_ble_gatt_packetizer *pack
 {
     free(packetizer);
 }
+
+int golioth_ble_gatt_packetizer_decode(const void *buf,
+                                       size_t buf_len,
+                                       const void **payload,
+                                       bool *is_first,
+                                       bool *is_last)
+{
+    const struct golioth_ble_gatt_packet *pkt = buf;
+
+    *is_first = (0 != (pkt->flags & GOLIOTH_BLE_GATT_PACKET_FIRST));
+    *is_last = (0 != (pkt->flags & GOLIOTH_BLE_GATT_PACKET_LAST));
+
+    *payload = &pkt->data;
+
+    return buf_len - sizeof(struct golioth_ble_gatt_packet);
+}

--- a/src/transport/ble_gatt/packetizer.h
+++ b/src/transport/ble_gatt/packetizer.h
@@ -28,3 +28,9 @@ enum golioth_ble_gatt_packetizer_result golioth_ble_gatt_packetizer_get(
     size_t *dst_len);
 int golioth_ble_gatt_packetizer_error(struct golioth_ble_gatt_packetizer *packetizer);
 void golioth_ble_gatt_packetizer_finish(struct golioth_ble_gatt_packetizer *packetizer);
+
+int golioth_ble_gatt_packetizer_decode(const void *buf,
+                                       size_t buf_len,
+                                       const void **payload,
+                                       bool *is_first,
+                                       bool *is_last);


### PR DESCRIPTION
Add support for decoding toothfairy packets to the packetizer. This function is trivial, but preserves abstraction barriers.