### PR TITLE
saead: session: canonicalize blocksize representation

### DIFF
--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -92,7 +92,7 @@ static ssize_t session_key_info_build(const struct session_id *id,
     session_id[id_len] = '\0';
 
     return sprintf(buf,
-                   "E0:%c:%s:C%c%c:%02x",
+                   "E0:%c:%s:C%c%c:%02X",
                    id->initiator == POUCH_ROLE_DEVICE ? 'D' : 'S',
                    session_id,
                    algorithm == PSA_ALG_CHACHA20_POLY1305 ? 'C' : 'A',


### PR DESCRIPTION
The blocksize is represented as a hexidecimal string during key agreement. There are (at least) two ways to represent each value that contains at least one alphabetic character because these characters can be either upper or lower case. We have determined that the canonical representation of hexadecimal numbers in strings will use upper case, so this commit updates the implementation to match.

Without this change, blocksizes greater than 512 (i.e. `log2(blocksize) >= 10`) would fail to decrypt on the cloud, due to different inputs to the key derivation function.