### PR TITLE
west: configure self.path as 'pouch'

### DIFF
--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -19,3 +19,6 @@ manifest:
           - trusted-firmware-m
           - littlefs
           - zcbor
+
+  self:
+    path: pouch

--- a/west.yml
+++ b/west.yml
@@ -22,3 +22,6 @@ manifest:
           - trusted-firmware-m
           - littlefs
           - zcbor
+
+  self:
+    path: pouch


### PR DESCRIPTION
Using 'west init -m URL' clones pouch repository to 'pouch.git'. Set
self.path to 'pouch', so that '.git' suffix will be omitted, as
otherwise it suggests it is a git bare repository instead.