### PR TITLE
examples: ble_gatt: enable mcumgr parameters command

### DIFF
--- a/examples/ble_gatt/prj.conf
+++ b/examples/ble_gatt/prj.conf
@@ -57,6 +57,10 @@ CONFIG_UART_CONSOLE_MCUMGR=y
 CONFIG_CRC=y
 CONFIG_MCUMGR_TRANSPORT_SHELL=y
 
+# Enable mcumgr params to allow smpmgr to query device for its MTU
+CONFIG_MCUMGR_GRP_OS=y
+CONFIG_MCUMGR_GRP_OS_MCUMGR_PARAMS=y
+
 # Enable file system commands
 CONFIG_MCUMGR_GRP_FS=y
 


### PR DESCRIPTION
Resolves golioth/firmware-issue-tracker#838