### PR TITLE
transport: ble_gatt: Add optional characteristic user descriptors

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -161,6 +161,14 @@ config POUCH_TRANSPORT_BLE_GATT
 
 endchoice
 
+if POUCH_TRANSPORT_BLE_GATT
+
+menu "BLE GATT Transport Options"
+rsource "src/transport/ble_gatt/Kconfig"
+endmenu
+
+endif
+
 module = POUCH
 module-str = Pouch
 source "subsys/logging/Kconfig.template.log_config"

--- a/src/transport/ble_gatt/Kconfig
+++ b/src/transport/ble_gatt/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config POUCH_TRANSPORT_GATT_CUD_ATTRIBUTES
+    bool "Include CUD attributes for each characteristic"
+    help
+        If enabled, Characteristic User Description attributes will
+        be added for each characteristic with a brief identifier. This
+        can be useful during debugging and development to identify
+        the characteristics without consulting their UUIDs.

--- a/src/transport/ble_gatt/golioth_ble_gatt_declarations.h
+++ b/src/transport/ble_gatt/golioth_ble_gatt_declarations.h
@@ -7,6 +7,13 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/sys/iterable_sections.h>
 
+#if IS_ENABLED(CONFIG_POUCH_TRANSPORT_GATT_CUD_ATTRIBUTES)
+#define GOLIOTH_BT_GATT_CUD(name) \
+    STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_zzz_cud) = BT_GATT_CUD(#name, BT_GATT_PERM_READ)
+#else
+#define GOLIOTH_BT_GATT_CUD(name)
+#endif
+
 #define GOLIOTH_BLE_GATT_CHARACTERISTIC(name, _uuid, _props, _perm, _read, _write, _user_data) \
     STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_chrc) =                                       \
         BT_GATT_ATTRIBUTE(BT_UUID_GATT_CHRC,                                                   \
@@ -17,7 +24,8 @@
                               BT_GATT_CHRC_INIT(_uuid, 0U, _props),                            \
                           }));                                                                 \
     STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_val) =                                        \
-        BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _user_data)
+        BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _user_data);                            \
+    GOLIOTH_BT_GATT_CUD(name)
 
 #define GOLIOTH_BLE_GATT_SERVICE(_uuid) \
     STRUCT_SECTION_ITERABLE(bt_gatt_attr, AAA_golioth_ble_gatt_svc) = BT_GATT_PRIMARY_SERVICE(_uuid)


### PR DESCRIPTION
These are optional string descriptors that can be added to characteristics to provide human-readable information to users. They are useful in debugging and development to be able to identify characteristics without having to cross reference the UUID definitions. They are kept off by default because they serve no use in normal operation.

In the nRF Connect app, they appear as additional descriptors that need to be explicitly read, but in the Light Blue app they are automatically read and used as the characteristic names, which is pretty slick:

<img width="509" height="476" alt="Screenshot 2025-09-22 at 6 47 12 PM" src="https://github.com/user-attachments/assets/62297078-2fcb-463a-9852-de8afb821f20" />

<img width="1080" height="2400" alt="1000012295" src="https://github.com/user-attachments/assets/cdc735cd-6bc6-4ee1-83b0-fe329392de5e" />
