### PR TITLE
transport: ble_gatt: use SIG-provided 16-bit service UUID

### DIFF
--- a/lib/pouch_ble_gatt_common/include/pouch/transport/ble_gatt/common/uuids.h
+++ b/lib/pouch_ble_gatt_common/include/pouch/transport/ble_gatt/common/uuids.h
@@ -4,8 +4,9 @@
 
 #include <zephyr/bluetooth/uuid.h>
 
-#define GOLIOTH_BLE_GATT_UUID_SVC_VAL \
+#define GOLIOTH_BLE_GATT_UUID_SVC_VAL_128 \
     BT_UUID_128_ENCODE(0x89a316ae, 0x89b7, 0x4ef6, 0xb1d3, 0x5c9a6e27d272)
+#define GOLIOTH_BLE_GATT_UUID_SVC_VAL_16 0xFC49
 
 #define GOLIOTH_BLE_GATT_UUID_UPLINK_CHRC_VAL \
     BT_UUID_128_ENCODE(0x89a316ae, 0x89b7, 0x4ef6, 0xb1d3, 0x5c9a6e27d273)

--- a/src/transport/ble_gatt/peripheral.c
+++ b/src/transport/ble_gatt/peripheral.c
@@ -14,8 +14,8 @@
 
 #include "golioth_ble_gatt_declarations.h"
 
-static const struct bt_uuid_128 golioth_ble_gatt_svc_uuid =
-    BT_UUID_INIT_128(GOLIOTH_BLE_GATT_UUID_SVC_VAL);
+static const struct bt_uuid_16 golioth_ble_gatt_svc_uuid =
+    BT_UUID_INIT_16(GOLIOTH_BLE_GATT_UUID_SVC_VAL_16);
 
 GOLIOTH_BLE_GATT_SERVICE(&golioth_ble_gatt_svc_uuid);
 


### PR DESCRIPTION
The 16-bit UUID is small enough that we can fit all of the advertising data in a single packet, and no longer need the scan response for the example application.

Using this will require a corresponding change on the Gateway.