### PR TITLE
Encrypted uplink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CONFIG_POUCH)
 
     zephyr_library_sources_ifdef(CONFIG_POUCH_ENCRYPTION_NONE src/crypto_none.c)
     zephyr_library_sources_ifdef(CONFIG_POUCH_ENCRYPTION_SAEAD
+        src/crypto_saead.c
         src/cert.c
         src/saead/session.c
         src/saead/uplink.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ if(CONFIG_POUCH)
         src/saead/uplink.c
     )
 
+    # Add MbedTLS features through a config file override:
+    if (CONFIG_POUCH_ENCRYPTION_SAEAD AND CONFIG_NRF_SECURITY)
+        zephyr_library_compile_definitions(MBEDTLS_USER_CONFIG_FILE="${CMAKE_CURRENT_LIST_DIR}/src/saead/mbedtls_config.h")
+    endif()
+
     if (DEFINED CONFIG_POUCH_CA_CERT_FILENAME)
         find_file(ca_cert ${CONFIG_POUCH_CA_CERT_FILENAME}
             PATHS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if(CONFIG_POUCH)
     zephyr_library_sources_ifdef(CONFIG_POUCH_ENCRYPTION_SAEAD
         src/cert.c
         src/saead/session.c
+        src/saead/uplink.c
     )
 
     if (DEFINED CONFIG_POUCH_CA_CERT_FILENAME)

--- a/include/pouch/types.h
+++ b/include/pouch/types.h
@@ -5,6 +5,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <psa/crypto_types.h>
 
 /**
  * @file types.h
@@ -53,6 +54,8 @@ enum pouch_encryption
 {
     /** No encryption */
     POUCH_ENCRYPTION_PLAINTEXT,
+    /** Streaming AEAD encryption */
+    POUCH_ENCRYPTION_SAEAD,
 };
 
 /** Pouch configuration for plaintext encryption */
@@ -66,6 +69,26 @@ struct pouch_encryption_config_plaintext
     const char *device_id;
 };
 
+/** Pouch configuration for saead encryption */
+struct pouch_encryption_config_saead
+{
+    /**
+     * The device certificate in DER format.
+     *
+     * The memory pointed to by this field must remain valid while the pouch stack is in use.
+     *
+     * The certificate must be a valid X.509 certificate.
+     * The certificate must be signed by a trusted CA.
+     * The certificate must contain the public key that corresponds to the provided private key.
+     */
+    struct pouch_cert certificate;
+
+    /**
+     * The ID of the device's private key in the PSA key store.
+     */
+    psa_key_id_t private_key;
+};
+
 /** Pouch configuration */
 struct pouch_config
 {
@@ -76,5 +99,7 @@ struct pouch_config
     {
         /** Plaintext configuration */
         struct pouch_encryption_config_plaintext plaintext;
+        /** Streaming AEAD configuration */
+        struct pouch_encryption_config_saead saead;
     } encryption;
 };

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -24,14 +24,13 @@ choice
 
 config POUCH_ENCRYPTION_SAEAD
   bool "Streaming AEAD"
-  select PSA_WANT_ALG_ECDSA
   select PSA_WANT_ALG_ECDH
   select PSA_WANT_ALG_HKDF
+  select PSA_WANT_ALG_HMAC
   select PSA_WANT_ALG_STREAM_CIPHER
   select PSA_WANT_ALG_SHA_256
-  select MBEDTLS_X509_LIBRARY
-  select MBEDTLS_X509_CRT_PARSE_C
-  select MBEDTLS_PK_PARSE_C
+  select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE
+  select PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY
   select BASE64
   help
     Use a streaming AEAD encryption scheme for uplink Pouch transfers.
@@ -92,6 +91,12 @@ config POUCH_CA_CERT_FILENAME
     This is used to verify the server's identity.
 
 endif
