### PR TITLE
block: Simplify header logic

### DIFF
--- a/tests/pouch/uplink/src/uplink.c
+++ b/tests/pouch/uplink/src/uplink.c
@@ -690,10 +690,10 @@ ZTEST(uplink, test_stream_length_aligned_to_block_size)
         pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
     zassert_not_null(stream, "Failed to open stream");
 
-    // Write data that is exactly aligned to the size of two blocks. Need to account for the ID in
-    // both blocks, as well as the size of the content_type, path_length and path in the first
+    // Write data that is exactly aligned to the size of two blocks. Need to account for the header
+    // in both blocks, as well as the size of the content_type, path_length and path in the first
     // block.
-    size_t data_len = (CONFIG_POUCH_BLOCK_SIZE - 1) * 2 - (2 + 1 + strlen("test/path"));
+    size_t data_len = (CONFIG_POUCH_BLOCK_SIZE - 3) * 2 - (2 + 1 + strlen("test/path"));
     uint8_t *data = malloc(data_len);
     for (int i = 0; i < sizeof(data); i++)
     {
@@ -724,7 +724,7 @@ ZTEST(uplink, test_stream_length_aligned_to_block_size)
     zassert_true(block1.block.more_data, "Unexpected no more data");
     zassert_not_equal(block1.block.id, 0, "Unexpected stream ID");
     zassert_equal(block1.block.data_len,
-                  CONFIG_POUCH_BLOCK_SIZE - 1,  // 1 for the id
+                  CONFIG_POUCH_BLOCK_SIZE - 3,  // 3 for the header
                   "Unexpected block length %d",
                   block1.data_len);
     zassert_mem_equal(block1.data, data, block1.data_len);
@@ -735,7 +735,7 @@ ZTEST(uplink, test_stream_length_aligned_to_block_size)
     zassert_false(block2.more_data, "Unexpected more data");
     zassert_equal(block2.id, block1.block.id, "Unexpected stream ID");
     zassert_equal(block2.data_len,
-                  CONFIG_POUCH_BLOCK_SIZE - 1,  // 1 for the id
+                  CONFIG_POUCH_BLOCK_SIZE - 3,  // 3 for the header
                   "Unexpected block length %d",
                   block2.data_len);
     zassert_mem_equal(block2.data, &data[block1.data_len], block2.data_len);

--- a/tests/pouch/uplink/testcase.yaml
+++ b/tests/pouch/uplink/testcase.yaml
@@ -2,6 +2,8 @@ tests:
   pouch.uplink:
     platform_allow:
       - native_sim
+      - native_sim/native/64
     integration_platforms:
       - native_sim
+      - native_sim/native/64
     tags: test_framework


### PR DESCRIPTION
Clarify the format of the block header. Include the header in the configurable block size to simplify calculations. The header is sent on the wire, so including it in the configurable block size is more intuitive to the user. Previously, part, but not all, of the header was allocated as additional overhead.