### PR TITLE
transport: ble_gatt: info: fix build for plaintext encryption

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,10 @@ jobs:
         shell: bash
         run: |
           west build -p -b nrf52840dk/nrf52840 pouch/examples/ble_gatt
+      - name: Compile (plaintext)
+        shell: bash
+        run: |
+          west build -p -b nrf52840dk/nrf52840 pouch/examples/ble_gatt -- -DCONFIG_POUCH_ENCRYPTION_NONE=y
       - name: Run tests
         env:
           ZEPHYR_BASE: ${{ github.workspace }}/deps/zephyr

--- a/examples/ble_gatt/Kconfig
+++ b/examples/ble_gatt/Kconfig
@@ -4,6 +4,13 @@
 
 source "$ZEPHYR_BASE/Kconfig"
 
+config EXAMPLE_DEVICE_ID
+  string "Device ID"
+  depends on POUCH_ENCRYPTION_NONE
+  help
+      The device ID to use for the device in pouches sent to the
+      Golioth cloud.
+
 config EXAMPLE_SYNC_PERIOD_S
     int "Sync Period"
     default 20

--- a/examples/ble_gatt/src/main.c
+++ b/examples/ble_gatt/src/main.c
@@ -142,7 +142,10 @@ int main(void)
 
     LOG_DBG("Bluetooth initialized");
 
-    struct pouch_config config;
+    struct pouch_config config = {0};
+
+#if CONFIG_POUCH_ENCRYPTION_SAEAD
+
     err = load_certificate(&config.certificate);
     if (err)
     {
@@ -157,6 +160,12 @@ int main(void)
         return 0;
     }
 
+#else  // CONFIG_POUCH_ENCRYPTION_SAEAD
+
+    config.device_id = CONFIG_EXAMPLE_DEVICE_ID;
+
+#endif  // CONFIG_POUCH_ENCRYPTION_SAEAD
+
     err = pouch_init(&config);
     if (err)
     {
@@ -166,8 +175,13 @@ int main(void)
 
     LOG_DBG("Pouch successfully initialized");
 
+
+#if CONFIG_POUCH_ENCRYPTION_SAEAD
+
     // Can safely free the raw certificate after pouch initialization:
     free_certificate(&config.certificate);
+
+#endif
 
     err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
     if (err)

--- a/src/transport/ble_gatt/info_characteristic.c
+++ b/src/transport/ble_gatt/info_characteristic.c
@@ -39,12 +39,17 @@ static struct info_ctx
 
 static int build_info_data(void)
 {
+#if CONFIG_POUCH_ENCRYPTION_SAEAD
     uint8_t snr[CERT_SERIAL_MAXLEN];
     ssize_t snr_len = pouch_server_certificate_serial_get(snr, sizeof(snr));
     if (snr_len < 0)
     {
         return snr_len;
     }
+#else
+    uint8_t *snr = NULL;
+    ssize_t snr_len = 0;
+#endif
 
     // TODO: Set the Provisioned flag once we have the functionality to know whether provisioning
     // has taken place.


### PR DESCRIPTION
When Pouch is compiled without encryption support, the info characteristic failed to link due to an unresolved reference to `pouch_server_certificate_serial_get()`.