### PR TITLE
Remove hard coded log levels

### DIFF
--- a/golioth_sdk/dispatch.c
+++ b/golioth_sdk/dispatch.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(glth_dispatch, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(glth_dispatch);
 
 #include <pouch/downlink.h>
 #include <pouch/events.h>

--- a/lib/zcbor_utils/zcbor_utils.c
+++ b/lib/zcbor_utils/zcbor_utils.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(zcbor_util, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(zcbor_util);
 
 #include <errno.h>
 

--- a/src/cert.c
+++ b/src/cert.c
@@ -10,7 +10,7 @@
 #include <pouch/transport/certificate.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(cert, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(cert);
 
 static const uint8_t raw_ca_cert[] = {
 #if IS_ENABLED(CONFIG_POUCH_VALIDATE_SERVER_CERT)

--- a/src/saead/downlink.c
+++ b/src/saead/downlink.c
@@ -14,7 +14,7 @@
 #include <mbedtls/base64.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(saead_downlink, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(saead_downlink);
 
 #define DOWNLINK_KEY_USAGE (PSA_KEY_USAGE_DECRYPT | PSA_KEY_USAGE_VERIFY_MESSAGE)
 

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -16,7 +16,7 @@
 #include <zephyr/sys/base64.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(saead_session, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(saead_session);
 
 /**
  * String length required to base64 encode a buffer of a given length, excluding the 0 terminator.

--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -14,7 +14,7 @@
 #include <mbedtls/base64.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(saead_uplink, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(saead_uplink);
 
 static struct session uplink;
 

--- a/src/transport/ble_gatt/info_characteristic.c
+++ b/src/transport/ble_gatt/info_characteristic.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(info_chrc, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(info_chrc);
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>


### PR DESCRIPTION
Several pouch modules had their log level hardcoded in the registration macro. This shouldn't be the default, so this change removes all of those, except the ones in the example.