### PR TITLE
Kconfig: use () instead of {} for variables

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -142,7 +142,7 @@ config MBEDTLS_USER_CONFIG_ENABLE
   default y
 
 config MBEDTLS_USER_CONFIG_FILE
-  default "${ZEPHYR_POUCH_MODULE_DIR}/src/saead/mbedtls_config.h"
+  default "$(ZEPHYR_POUCH_MODULE_DIR)/src/saead/mbedtls_config.h"
 
 endmenu
 


### PR DESCRIPTION
I'm not sure how the curly braces were working at all before, but the proper syntax is parenthesis.
https://docs.kernel.org/kbuild/kconfig-macro-language.html