### PR TITLE
ble_gatt: add version byte to advertising service data

### DIFF
--- a/include/pouch/types.h
+++ b/include/pouch/types.h
@@ -11,6 +11,8 @@
  * @brief Pouch type definitions
  */
 
+#define POUCH_VERSION 1
+
 /**
  * @defgroup content_types Pouch content types
  * @{

--- a/lib/pouch_ble_gatt_common/include/pouch/transport/ble_gatt/common/types.h
+++ b/lib/pouch_ble_gatt_common/include/pouch/transport/ble_gatt/common/types.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Golioth
+ */
+
+#include <zephyr/toolchain.h>
+
+#define GOLIOTH_BLE_GATT_VERSION 1
+
+#define GOLIOTH_BLE_GATT_ADV_VERSION_POUCH_SHIFT 4
+#define GOLIOTH_BLE_GATT_ADV_VERSION_POUCH_MASK 0xF0
+#define GOLIOTH_BLE_GATT_ADV_VERSION_SELF_SHIFT 0
+#define GOLIOTH_BLE_GATT_ADV_VERSION_SELF_MASK 0x0F
+
+#define GOLIOTH_BLE_GATT_ADV_FLAG_SYNC_REQUEST (1 << 0)
+
+struct golioth_ble_gatt_adv_data
+{
+    uint8_t version;
+    uint8_t flags;
+} __packed;


### PR DESCRIPTION
This updates the advertising data to add a version byte, in line with the recent updates to the Toothfairy spec. This requires a [corresponding change in the gateway](https://github.com/golioth/bluetooth-gateway/pull/35).