### PR TITLE
downlink: fix 'pouch_buf' memory leak

### DIFF
--- a/src/downlink.c
+++ b/src/downlink.c
@@ -226,4 +226,8 @@ void pouch_downlink_push(const void *buf, size_t buf_len)
     }
 }
 
-void pouch_downlink_finish(void) {}
+void pouch_downlink_finish(void)
+{
+    buf_free(pouch_buf);
+    pouch_buf = NULL;
+}


### PR DESCRIPTION
`pouch_buf` is allocated in `pouch_dwnlink_start()` and possibly reallocated in `pouch_downlink_push()`. However, there was no final `buf_free()` call, so with the next `pouch_downlink_start()` there was a memory leak due to pointer override with new allocation.

Free `pouch_buf` in `pouch_downlink_finish()` and assing it to NULL, so next invocation of `pouch_downlink_start()` is not creating memory leak.