### PR TITLE
Add log level settings

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -154,6 +154,10 @@ config POUCH_TRANSPORT_BLE_GATT
 
 endchoice
 
+module = POUCH
+module-str = Pouch
+source "subsys/logging/Kconfig.template.log_config"
+
 endif
 
 # Libraries

--- a/golioth_sdk/Kconfig
+++ b/golioth_sdk/Kconfig
@@ -51,4 +51,9 @@ config GOLIOTH_OTA_MAX_VERSION_LEN
 
 endif
 
+module = GOLIOTH
+module-str = Golioth
+source "subsys/logging/Kconfig.template.log_config"
+
+
 endif

--- a/golioth_sdk/dispatch.c
+++ b/golioth_sdk/dispatch.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(glth_dispatch);
+LOG_MODULE_REGISTER(glth_dispatch, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #include <pouch/downlink.h>
 #include <pouch/events.h>

--- a/golioth_sdk/ota.c
+++ b/golioth_sdk/ota.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ota);
+LOG_MODULE_REGISTER(ota, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #include <pouch/types.h>
 #include <pouch/uplink.h>

--- a/golioth_sdk/ota_upper.c
+++ b/golioth_sdk/ota_upper.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ota_upper);
+LOG_MODULE_REGISTER(ota_upper, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 

--- a/golioth_sdk/settings.c
+++ b/golioth_sdk/settings.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(glth_settings);
+LOG_MODULE_REGISTER(glth_settings, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #include <zephyr/drivers/gpio.h>
 

--- a/lib/zcbor_utils/zcbor_utils.c
+++ b/lib/zcbor_utils/zcbor_utils.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(zcbor_util);
+LOG_MODULE_REGISTER(zcbor_util, CONFIG_POUCH_LOG_LEVEL);
 
 #include <errno.h>
 

--- a/src/cert.c
+++ b/src/cert.c
@@ -10,7 +10,7 @@
 #include <pouch/transport/certificate.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(cert);
+LOG_MODULE_REGISTER(cert, CONFIG_POUCH_LOG_LEVEL);
 
 static const uint8_t raw_ca_cert[] = {
 #if IS_ENABLED(CONFIG_POUCH_VALIDATE_SERVER_CERT)

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -18,7 +18,7 @@
 #include "entry.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(downlink);
+LOG_MODULE_REGISTER(downlink, CONFIG_POUCH_LOG_LEVEL);
 
 static struct pouch_buf *pouch_buf;
 static bool pouch_header;

--- a/src/entry.c
+++ b/src/entry.c
@@ -15,7 +15,7 @@
 #include <pouch/downlink.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(entry);
+LOG_MODULE_REGISTER(entry, CONFIG_POUCH_LOG_LEVEL);
 
 #define ENTRY_HEADER_OVERHEAD 5
 

--- a/src/saead/downlink.c
+++ b/src/saead/downlink.c
@@ -14,7 +14,7 @@
 #include <mbedtls/base64.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(saead_downlink);
+LOG_MODULE_REGISTER(saead_downlink, CONFIG_POUCH_LOG_LEVEL);
 
 #define DOWNLINK_KEY_USAGE (PSA_KEY_USAGE_DECRYPT | PSA_KEY_USAGE_VERIFY_MESSAGE)
 

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -16,7 +16,7 @@
 #include <zephyr/sys/base64.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(saead_session);
+LOG_MODULE_REGISTER(saead_session, CONFIG_POUCH_LOG_LEVEL);
 
 /**
  * String length required to base64 encode a buffer of a given length, excluding the 0 terminator.

--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -14,7 +14,7 @@
 #include <mbedtls/base64.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(saead_uplink);
+LOG_MODULE_REGISTER(saead_uplink, CONFIG_POUCH_LOG_LEVEL);
 
 static struct session uplink;
 

--- a/src/transport/ble_gatt/info_characteristic.c
+++ b/src/transport/ble_gatt/info_characteristic.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(info_chrc);
+LOG_MODULE_REGISTER(info_chrc, CONFIG_POUCH_LOG_LEVEL);
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>


### PR DESCRIPTION
Adds a CONFIG_POUCH_LOG_LEVEL kconfig setting that controls the log level for all pouch modules, and a CONFIG_GOLIOTH_LOG_LEVEL for the golioth_sdk modules.