### PR TITLE
examples: ble_gatt: increase mbedTLS heap size to 1k

### DIFF
--- a/examples/ble_gatt/Kconfig
+++ b/examples/ble_gatt/Kconfig
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+configdefault MBEDTLS_HEAP_SIZE
+  int
+  default 1024
+
 source "$ZEPHYR_BASE/Kconfig"
 
 config EXAMPLE_DEVICE_ID


### PR DESCRIPTION
mbedTLS failed to allocate enough memory when loading device key.
Increase heap from 512 to 1024 to fix that.