### PR TITLE
packetizer: don't create 0 length payload packets

### DIFF
--- a/lib/pouch_ble_gatt_common/packetizer.c
+++ b/lib/pouch_ble_gatt_common/packetizer.c
@@ -136,7 +136,14 @@ enum golioth_ble_gatt_packetizer_result golioth_ble_gatt_packetizer_get(
             goto finish;
         }
 
-        *dst_len = sizeof(struct golioth_ble_gatt_packet) + bytes_to_fill;
+        if (bytes_to_fill > 0)
+        {
+            *dst_len = sizeof(struct golioth_ble_gatt_packet) + bytes_to_fill;
+        }
+        else
+        {
+            *dst_len = 0;
+        }
 
         if (GOLIOTH_BLE_GATT_PACKETIZER_NO_MORE_DATA == cb_result)
         {


### PR DESCRIPTION
This allows callers to detect when a packet has no payload without having to know the length of the toothfairy header.