### PR TITLE
cert: check server certificate common name

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -120,6 +120,13 @@ menuconfig POUCH_VALIDATE_SERVER_CERT
     Disabling this will disable the server certificate validation.
     This should never be disabled in production.
 
+config POUCH_SERVER_CERT_CN
+  string "Server certificate common name"
+  default "pouch.golioth.io"
+  help
+    The expected common name or subject alternative name for the
+    server leaf certificate.
+
 if POUCH_VALIDATE_SERVER_CERT
 
 config POUCH_CA_CERT_FILENAME

--- a/src/cert.c
+++ b/src/cert.c
@@ -111,7 +111,13 @@ static int authenticate_server_cert(mbedtls_x509_crt *cert)
     }
 
     uint32_t flags = 0;
-    int ret = mbedtls_x509_crt_verify(cert, ca_cert, NULL, NULL, &flags, NULL, NULL);
+    int ret = mbedtls_x509_crt_verify(cert,
+                                      ca_cert,
+                                      NULL,
+                                      CONFIG_POUCH_SERVER_CERT_CN,
+                                      &flags,
+                                      NULL,
+                                      NULL);
     if (ret != 0)
     {
         LOG_ERR("Failed verifying server cert: 0x%x, %x", -ret, flags);


### PR DESCRIPTION
Adds check for server certificate common name during verification.

Will need rebase on #76 before merge.