### PR TITLE
Enable ECP APIs in Zephyr

### DIFF
--- a/src/saead/mbedtls_config.h
+++ b/src/saead/mbedtls_config.h
@@ -18,7 +18,6 @@
 #define MBEDTLS_OID_C
 #define MBEDTLS_PK_C
 #define MBEDTLS_PK_PARSE_C
-#define MBEDTLS_PK_USE_PSA_EC_DATA
 
 // Server certificates are signed with secp384r1
 #define MBEDTLS_PSA_ACCEL_ECC_SECP_R1_384


### PR DESCRIPTION
Disables mbedTLS PSA based key memory to allow it to use ECP, which makes the change in #63 to work on all platforms. Without the direct private field access, we didn't need this setting anymore anyway.