### PR TITLE
Use updated info characteristic

### DIFF
--- a/examples/ble_gatt/src/main.c
+++ b/examples/ble_gatt/src/main.c
@@ -121,14 +121,14 @@ GOLIOTH_SETTINGS_HANDLER(LED, led_setting_cb, NULL);
 
 int main(void)
 {
-    struct golioth_ble_gatt_peripheral *peripheral =
-        golioth_ble_gatt_peripheral_create("");  // TODO: This should no longer take the device ID
-    if (NULL == peripheral)
+    int err = golioth_ble_gatt_peripheral_init();
+    if (err)
     {
-        LOG_ERR("Failed to create peripheral");
+        LOG_ERR("Failed to initialize Pouch BLE GATT peripheral (err %d)", err);
+        return 0;
     }
 
-    int err = bt_enable(NULL);
+    err = bt_enable(NULL);
     if (err)
     {
         LOG_ERR("Bluetooth init failed (err %d)", err);

--- a/include/pouch/transport/ble_gatt/peripheral.h
+++ b/include/pouch/transport/ble_gatt/peripheral.h
@@ -12,7 +12,4 @@
 #define GOLIOTH_BLE_GATT_ADV_DATA \
     BT_DATA_BYTES(BT_DATA_SVC_DATA128, GOLIOTH_BLE_GATT_UUID_SVC_VAL, 0xA5)
 
-struct golioth_ble_gatt_peripheral;
-
-struct golioth_ble_gatt_peripheral *golioth_ble_gatt_peripheral_create(const char *device_id);
-int golioth_ble_gatt_peripheral_destroy(struct golioth_ble_gatt_peripheral *peripheral);
+int golioth_ble_gatt_peripheral_init(void);

--- a/src/transport/ble_gatt/CMakeLists.txt
+++ b/src/transport/ble_gatt/CMakeLists.txt
@@ -19,7 +19,6 @@ zephyr_library_sources_ifdef(CONFIG_POUCH_ENCRYPTION_SAEAD
 )
 
 zephyr_linker_sources(DATA_SECTIONS attributes.ld)
-zephyr_linker_sources(SECTIONS characteristics.ld)
 
 add_custom_command(OUTPUT info_encode.c
     COMMAND zcbor code -c ${CMAKE_CURRENT_LIST_DIR}/info.cddl -t

--- a/src/transport/ble_gatt/characteristics.ld
+++ b/src/transport/ble_gatt/characteristics.ld
@@ -1,6 +1,0 @@
-# Copyright (c) 2025 Golioth, Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-
-#include <zephyr/linker/iterable_sections.h>
-ITERABLE_SECTION_ROM(golioth_ble_gatt_characteristic, 4)

--- a/src/transport/ble_gatt/downlink_characteristic.c
+++ b/src/transport/ble_gatt/downlink_characteristic.c
@@ -55,6 +55,5 @@ GOLIOTH_BLE_GATT_CHARACTERISTIC(downlink,
                                 BT_GATT_CHRC_WRITE,
                                 BT_GATT_PERM_WRITE,
                                 NULL,
-                                NULL,
                                 downlink_write,
                                 NULL);

--- a/src/transport/ble_gatt/golioth_ble_gatt_declarations.h
+++ b/src/transport/ble_gatt/golioth_ble_gatt_declarations.h
@@ -7,39 +7,17 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/sys/iterable_sections.h>
 
-struct golioth_ble_gatt_peripheral;
-
-typedef int (*golioth_ble_gatt_chrc_init_func)(const struct golioth_ble_gatt_peripheral *,
-                                               struct bt_gatt_attr *);
-
-struct golioth_ble_gatt_characteristic
-{
-    struct bt_gatt_attr *attr;
-    golioth_ble_gatt_chrc_init_func init;
-};
-
-#define GOLIOTH_BLE_GATT_CHARACTERISTIC(name,                                          \
-                                        _uuid,                                         \
-                                        _props,                                        \
-                                        _perm,                                         \
-                                        _init_fn,                                      \
-                                        _read,                                         \
-                                        _write,                                        \
-                                        _user_data)                                    \
-    STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_chrc) =                               \
-        BT_GATT_ATTRIBUTE(BT_UUID_GATT_CHRC,                                           \
-                          BT_GATT_PERM_READ,                                           \
-                          bt_gatt_attr_read_chrc,                                      \
-                          NULL,                                                        \
-                          ((struct bt_gatt_chrc[]) {                                   \
-                              BT_GATT_CHRC_INIT(_uuid, 0U, _props),                    \
-                          }));                                                         \
-    STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_val) =                                \
-        BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _user_data);                    \
-    const STRUCT_SECTION_ITERABLE(golioth_ble_gatt_characteristic, _##name##_init) = { \
-        .attr = &name##_val,                                                           \
-        .init = _init_fn,                                                              \
-    }
+#define GOLIOTH_BLE_GATT_CHARACTERISTIC(name, _uuid, _props, _perm, _read, _write, _user_data) \
+    STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_chrc) =                                       \
+        BT_GATT_ATTRIBUTE(BT_UUID_GATT_CHRC,                                                   \
+                          BT_GATT_PERM_READ,                                                   \
+                          bt_gatt_attr_read_chrc,                                              \
+                          NULL,                                                                \
+                          ((struct bt_gatt_chrc[]) {                                           \
+                              BT_GATT_CHRC_INIT(_uuid, 0U, _props),                            \
+                          }));                                                                 \
+    STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_val) =                                        \
+        BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _user_data)
 
 #define GOLIOTH_BLE_GATT_SERVICE(_uuid) \
     STRUCT_SECTION_ITERABLE(bt_gatt_attr, AAA_golioth_ble_gatt_svc) = BT_GATT_PRIMARY_SERVICE(_uuid)

