### PR TITLE
Remove mbedTLS user config file in NCS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,6 @@ if(CONFIG_POUCH)
         src/saead/downlink.c
     )
 
-    # Add MbedTLS features through a config file override:
-    if (CONFIG_POUCH_ENCRYPTION_SAEAD AND CONFIG_NRF_SECURITY)
-        zephyr_library_compile_definitions(MBEDTLS_USER_CONFIG_FILE="${CMAKE_CURRENT_LIST_DIR}/src/saead/mbedtls_config.h")
-    endif()
-
     if (DEFINED CONFIG_POUCH_CA_CERT_FILENAME)
         find_file(ca_cert ${CONFIG_POUCH_CA_CERT_FILENAME}
             PATHS


### PR DESCRIPTION
The workaround to enable a user config file in NCS is no longer necessary, now that we're able to use ecp for pubkey access (#61), and the required hashes are enabled through kconfig (#66).