### PR TITLE
examples: ble_gatt: build credentials.c conditionally

### DIFF
--- a/examples/ble_gatt/CMakeLists.txt
+++ b/examples/ble_gatt/CMakeLists.txt
@@ -9,5 +9,8 @@ project(ble_gatt_example)
 
 target_sources(app PRIVATE
   src/main.c
+)
+
+target_sources_ifndef(CONFIG_POUCH_ENCRYPTION_NONE app PRIVATE
   src/credentials.c
 )


### PR DESCRIPTION
This fixes build time warning about implicit declaration of function
'mbedtls_pk_parse_key'.