### PR TITLE
example: ble_gatt: make credentials directory configurable

### DIFF
--- a/examples/ble_gatt/Kconfig
+++ b/examples/ble_gatt/Kconfig
@@ -10,3 +10,9 @@ config EXAMPLE_SYNC_PERIOD_S
     help
       The time, in seconds, after a sync to wait before requesting a sync from
       a gateway.
+
+config EXAMPLE_CREDENTIALS_DIR
+    string "Directory containing credentials"
+    default "/lfs1/credentials"
+    help
+      Directory on mounted file system containing credentials.

--- a/examples/ble_gatt/src/credentials.c
+++ b/examples/ble_gatt/src/credentials.c
@@ -11,7 +11,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(credentials, LOG_LEVEL_DBG);
 
-#define CERT_DIR "/lfs1/credentials"
+#define CERT_DIR CONFIG_EXAMPLE_CREDENTIALS_DIR
 #define CERT_FILE CERT_DIR "/crt.der"
 #define KEY_FILE CERT_DIR "/key.der"
 


### PR DESCRIPTION
By default credentials are stored in LittleFS. Allow to change that to
any directory (potentially other FS), so that there are more testing
possibilities.

This will be useful for mounting host FS when using native_sim and/or
nrf52_bsim.