### PR TITLE
Uplink indications

### DIFF
--- a/src/transport/ble_gatt/golioth_ble_gatt_declarations.h
+++ b/src/transport/ble_gatt/golioth_ble_gatt_declarations.h
@@ -27,6 +27,10 @@
         BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _user_data);                            \
     GOLIOTH_BT_GATT_CUD(name)
 
+#define GOLIOTH_BLE_GATT_CCC(name, _changed, _write, _perm) \
+    STRUCT_SECTION_ITERABLE(bt_gatt_attr, name##_zzz_ccc) = \
+        BT_GATT_CCC_WITH_WRITE_CB(_changed, _write, _perm)
+
 #define GOLIOTH_BLE_GATT_SERVICE(_uuid) \
     STRUCT_SECTION_ITERABLE(bt_gatt_attr, AAA_golioth_ble_gatt_svc) = BT_GATT_PRIMARY_SERVICE(_uuid)
 

--- a/west.yml
+++ b/west.yml
@@ -6,13 +6,13 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: v4.1.0
+      revision: v4.2.0
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import:
         name-allowlist:
           - zephyr
-          - cmsis
+          - cmsis_6
           - hal_nordic
           - mbedtls
           - mcuboot


### PR DESCRIPTION
Support using indications to send uplink. Explicit reads from the Gateway are still supported.

Resolves golioth/firmware-issue-tracker#845