### PR TITLE
settings_callbacks: s/EFTYPE/EINVAL/

### DIFF
--- a/golioth_sdk/settings_callbacks.c
+++ b/golioth_sdk/settings_callbacks.c
@@ -20,7 +20,7 @@ int golioth_settings_receive_one(const struct setting_value *value)
         {
             if (setting->type != value->type)
             {
-                return -EFTYPE;
+                return -EINVAL;
             }
 
             switch (setting->type)


### PR DESCRIPTION
`EFTYPE` is not defined on Linux systems (more specifically in standard
Linux libc), which makes it impossible to build for native_sim platform.

Use `EINVAL` instead, so that better libc compatibility is provided.