### PR TITLE
examples: ble_gatt: drop nrf52840dk overlay

### DIFF
--- a/examples/ble_gatt/boards/nrf52840k_nrf52840.conf
+++ b/examples/ble_gatt/boards/nrf52840k_nrf52840.conf
@@ -1,2 +1,0 @@
-CONFIG_SHELL=y
-


### PR DESCRIPTION
CONFIG_SHELL is already enabled in prj.conf, so there is no need for
board specific overlay.