### PR TITLE
Clear downlink session flags on start

### DIFF
--- a/src/saead/downlink.c
+++ b/src/saead/downlink.c
@@ -118,6 +118,7 @@ int saead_downlink_session_start(const struct session_id *id,
         return -EIO;
     }
 
+    downlink.flags = ATOMIC_INIT(0);
     downlink.pouch.id = 0;
     downlink.algorithm = algorithm;
     downlink.key = session_key;


### PR DESCRIPTION
The downlink session flags were never cleared, leaving the HAS_POUCH flag high between sessions. This triggered replay protection on pouch 0 in all but the first session, as we thought we had seen that pouch before.