### PR TITLE
Packetizer decoder: Check for invalid parameters

### DIFF
--- a/lib/pouch_ble_gatt_common/include/pouch/transport/ble_gatt/common/packetizer.h
+++ b/lib/pouch_ble_gatt_common/include/pouch/transport/ble_gatt/common/packetizer.h
@@ -4,6 +4,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <sys/types.h>
 
 struct golioth_ble_gatt_packetizer;
 
@@ -29,8 +30,8 @@ enum golioth_ble_gatt_packetizer_result golioth_ble_gatt_packetizer_get(
 int golioth_ble_gatt_packetizer_error(struct golioth_ble_gatt_packetizer *packetizer);
 void golioth_ble_gatt_packetizer_finish(struct golioth_ble_gatt_packetizer *packetizer);
 
-int golioth_ble_gatt_packetizer_decode(const void *buf,
-                                       size_t buf_len,
-                                       const void **payload,
-                                       bool *is_first,
-                                       bool *is_last);
+ssize_t golioth_ble_gatt_packetizer_decode(const void *buf,
+                                           size_t buf_len,
+                                           const void **payload,
+                                           bool *is_first,
+                                           bool *is_last);

--- a/lib/pouch_ble_gatt_common/packetizer.c
+++ b/lib/pouch_ble_gatt_common/packetizer.c
@@ -157,12 +157,22 @@ void golioth_ble_gatt_packetizer_finish(struct golioth_ble_gatt_packetizer *pack
     free(packetizer);
 }
 
-int golioth_ble_gatt_packetizer_decode(const void *buf,
-                                       size_t buf_len,
-                                       const void **payload,
-                                       bool *is_first,
-                                       bool *is_last)
+ssize_t golioth_ble_gatt_packetizer_decode(const void *buf,
+                                           size_t buf_len,
+                                           const void **payload,
+                                           bool *is_first,
+                                           bool *is_last)
 {
+    if (buf == NULL || payload == NULL || is_first == NULL || is_last == NULL)
+    {
+        return -EINVAL;
+    }
+
+    if (buf_len < sizeof(struct golioth_ble_gatt_packet))
+    {
+        return -EINVAL;
+    }
+
     const struct golioth_ble_gatt_packet *pkt = buf;
 
     *is_first = (0 != (pkt->flags & GOLIOTH_BLE_GATT_PACKET_FIRST));


### PR DESCRIPTION
GATT read callback occasionally gets zero length data. This should result in an error, but it's currently just accessing the first byte.

Adds a couple of guards and changes the return type to ssize_t.