+
+config MBEDTLS_USER_CONFIG_ENABLE
+  default y
+
+config MBEDTLS_USER_CONFIG_FILE
+  default "${ZEPHYR_POUCH_MODULE_DIR}/src/saead/mbedtls_config.h"
 
 endmenu
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -19,7 +19,6 @@ config POUCH_BLOCK_SIZE
 
 choice
   prompt "Pouch uplink encryption scheme"
-  default POUCH_ENCRYPTION_NONE # NOTE: This will change once SAEAD encryption is available.
   help
     Select the encryption method to use for uplink Pouch transfers.
 

--- a/src/block.c
+++ b/src/block.c
@@ -63,7 +63,7 @@ static void write_block_header(struct pouch_buf *block, size_t size, uint8_t id,
 
 size_t block_space_get(const struct pouch_buf *block)
 {
-    return CONFIG_POUCH_BLOCK_SIZE - block_size_get(block);
+    return MAX_BLOCK_SIZE - block_size_get(block);
 }
 
 size_t block_size_get(const struct pouch_buf *block)
@@ -78,7 +78,7 @@ void block_size_write(struct pouch_buf *block, uint16_t size)
 
 struct pouch_buf *block_alloc(void)
 {
-    struct pouch_buf *block = buf_alloc(CONFIG_POUCH_BLOCK_SIZE);
+    struct pouch_buf *block = buf_alloc(MAX_BLOCK_SIZE);
     if (block != NULL)
     {
         write_block_header(block, 0, BLOCK_ID_ENTRY, FIRST_DATA_MASK | LAST_DATA_MASK);
@@ -89,7 +89,7 @@ struct pouch_buf *block_alloc(void)
 
 struct pouch_buf *block_alloc_stream(uint8_t stream_id, bool first)
 {
-    struct pouch_buf *block = buf_alloc(CONFIG_POUCH_BLOCK_SIZE);
+    struct pouch_buf *block = buf_alloc(MAX_BLOCK_SIZE);
     if (block != NULL)
     {
         write_block_header(block, 0, stream_id, first ? FIRST_DATA_MASK : 0);

--- a/src/block.h
+++ b/src/block.h
@@ -4,9 +4,15 @@
 #pragma once
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
 #include "buf.h"
 
 #define BLOCK_ID_MASK 0x1f
+
+/** Log2 of max block size */
+#define MAX_BLOCK_SIZE_LOG LOG2(CONFIG_POUCH_BLOCK_SIZE)
+/** Rounded maximum block size */
+#define MAX_BLOCK_SIZE (1 << MAX_BLOCK_SIZE_LOG)
 
 void block_decode_hdr(struct pouch_bufview *v,
                       uint16_t *block_size,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -7,11 +7,20 @@
 #include "buf.h"
 #include <pouch/types.h>
 
+/** Initialize crypto module */
+int crypto_init(const struct pouch_config *config);
+
+/** Notify the crypto module that a new pouch session is starting */
+int crypto_session_start(void);
+
+/** Notify the crypto module that the pouch session is ending */
+void crypto_session_end(void);
+
 /** Initialize a new pouch in the encryption engine. */
 int crypto_pouch_start(void);
 
 /** Construct the encryption info part of the pouch header */
-int crypto_header_get(const struct pouch_config *config, struct encryption_info *encryption_info);
+int crypto_header_get(struct encryption_info *encryption_info);
 
 /**
  * Decrypt a block of data.

--- a/src/crypto_none.c
+++ b/src/crypto_none.c
@@ -15,7 +15,7 @@ int crypto_header_get(const struct pouch_config *config, struct encryption_info 
         return -EINVAL;
     }
 
-    encryption_info->Union_choice = encryption_info_union_plaintext_info_m_c;
+    encryption_info->union_choice = encryption_info_union_plaintext_info_m_c;
     encryption_info->plaintext_info_m.id.len = strlen(config->encryption.plaintext.device_id);
     encryption_info->plaintext_info_m.id.value = config->encryption.plaintext.device_id;
 

--- a/src/crypto_none.c
+++ b/src/crypto_none.c
@@ -2,22 +2,49 @@
  * Copyright (c) 2025 Golioth, Inc.
  */
 #include "crypto.h"
+#include <string.h>
+
+static const char *device_id;
+
+int crypto_init(const struct pouch_config *config)
+{
+    if (config->encryption_type != POUCH_ENCRYPTION_PLAINTEXT)
+    {
+        return -ENOTSUP;
+    }
+
+    if (config->encryption.plaintext.device_id == NULL)
+    {
+        return -EINVAL;
+    }
+
+    if (strlen(config->encryption.plaintext.device_id) > POUCH_DEVICE_ID_MAX_LEN)
+    {
+        return -EINVAL;
+    }
+
+    device_id = config->encryption.plaintext.device_id;
+
+    return 0;
+}
+
+int crypto_session_start(void)
+{
+    return 0;
+}
+
+void crypto_session_end(void) {}
 
 int crypto_pouch_start(void)
 {
     return 0;
 }
 
-int crypto_header_get(const struct pouch_config *config, struct encryption_info *encryption_info)
+int crypto_header_get(struct encryption_info *encryption_info)
 {
-    if (config->encryption.plaintext.device_id == NULL)
-    {
-        return -EINVAL;
-    }
-
-    encryption_info->union_choice = encryption_info_union_plaintext_info_m_c;
-    encryption_info->plaintext_info_m.id.len = strlen(config->encryption.plaintext.device_id);
-    encryption_info->plaintext_info_m.id.value = config->encryption.plaintext.device_id;
+    encryption_info->Union_choice = encryption_info_union_plaintext_info_m_c;
+    encryption_info->plaintext_info_m.id.len = strlen(device_id);
+    encryption_info->plaintext_info_m.id.value = device_id;
 
     return 0;
 }

--- a/src/crypto_saead.c
+++ b/src/crypto_saead.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Golioth, Inc.
+ */
+#include "crypto.h"
+#include "saead/uplink.h"
+#include "cert.h"
+
+#if CONFIG_POUCH_ENCRYPTION_CHACHA20_POLY1305
+#define ENCRYPTION_ALGORITHM PSA_ALG_CHACHA20_POLY1305
+#elif CONFIG_POUCH_ENCRYPTION_AES_GCM
+#define ENCRYPTION_ALGORITHM PSA_ALG_AES_GCM
+#else
+#error "unknown encryption algorithm"
+#endif
+
+static psa_key_id_t pkey;
+
+int crypto_init(const struct pouch_config *config)
+{
+    if (config->encryption_type != POUCH_ENCRYPTION_SAEAD)
+    {
+        return -ENOTSUP;
+    }
+
+    if (config->encryption.saead.private_key == PSA_KEY_ID_NULL)
+    {
+        return -EINVAL;
+    }
+
+    int err = cert_device_set(&config->encryption.saead.certificate);
+    if (err)
+    {
+        return err;
+    }
+
+    pkey = config->encryption.saead.private_key;
+
+    return 0;
+}
+
+int crypto_session_start(void)
+{
+    return uplink_session_start(ENCRYPTION_ALGORITHM, pkey);
+}
+
+void crypto_session_end(void)
+{
+    uplink_session_end();
+}
+
+int crypto_pouch_start(void)
+{
+    return uplink_pouch_start();
+}
+
+int crypto_header_get(struct encryption_info *encryption_info)
+{
+    encryption_info->Union_choice = encryption_info_union_saead_info_m_c;
+    return uplink_header_get(&encryption_info->saead_info_m);
+}
+
+struct pouch_buf *crypto_decrypt_block(struct pouch_buf *block)
+{
+    return block;
+}
+
+struct pouch_buf *crypto_encrypt_block(struct pouch_buf *block)
+{
+    return uplink_encrypt_block(block);
+}

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -94,7 +94,7 @@ void pouch_downlink_start(void)
 
     pouch_header = false;
 
-    pouch_buf = buf_alloc(CONFIG_POUCH_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN);
+    pouch_buf = buf_alloc(MAX_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN);
     if (!pouch_buf)
     {
         LOG_ERR("Failed to allocate pouch buf");
@@ -138,15 +138,14 @@ void pouch_downlink_push(const void *buf, size_t buf_len)
             return;
         }
 
-        if (buf_size_get(pouch_buf) >= CONFIG_POUCH_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN)
+        if (buf_size_get(pouch_buf) >= MAX_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN)
         {
             LOG_ERR("No more space for pouch header");
             return;
         }
 
         size_t buf_written =
-            MIN(buf_len,
-                CONFIG_POUCH_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN - buf_size_get(pouch_buf));
+            MIN(buf_len, MAX_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN - buf_size_get(pouch_buf));
         buf_write(pouch_buf, buf_p, buf_written);
 
         buf_p += buf_written;
@@ -176,11 +175,11 @@ void pouch_downlink_push(const void *buf, size_t buf_len)
         {
             uint16_t block_size = pouch_bufview_read_be16(&v);
 
-            if (block_size >= CONFIG_POUCH_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN)
+            if (block_size >= MAX_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN)
             {
                 LOG_ERR("Block size %u is bigger than supported %u",
                         (unsigned int) block_size,
-                        (unsigned int) (CONFIG_POUCH_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN));
+                        (unsigned int) (MAX_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN));
                 return;
             }
 
@@ -192,7 +191,7 @@ void pouch_downlink_push(const void *buf, size_t buf_len)
 
                 struct pouch_buf *pouch_buf_to_send = pouch_buf;
 
-                pouch_buf = buf_alloc(CONFIG_POUCH_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN);
+                pouch_buf = buf_alloc(MAX_BLOCK_SIZE + CONFIG_POUCH_AUTH_TAG_LEN);
                 if (!pouch_buf)
                 {
                     LOG_ERR("Failed to allocate pouch buf");

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -36,15 +36,13 @@ static struct
 static void decrypt_blocks(struct k_work *work);
 static void consume_blocks(struct k_work *work);
 
-int downlink_init(const struct pouch_config *config)
+void downlink_init(void)
 {
     buf_queue_init(&decrypt.queue);
     k_work_init(&decrypt.work, decrypt_blocks);
 
     buf_queue_init(&consume.queue);
     k_work_init(&consume.work, consume_blocks);
-
-    return 0;
 }
 
 static void consume_blocks(struct k_work *work)

--- a/src/downlink.h
+++ b/src/downlink.h
@@ -3,8 +3,5 @@
  */
 #pragma once
 
-#include <stdbool.h>
-#include <pouch/types.h>
-
 /** Initialize the pouch downlink handler */
-int downlink_init(const struct pouch_config *config);
+void downlink_init(void);

--- a/src/header.c
+++ b/src/header.c
@@ -2,9 +2,11 @@
  * Copyright (c) 2025 Golioth, Inc.
  */
 #include "header.h"
+#include "cert.h"
 #include "crypto.h"
 #include "buf.h"
 #include "cddl/header_encode.h"
+#include "saead/session.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -27,6 +29,8 @@
 
 #define POUCH_HEADER_MAX_LEN \
     (POUCH_HEADER_OVERHEAD + POUCH_HEADER_OVERHEAD_ENCRYPTION_NONE + POUCH_DEVICE_ID_MAX_LEN)
+#elif defined(CONFIG_POUCH_ENCRYPTION_SAEAD)
+#define POUCH_HEADER_MAX_LEN (16 + SESSION_ID_LEN + CERT_REF_SHORT_LEN)
 #else
 #error "Unsupported encryption type"
 #endif

--- a/src/header.c
+++ b/src/header.c
@@ -35,13 +35,13 @@
 #error "Unsupported encryption type"
 #endif
 
-static int write_header(const struct pouch_config *config, struct pouch_buf *buf, size_t maxlen)
+static int write_header(struct pouch_buf *buf, size_t maxlen)
 {
     struct pouch_header header = {
         .version = POUCH_HEADER_VERSION,
     };
 
-    int err = crypto_header_get(config, &header.encryption_info_m);
+    int err = crypto_header_get(&header.encryption_info_m);
     if (err)
     {
         return err;
@@ -59,7 +59,7 @@ static int write_header(const struct pouch_config *config, struct pouch_buf *buf
     return 0;
 }
 
-struct pouch_buf *pouch_header_create(const struct pouch_config *config)
+struct pouch_buf *pouch_header_create(void)
 {
     struct pouch_buf *header = buf_alloc(POUCH_HEADER_MAX_LEN);
     if (!header)
@@ -67,7 +67,7 @@ struct pouch_buf *pouch_header_create(const struct pouch_config *config)
         return NULL;
     }
 
-    int err = write_header(config, header, POUCH_HEADER_MAX_LEN);
+    int err = write_header(header, POUCH_HEADER_MAX_LEN);
     if (err)
     {
         buf_free(header);

--- a/src/header.cddl
+++ b/src/header.cddl
@@ -5,7 +5,7 @@ pouch_header = [
 
 encryption_info = [
     plaintext_info //
-    saead_fixed_info
+    saead_info
 ]
 
 plaintext_info = (
@@ -13,29 +13,33 @@ plaintext_info = (
     id: tstr,
 )
 
-saead_fixed_info = (
+saead_info = (
     encryption_type: 1,
-    algorithm: aes_gcm / chacha20_poly1305,
-    nonce: bstr .size 10,
-    key_info,
+    session: session_info,
+    pouch_id: uint .size 2,
 )
 
-; Algorithm identifiers
-aes_gcm = 1
-chacha20_poly1305 = 2
-
-key_info = [
-    psk //
-    ecdh
+session_info = [
+    id: session_id_random / session_id_sequential,
+    initiator: device / server,
+    algorithm: aes_gcm / chacha20_poly1305,
+    max_block_size_log: uint .size 1,
+    cert_ref: bstr .size 6,
 ]
 
-psk = (
-    key_type: 1,
-    psk_id: tstr,
-)
+session_id_random = [
+    random: bstr .size 16,
+]
 
-ecdh = (
-    key_type: 2,
-    cert_id: tstr,
-    nonce: bstr .size 12,
-)
+session_id_sequential = [
+    tag: bstr .size 8,
+    seq: uint .size 8,
+]
+
+; Role identifiers
+device = 0
+server = 1
+
+; Algorithm identifiers
+chacha20_poly1305 = 1
+aes_gcm = 2

--- a/src/header.h
+++ b/src/header.h
@@ -4,9 +4,8 @@
 #pragma once
 
 #include "buf.h"
-#include <pouch/types.h>
 
 /**
  * Allocate and encode a pouch header.
  */
-struct pouch_buf *pouch_header_create(const struct pouch_config *config);
+struct pouch_buf *pouch_header_create(void);

--- a/src/pouch.c
+++ b/src/pouch.c
@@ -3,14 +3,10 @@
  */
 #include "downlink.h"
 #include "uplink.h"
+#include "crypto.h"
 
 #include <pouch/events.h>
-#include <pouch/transport/uplink.h>
-#include <pouch/types.h>
-#include <string.h>
 
-#include <zephyr/init.h>
-#include <zephyr/kernel.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/ring_buffer.h>
 
@@ -25,26 +21,8 @@ void pouch_event_emit(enum pouch_event event)
 
 int pouch_init(const struct pouch_config *config)
 {
-    int err;
+    downlink_init();
+    uplink_init();
 
-    if (config->encryption_type != POUCH_ENCRYPTION_PLAINTEXT)
-    {
-        return -ENOTSUP;
-    }
-    if (!config->encryption.plaintext.device_id)
-    {
-        return -EINVAL;
-    }
-    if (strlen(config->encryption.plaintext.device_id) > POUCH_DEVICE_ID_MAX_LEN)
-    {
-        return -EINVAL;
-    }
-
-    err = downlink_init(config);
-    if (err)
-    {
-        return err;
-    }
-
-    return uplink_init(config);
+    return crypto_init(config);
 }

--- a/src/saead/mbedtls_config.h
+++ b/src/saead/mbedtls_config.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Golioth, Inc.
+ */
+#pragma once
+
+/* Zephyr's MbedTLS configuration mechanism does not provide sufficient control over the available
+ * options for us to use it for pouch. To get around this, this file is included as a user config
+ * file, which gets included in the MbedTLS configuration mechanism.
+ */
+
+// Parsing certificates, and its required dependencies:
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PK_USE_PSA_EC_DATA
+
+// Server certificates are signed with secp384r1
+#define MBEDTLS_PSA_ACCEL_ECC_SECP_R1_384

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -202,7 +202,7 @@ static void nonce_generate(const struct session *session,
 
 struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_buf *block)
 {
-    struct pouch_buf *encrypted = buf_alloc(CONFIG_POUCH_BLOCK_SIZE + AUTH_TAG_LEN);
+    struct pouch_buf *encrypted = buf_alloc(MAX_BLOCK_SIZE + AUTH_TAG_LEN);
     if (encrypted == NULL)
     {
         LOG_ERR("Couldn't allocate encrypted block");
@@ -265,7 +265,7 @@ struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_bu
 
 struct pouch_buf *session_decrypt_block(struct session *session, struct pouch_buf *block)
 {
-    struct pouch_buf *decrypted = buf_alloc(CONFIG_POUCH_BLOCK_SIZE);
+    struct pouch_buf *decrypted = buf_alloc(MAX_BLOCK_SIZE);
     if (decrypted == NULL)
     {
         return NULL;

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -5,6 +5,7 @@
 
 #include "../block.h"
 #include <stdint.h>
+#include <stdio.h>
 #include <sys/types.h>
 #include <psa/crypto.h>
 #include <zephyr/sys/byteorder.h>

--- a/src/saead/session.h
+++ b/src/saead/session.h
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
 #include <psa/crypto.h>
+#include <string.h>
 
 #define SESSION_ID_LEN 16
 #define SESSION_ID_TAG_LEN (SESSION_ID_LEN - sizeof(uint64_t))

--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -1,0 +1,119 @@
+#include "uplink.h"
+#include "session.h"
+#include "../cert.h"
+#include "../block.h"
+#include <stdint.h>
+#include <psa/crypto.h>
+#include <zephyr/sys/byteorder.h>
+#include <mbedtls/base64.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(saead_uplink, LOG_LEVEL_DBG);
+
+static struct session uplink;
+
+int uplink_session_start(psa_algorithm_t algorithm, psa_key_id_t private_key)
+{
+    session_init(&uplink, algorithm);
+    struct pubkey pubkey;
+
+    uplink.flags = ATOMIC_INIT(0);
+
+    // Sequential IDs require replay protection, which isn't supported yet:
+    uplink.id.type = SESSION_ID_TYPE_RANDOM;
+
+    int err = session_id_generate(&uplink.id);
+    if (err)
+    {
+        LOG_ERR("Session ID generation failed (err: %d)", err);
+        return err;
+    }
+
+    cert_server_key_get(&pubkey);
+
+    uplink.key = session_key_generate(&uplink.id,
+                                      algorithm,
+                                      MAX_BLOCK_SIZE_LOG,
+                                      private_key,
+                                      &pubkey,
+                                      PSA_KEY_USAGE_ENCRYPT);
+    if (err)
+    {
+        LOG_ERR("Session key generation failed (err: %d)", err);
+        return err;
+    }
+
+    atomic_set_bit(&uplink.flags, SESSION_VALID);
+    atomic_set_bit(&uplink.flags, SESSION_ACTIVE);
+
+    return 0;
+}
+
+int uplink_pouch_start(void)
+{
+    return session_pouch_start(&uplink, uplink.pouch.id + 1);
+}
+
+int uplink_header_get(struct saead_info *info)
+{
+    if (!atomic_test_bit(&uplink.flags, SESSION_ACTIVE))
+    {
+        LOG_ERR("Session not active");
+        return -ENOTCONN;
+    }
+
+    if (uplink.id.type == SESSION_ID_TYPE_SEQUENTIAL)
+    {
+        info->session.id_choice = session_info_id_session_id_sequential_m_c;
+        info->session.session_id_sequential_m.seq = uplink.id.value.sequential.seqnum;
+        info->session.session_id_sequential_m.tag.value = uplink.id.value.sequential.tag;
+        info->session.session_id_sequential_m.tag.len = sizeof(uplink.id.value.sequential.tag);
+    }
+    else
+    {
+        info->session.id_choice = session_info_id_session_id_random_m_c;
+        info->session.session_id_random_m.value = uplink.id.value.random;
+        info->session.session_id_random_m.len = sizeof(uplink.id.value.random);
+    }
+
+    info->session.algorithm_choice = (uplink.algorithm == PSA_ALG_CHACHA20_POLY1305)
+        ? session_info_algorithm_chacha20_poly1305_m_c
+        : session_info_algorithm_aes_gcm_m_c;
+    info->session.initiator_choice = session_info_initiator_device_m_c;
+    info->session.max_block_size_log = MAX_BLOCK_SIZE_LOG;
+
+    const uint8_t *cert_ref = cert_ref_get();
+    if (cert_ref == NULL)
+    {
+        return -EBUSY;
+    }
+
+    info->session.cert_ref.value = cert_ref;
+    info->session.cert_ref.len = CERT_REF_SHORT_LEN;
+
+    info->pouch_id = uplink.pouch.id;
+
+    return 0;
+}
+
+struct pouch_buf *uplink_encrypt_block(struct pouch_buf *block)
+{
+    struct pouch_buf *encrypted = NULL;
+    if (atomic_test_bit(&uplink.flags, SESSION_ACTIVE))
+    {
+        encrypted = session_encrypt_block(&uplink, block);
+    }
+    else
+    {
+        LOG_WRN("Not in a session");
+    }
+
+    buf_free(block);
+
+    return encrypted;
+}
+
+void uplink_session_end(void)
+{
+    session_end(&uplink);
+}

--- a/src/saead/uplink.h
+++ b/src/saead/uplink.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "session.h"
+#include "../buf.h"
+#include "cddl/header_types.h"
+
+/** Start an uplink session */
+int uplink_session_start(psa_algorithm_t algorithm, psa_key_id_t private_key);
+
+/** End the ongoing uplink session */
+void uplink_session_end(void);
+
+/** Get the session info associated with the ongoing uplink session */
+int uplink_header_get(struct saead_info *info);
+
+/** Start a new pouch in the ongoing uplink session, and allocate a unique pouch ID for it. */
+int uplink_pouch_start(void);
+
+/** Encrypt a block in the current uplink pouch */
+struct pouch_buf *uplink_encrypt_block(struct pouch_buf *block);

--- a/src/uplink.h
+++ b/src/uplink.h
@@ -7,7 +7,7 @@
 #include <pouch/types.h>
 
 /** Initialize the pouch uplink handler */
-int uplink_init(const struct pouch_config *config);
+void uplink_init(void);
 
 void uplink_enqueue(struct pouch_buf *block);
 

--- a/tests/pouch/uplink/prj.conf
+++ b/tests/pouch/uplink/prj.conf
@@ -1,4 +1,5 @@
 CONFIG_ZTEST=y
 CONFIG_POUCH=y
+CONFIG_POUCH_ENCRYPTION_NONE=y
 # Some of the tests require more threads waiting on the same mutex than the basic wait queue can handle
 CONFIG_WAITQ_SCALABLE=y


### PR DESCRIPTION
Adds uplink SAEAD sessions, and a crypto_saead.c module.
This adds SAEAD support to the pouch header and config structure, adds some lifecycle functions to the crypto modules and shuffles the configuration ownership around a bit so that it makes more sense.