### PR TITLE
west: drop import 'path-prefix' (deps)

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pip packages
         run: |
           uv pip install \
-            -r deps/zephyr/scripts/requirements-base.txt        \
+            -r zephyr/scripts/requirements-base.txt        \
             -r pouch/requirements.txt
 
           uv pip install            \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Install pip packages
         run: |
           uv pip install \
-            -r deps/zephyr/scripts/requirements-base.txt        \
-            -r deps/zephyr/scripts/requirements-build-test.txt  \
-            -r deps/zephyr/scripts/requirements-run-test.txt         \
+            -r zephyr/scripts/requirements-base.txt        \
+            -r zephyr/scripts/requirements-build-test.txt  \
+            -r zephyr/scripts/requirements-run-test.txt         \
             -r pouch/requirements.txt
 
           uv pip install          \
@@ -59,9 +59,9 @@ jobs:
           west build -p -b nrf52840dk/nrf52840 pouch/examples/ble_gatt -- -DCONFIG_POUCH_ENCRYPTION_NONE=y
       - name: Run tests
         env:
-          ZEPHYR_BASE: ${{ github.workspace }}/deps/zephyr
+          ZEPHYR_BASE: ${{ github.workspace }}/zephyr
           EXTRA_ZEPHYR_MODULES: ${{ github.workspace }}/pouch
-        run: ./deps/zephyr/scripts/twister -v -T pouch/tests
+        run: ./zephyr/scripts/twister -v -T pouch/tests
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5

--- a/examples/ble_gatt/README.md
+++ b/examples/ble_gatt/README.md
@@ -40,7 +40,7 @@ boots for the first time.
 > the file system, which generates the following warnings in the device log:
 >
 > ```log
-> [00:00:00.392,486] <err> littlefs: WEST_TOPDIR/deps/modules/fs/littlefs/lfs.c:1389: Corrupted dir pair at {0x0, 0x1}
+> [00:00:00.392,486] <err> littlefs: WEST_TOPDIR/modules/fs/littlefs/lfs.c:1389: Corrupted dir pair at {0x0, 0x1}
 > [00:00:00.392,517] <wrn> littlefs: can't mount (LFS -84); formatting
 > ```
 >

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -4,7 +4,6 @@ manifest:
       revision: v3.0.1
       url: http://github.com/nrfconnect/sdk-nrf
       import:
-        path-prefix: deps
         name-allowlist:
           - nrf
           - zephyr

--- a/west.yml
+++ b/west.yml
@@ -10,7 +10,6 @@ manifest:
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import:
-        path-prefix: deps
         name-allowlist:
           - zephyr
           - cmsis


### PR DESCRIPTION
Having consisent Zephyr application tree structure allows to quickly
switch between repositories (e.g. to/from bluetooth-gateway), while
having just a single clone of each shared dependency.

This change makes it consistent with golioth-firmware-sdk and
bluetooth-firmware repos and allows to share single west workspace and
switch by invoking 'west config manifest.path MANIFEST_REPO'.