### PR TITLE
Add NCS manifest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,11 @@ concurrency:
 jobs:
   build:
     container: golioth/golioth-zephyr-base:0.16.8-SDK-v0
+    strategy:
+      matrix:
+        manifest:
+          - west.yml
+          - west-ncs.yml
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
     runs-on: ubuntu-24.04
@@ -23,7 +28,7 @@ jobs:
           path: pouch
       - name: Init and update west
         run: |
-          west init -l pouch
+          west init -l pouch --mf ${{ matrix.manifest }}
           west update --narrow -o=--depth=1
       - name: Install pip packages
         run: |

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -1,0 +1,20 @@
+manifest:
+  projects:
+    - name: nrf
+      revision: v3.0.1
+      url: http://github.com/nrfconnect/sdk-nrf
+      import:
+        path-prefix: deps
+        name-allowlist:
+          - nrf
+          - zephyr
+          - cmsis
+          - hal_nordic
+          - nrfxlib
+          - mbedtls
+          - mcuboot
+          - segger
+          - tfm-mcuboot
+          - oberon-psa-crypto
+          - trusted-firmware-m
+          - zcbor


### PR DESCRIPTION
Incoming additions around cryptography are significantly easier to implement on Nordic devices when using NCS than with raw zephyr. This adds an ncs manifest, so that we can run both.