### PR TITLE
cmake: allow including libraries without pouch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,37 +1,37 @@
-if(NOT CONFIG_POUCH)
-    return()
-endif()
+if(CONFIG_POUCH)
 
-zephyr_include_directories(include)
+    zephyr_include_directories(include)
 
-zephyr_library()
+    zephyr_library()
 
-zephyr_library_sources(
-  ${CMAKE_CURRENT_BINARY_DIR}/header_encode.c
-  src/pouch.c
-  src/uplink.c
-  src/header.c
-  src/buf.c
-  src/block.c
-  src/entry.c
-  src/stream.c
-)
+    zephyr_library_sources(
+      ${CMAKE_CURRENT_BINARY_DIR}/header_encode.c
+      src/pouch.c
+      src/uplink.c
+      src/header.c
+      src/buf.c
+      src/block.c
+      src/entry.c
+      src/stream.c
+    )
 
-zephyr_library_sources_ifdef(CONFIG_POUCH_ENCRYPTION_NONE src/crypto_none.c)
+    zephyr_library_sources_ifdef(CONFIG_POUCH_ENCRYPTION_NONE src/crypto_none.c)
 
-zephyr_linker_sources(SECTIONS src/event_handlers.ld)
+    zephyr_linker_sources(SECTIONS src/event_handlers.ld)
 
-add_custom_command(OUTPUT header_encode.c
-    COMMAND zcbor code -c ${CMAKE_CURRENT_LIST_DIR}/src/header.cddl -t pouch_header -se --include-prefix cddl/ --oc header_encode.c --oh include/cddl/header_encode.h
-    BYPRODUCTS include/cddl/header_encode.h include/cddl/header_types.h
-    DEPENDS src/header.cddl)
+    add_custom_command(OUTPUT header_encode.c
+        COMMAND zcbor code -c ${CMAKE_CURRENT_LIST_DIR}/src/header.cddl -t pouch_header -se --include-prefix cddl/ --oc header_encode.c --oh include/cddl/header_encode.h
+        BYPRODUCTS include/cddl/header_encode.h include/cddl/header_types.h
+        DEPENDS src/header.cddl)
 
-zephyr_library_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+    zephyr_library_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
-# Transports
+    # Transports
 
-if (CONFIG_POUCH_TRANSPORT_BLE_GATT)
-    add_subdirectory(src/transport/ble_gatt)
+    if (CONFIG_POUCH_TRANSPORT_BLE_GATT)
+        add_subdirectory(src/transport/ble_gatt)
+    endif()
+
 endif()
 
 # Libraries


### PR DESCRIPTION
Ensure that library CMakeLists.txt files are included even when `CONFIG_POUCH` is disabled.

Easier to review when ignoring whitespace changes.