--- a/src/transport/ble_gatt/info.cddl
+++ b/src/transport/ble_gatt/info.cddl
@@ -1,4 +1,4 @@
 golioth_ble_gatt_info = {
-    "enc_type" => "plaintext" / "other",
-    "device_id" => tstr,
+    "flags" => uint .size 1,
+    "server_cert_snr" => bstr,
 }

--- a/src/transport/ble_gatt/info_characteristic.c
+++ b/src/transport/ble_gatt/info_characteristic.c
@@ -13,13 +13,19 @@ LOG_MODULE_REGISTER(info_chrc, LOG_LEVEL_DBG);
 
 #include <pouch/transport/ble_gatt/common/packetizer.h>
 #include <pouch/transport/ble_gatt/common/uuids.h>
+#include <pouch/transport/certificate.h>
+#include <pouch/certificate.h>
 
 #include "golioth_ble_gatt_declarations.h"
-#include "peripheral_int.h"
 
 #include <cddl/info_encode.h>
 
 #define INFO_CHRC_MAX_SIZE 64
+
+enum info_flags
+{
+    INFO_FLAG_PROVISIONED = BIT(0),
+};
 
 static const struct bt_uuid_128 golioth_ble_gatt_info_chrc_uuid =
     BT_UUID_INIT_128(GOLIOTH_BLE_GATT_UUID_INFO_CHRC_VAL);
@@ -30,6 +36,36 @@ static struct info_ctx
     size_t buf_len;
     struct golioth_ble_gatt_packetizer *packetizer;
 } info_chrc_ctx;
