### PR TITLE
examples: ble_gatt: don't free certificate

### DIFF
--- a/examples/ble_gatt/src/main.c
+++ b/examples/ble_gatt/src/main.c
@@ -175,14 +175,6 @@ int main(void)
 
     LOG_DBG("Pouch successfully initialized");
 
-
-#if CONFIG_POUCH_ENCRYPTION_SAEAD
-
-    // Can safely free the raw certificate after pouch initialization:
-    free_certificate(&config.certificate);
-
-#endif
-
     err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
     if (err)
     {


### PR DESCRIPTION
Certificate is passed as pointer (wrapped with 'struct pouch_cert') and
stored as such. Freeing certificate results in use-after-free.

Don't free certificate, so that allocated buffer contents are valid
through the lifetime of application.