+
+static int build_info_data(void)
+{
+    uint8_t snr[CERT_SERIAL_MAXLEN];
+    ssize_t snr_len = pouch_server_certificate_serial_get(snr, sizeof(snr));
+    if (snr_len < 0)
+    {
+        return snr_len;
+    }
+
+    // TODO: Set the Provisioned flag once we have the functionality to know whether provisioning
+    // has taken place.
+    enum info_flags flags = 0;
+
+    struct golioth_ble_gatt_info info = {
+        .golioth_ble_gatt_info_flags = flags,
+        .golioth_ble_gatt_info_server_cert_snr =
+            {
+                .value = snr,
+                .len = snr_len,
+            },
+    };
+
+    info_chrc_ctx.buf_len = INFO_CHRC_MAX_SIZE;
+
+    return cbor_encode_golioth_ble_gatt_info(info_chrc_ctx.buf,
+                                             INFO_CHRC_MAX_SIZE,
+                                             &info,
+                                             &info_chrc_ctx.buf_len);
+}
 
 static ssize_t info_read(struct bt_conn *conn,
                          const struct bt_gatt_attr *attr,
@@ -50,6 +86,12 @@ static ssize_t info_read(struct bt_conn *conn,
 
     if (NULL == ctx->packetizer)
     {
+        int err = build_info_data();
+        if (err)
+        {
+            return err;
+        }
+
         ctx->packetizer = golioth_ble_gatt_packetizer_start_buffer(ctx->buf, ctx->buf_len);
     }
 
@@ -74,33 +116,10 @@ static ssize_t info_read(struct bt_conn *conn,
     return buf_len;
 }
 
-static int info_init(const struct golioth_ble_gatt_peripheral *peripheral,
-                     struct bt_gatt_attr *attr)
-{
-    struct info_ctx *ctx = attr->user_data;
-    const char *device_id;
-
-    golioth_ble_gatt_int_peripheral_get_device_id(peripheral, &device_id);
-
-    struct golioth_ble_gatt_info info = {
-        .golioth_ble_gatt_info_enc_type_choice = golioth_ble_gatt_info_enc_type_plaintext_tstr_c,
-        .golioth_ble_gatt_info_device_id =
-            {
-                .value = device_id,
-                .len = strlen(device_id),
-            },
-    };
-
-    int err = cbor_encode_golioth_ble_gatt_info(ctx->buf, INFO_CHRC_MAX_SIZE, &info, &ctx->buf_len);
-
-    return err;
-}
-
 GOLIOTH_BLE_GATT_CHARACTERISTIC(info,
                                 (const struct bt_uuid *) &golioth_ble_gatt_info_chrc_uuid,
                                 BT_GATT_CHRC_READ,
                                 BT_GATT_PERM_READ,
-                                info_init,
                                 info_read,
                                 NULL,
                                 &info_chrc_ctx);

--- a/src/transport/ble_gatt/peripheral.c
+++ b/src/transport/ble_gatt/peripheral.c
@@ -14,11 +14,6 @@
 
 #include "golioth_ble_gatt_declarations.h"
 
-struct golioth_ble_gatt_peripheral
-{
-    const char *device_id;
-};
-
 static const struct bt_uuid_128 golioth_ble_gatt_svc_uuid =
     BT_UUID_INIT_128(GOLIOTH_BLE_GATT_UUID_SVC_VAL);
 
@@ -28,47 +23,7 @@ static struct bt_gatt_service golioth_svc = {
     .attrs = GOLIOTH_BLE_GATT_ATTR_ARRAY_PTR,
 };
 
-void golioth_ble_gatt_int_peripheral_get_device_id(
-    const struct golioth_ble_gatt_peripheral *peripheral,
-    const char **device_id)
+int golioth_ble_gatt_peripheral_init(void)
 {
-    *device_id = peripheral->device_id;
-}
-
-struct golioth_ble_gatt_peripheral *golioth_ble_gatt_peripheral_create(const char *device_id)
-{
-    struct golioth_ble_gatt_peripheral *peripheral =
-        malloc(sizeof(struct golioth_ble_gatt_peripheral));
-    if (NULL == peripheral)
-    {
-        goto finish;
-    }
-
-    peripheral->device_id = device_id;
-
-    GOLIOTH_BLE_GATT_ATTR_ARRAY_LEN(&golioth_svc.attr_count);
-    int err = bt_gatt_service_register(&golioth_svc);
-    if (0 != err)
-    {
-        free(peripheral);
-        peripheral = NULL;
-    }
-
-    STRUCT_SECTION_FOREACH(golioth_ble_gatt_characteristic, golioth_ble_gatt_chrc)
-    {
-        if (golioth_ble_gatt_chrc->init)
-        {
-            golioth_ble_gatt_chrc->init(peripheral, golioth_ble_gatt_chrc->attr);
-        }
-    }
-
-finish:
-    return peripheral;
-}
-
-int golioth_ble_gatt_peripheral_destroy(struct golioth_ble_gatt_peripheral *peripheral)
-{
-    free(peripheral);
-
-    return 0;
+    return bt_gatt_service_register(&golioth_svc);
 }

--- a/src/transport/ble_gatt/peripheral_int.h
+++ b/src/transport/ble_gatt/peripheral_int.h
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Golioth, Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-void golioth_ble_gatt_int_peripheral_get_device_id(
-    const struct golioth_ble_gatt_peripheral *peripheral,
-    const char **device_id);

--- a/src/transport/ble_gatt/server_cert_characteristic.c
+++ b/src/transport/ble_gatt/server_cert_characteristic.c
@@ -152,7 +152,6 @@ GOLIOTH_BLE_GATT_CHARACTERISTIC(server_cert,
                                 (const struct bt_uuid *) &golioth_ble_gatt_server_cert_chrc_uuid,
                                 BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE,
                                 BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
-                                NULL,
                                 server_cert_serial_read,
                                 server_cert_write,
                                 &server_cert_chrc_ctx);

--- a/src/transport/ble_gatt/uplink_characteristic.c
+++ b/src/transport/ble_gatt/uplink_characteristic.c
@@ -89,7 +89,6 @@ GOLIOTH_BLE_GATT_CHARACTERISTIC(uplink,
                                 (const struct bt_uuid *) &golioth_ble_gatt_uplink_chrc_uuid,
                                 BT_GATT_CHRC_READ,
                                 BT_GATT_PERM_READ,
-                                NULL,
                                 uplink_read,
                                 NULL,
                                 &uplink_chrc_ctx);


### PR DESCRIPTION
Changes the format of the info characteristic to flags and server cert serial number. This allows us to remove the init function for the attributes, as we have to construct the info structure before each read, in case any of the data changes. This simplifies the macro, setup and linker sections.

Renames the peripheral_create to init to reflect the lack of a destroy function, now that we don't have to allocate anything.