### PR TITLE
Implement HIL testing

### DIFF
--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -1,0 +1,92 @@
+name: "Build Gateway"
+
+on:
+  workflow_dispatch:
+    inputs:
+      gw_board:
+        required: false
+        type: string
+      gw_version:
+        required: false
+        type: string
+      gw_manifest_yml:
+        required: false
+        type: string
+      gw_blobs:
+        required: false
+        type: string
+
+  workflow_call:
+    inputs:
+      gw_board:
+        required: false
+        type: string
+      gw_version:
+        required: false
+        type: string
+      gw_manifest_yml:
+        required: false
+        type: string
+      gw_blobs:
+        required: false
+        type: string
+
+jobs:
+  build-gateway:
+    name: build-gw-${{ inputs.gw_board }}
+    container: golioth/golioth-zephyr-base:0.17.0-SDK-v0
+    env:
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: golioth/pouch-gateway
+          ref: ${{ inputs.gw_version }}
+          path: pouch-gateway
+
+      - name: Init and update west
+        run: |
+          west init -l pouch-gateway --mf ${{ inputs.gw_manifest_yml }}.yml
+          west update --narrow -o=--depth=1
+          git config --global user.email user@git-scm.com
+          git config --global user.name "Git User"
+          west patch apply || true
+
+      - name: Install pip packages
+        run: |
+          uv pip install \
+            -r pouch-gateway/requirements.txt \
+            -r zephyr/scripts/requirements-base.txt
+
+          uv pip install            \
+            cryptography==41.0.7  \
+            pyasn1                \
+            pyyaml                \
+            cbor>=1.0.0           \
+            imgtool>=1.9.0        \
+            jinja2                \
+            click
+
+      - name: Fetch Binary Blobs
+        if: ${{ inputs.gw_blobs }}
+        run: west blobs fetch -a ${{ inputs.gw_blobs }}
+
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          west build                                    \
+            -b ${{ inputs.gw_board }}                   \
+            pouch-gateway/gateway                       \
+            -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
+          cp build/zephyr/zephyr.hex gateway-${{ inputs.gw_board }}.hex
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gw-artifact-${{ inputs.gw_board }}-${{ inputs.manifest_yml }}
+          path: gateway-${{ inputs.gw_board }}.hex
+

--- a/.github/workflows/test-hil.yml
+++ b/.github/workflows/test-hil.yml
@@ -122,6 +122,35 @@ jobs:
         with:
           path: pouch
 
+      - name: Init and update west
+        run: |
+          rm -rf .west
+          west init -l pouch --mf ${{ inputs.manifest_yml }}.yml
+          west update --narrow -o=--depth=1
+
+      - name: Install pip packages
+        run: |
+          uv pip install \
+            -r zephyr/scripts/requirements-base.txt        \
+            -r zephyr/scripts/requirements-build-test.txt  \
+            -r zephyr/scripts/requirements-run-test.txt    \
+            -r pouch/requirements.txt                      \
+            'git+https://github.com/golioth/golioth-firmware-sdk@v0.22.0#egg=pytest_hil&subdirectory=tests/hil/scripts/pytest-hil/' \
+            git+https://github.com/golioth/python-golioth-tools@v0.8.1
+
+          uv pip install          \
+            cryptography==41.0.7  \
+            pyasn1                \
+            pyyaml                \
+            cbor>=1.0.0           \
+            imgtool>=1.9.0        \
+            jinja2                \
+            click                 \
+            smpmgr
+
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
+
       - name: Clean Binaries from Prior Runs
         shell: bash
         run: rm -rf *.bin *.hex
@@ -142,3 +171,71 @@ jobs:
       - name: Show downloads
         shell: bash
         run: ls -la .
+
+      - name: Run Pytest
+        shell: bash
+        env:
+          hil_board: ${{ inputs.hil_board }}
+          gw_board: ${{ inputs.gw_board }}
+          ARTIFACT_NAME: test_artifact_${{ inputs.hil_board }}-${{ inputs.manifest_yml }}-${{ inputs.binary_file }}
+          GW_ARTIFACT_NAME: gateway-${{ inputs.gw_board }}.hex
+        run: |
+          source /opt/credentials/runner_env.sh
+          export PATH=$PATH:/opt/SEGGER/JLink
+          PORT_VAR=CI_${hil_board^^}_PORT
+          SNR_VAR=CI_${hil_board^^}_SNR
+          GW_PORT_VAR=CI_${gw_board^^}_PORT
+          GW_SNR_VAR=CI_${gw_board^^}_SNR
+
+          pytest pouch/examples/ble_gatt/pytest              \
+              --rootdir .                                    \
+              --board ${hil_board}                           \
+              --port ${!PORT_VAR}                            \
+              --serial-number ${!SNR_VAR}                    \
+              --fw-image ${ARTIFACT_NAME}                    \
+              --api-url https://api.golioth.io               \
+              --api-key ${{ secrets.POUCH_CI_PROD_API_KEY }} \
+              --gw-board=${gw_board}                         \
+              --gw-port=${!GW_PORT_VAR}                      \
+              --gw-fw-image=${GW_ARTIFACT_NAME}              \
+              --gw-serial-number=${!GW_SNR_VAR}
+
+      - name: Erase flash
+        if: always()
+        shell: bash
+        env:
+          hil_board: ${{ inputs.hil_board }}
+          gw_board: ${{ inputs.gw_board }}
+        run: |
+          source /opt/credentials/runner_env.sh
+          export PATH=$PATH:/opt/SEGGER/JLink
+          SNR_VAR=CI_${hil_board^^}_SNR
+          PORT_VAR=CI_${hil_board^^}_PORT
+          cat <<EOF > erase_frdm_rw612.jlink
+          r
+          h
+          exec EnableEraseAllFlashBanks
+          erase 0x8000000 0x8624000
+          sleep 30
+          r
+          sleep 3
+          q
+          EOF
+
+          if [[ "${hil_board}" == "nrf52840dk" ]]; then
+            nrfjprog --recover --snr ${!SNR_VAR}
+          fi
+
+          if [[ "${gw_board}" == "frdm_rw612" ]]; then
+            JLinkExe \
+              -nogui 1 \
+              -if swd \
+              -speed auto \
+              -device RW612 \
+              -CommanderScript erase_frdm_rw612.jlink \
+              -SelectEmuBySN ${!SNR_VAR}
+          fi
+
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/test-hil.yml
+++ b/.github/workflows/test-hil.yml
@@ -18,6 +18,9 @@ on:
       binary_blob:
         required: false
         type: string
+      gw_board:
+        required: false
+        type: string
 
   workflow_call:
     inputs:
@@ -34,6 +37,9 @@ on:
         required: false
         type: string
       binary_blob:
+        required: false
+        type: string
+      gw_board:
         required: false
         type: string
 

--- a/.github/workflows/test-hil.yml
+++ b/.github/workflows/test-hil.yml
@@ -1,0 +1,91 @@
+name: "Pouch HIL Tests"
+
+on:
+  workflow_dispatch:
+    inputs:
+      hil_board:
+        required: true
+        type: string
+      west_board:
+        required: true
+        type: string
+      manifest_yml:
+        required: true
+        type: string
+      binary_file:
+        required: false
+        type: string
+      binary_blob:
+        required: false
+        type: string
+
+  workflow_call:
+    inputs:
+      hil_board:
+        required: true
+        type: string
+      west_board:
+        required: true
+        type: string
+      manifest_yml:
+        required: true
+        type: string
+      binary_file:
+        required: false
+        type: string
+      binary_blob:
+        required: false
+        type: string
+
+jobs:
+  build-leaf:
+    name: pouch-${{ inputs.hil_board }}-build
+    container: golioth/golioth-zephyr-base:0.17.0-SDK-v0
+    env:
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+      ARTIFACT_NAME: test_artifact_${{ inputs.hil_board }}-${{ inputs.manifest_yml }}-${{ inputs.binary_file }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: pouch
+      - name: Init and update west
+        run: |
+          west init -l pouch --mf ${{ inputs.manifest_yml }}.yml
+          west update --narrow -o=--depth=1
+      - name: Install pip packages
+        run: |
+          uv pip install \
+            -r zephyr/scripts/requirements-base.txt        \
+            -r zephyr/scripts/requirements-build-test.txt  \
+            -r zephyr/scripts/requirements-run-test.txt    \
+            -r pouch/requirements.txt
+
+          uv pip install          \
+            cryptography==41.0.7  \
+            pyasn1                \
+            pyyaml                \
+            cbor>=1.0.0           \
+            imgtool>=1.9.0        \
+            jinja2                \
+            click                 \
+            smpmgr
+
+      - name: Download binary blobs
+        if: ${{ inputs.binary_blob }}
+        run: |
+          west blobs fetch ${{ inputs.binary_blob }}
+
+      - name: Compile
+        shell: bash
+        run: |
+          west build --sysbuild -p -b ${{ inputs.west_board }} pouch/examples/ble_gatt
+          cp $(find build -name ${{ inputs.binary_file }}) $ARTIFACT_NAME
+
+      - name: Save artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_artifact_${{ inputs.hil_board }}-${{ inputs.manifest_yml }}
+          path: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/test-hil.yml
+++ b/.github/workflows/test-hil.yml
@@ -95,3 +95,50 @@ jobs:
         with:
           name: test_artifact_${{ inputs.hil_board }}-${{ inputs.manifest_yml }}
           path: ${{ env.ARTIFACT_NAME }}
+
+  test-hil:
+    name: hil-test-${{ inputs.hil_board }}-${{ inputs.manifest_yml }}
+    if: ${{ inputs.gw_board != '' }}
+    needs:
+      - build-leaf
+    runs-on:
+      - is_active
+      - has_${{ inputs.hil_board }}
+      - has_${{ inputs.gw_board }}
+    timeout-minutes: 30
+
+    container:
+      image: golioth/golioth-twister-base:89df175
+      env:
+        ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v4
+        with:
+          path: pouch
+
+      - name: Clean Binaries from Prior Runs
+        shell: bash
+        run: rm -rf *.bin *.hex
+
+      - name: Download Test Firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: test_artifact_${{ inputs.hil_board }}-${{ inputs.manifest_yml }}
+          path: .
+
+      - name: Download Gateway Firmware
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+          pattern: gw-artifact-*
+          merge-multiple: true
+
+      - name: Show downloads
+        shell: bash
+        run: ls -la .

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,25 +1,22 @@
-name: Tests
+name: Pouch Integration Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   workflow_dispatch:
+    inputs:
+      manifest_yml:
+        required: true
+        type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      manifest_yml:
+        required: true
+        type: string
 
 jobs:
-  build:
+  twister:
+    name: twister-${{ inputs.manifest_yml }}
     container: golioth/golioth-zephyr-base:0.17.0-SDK-v0
-    strategy:
-      matrix:
-        manifest:
-          - west.yml
-          - west-ncs.yml
-      fail-fast: false
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
     runs-on: ubuntu-24.04
@@ -30,14 +27,14 @@ jobs:
           path: pouch
       - name: Init and update west
         run: |
-          west init -l pouch --mf ${{ matrix.manifest }}
+          west init -l pouch --mf ${{ inputs.manifest_yml }}.yml
           west update --narrow -o=--depth=1
       - name: Install pip packages
         run: |
           uv pip install \
             -r zephyr/scripts/requirements-base.txt        \
             -r zephyr/scripts/requirements-build-test.txt  \
-            -r zephyr/scripts/requirements-run-test.txt         \
+            -r zephyr/scripts/requirements-run-test.txt    \
             -r pouch/requirements.txt
 
           uv pip install          \
@@ -49,17 +46,13 @@ jobs:
             jinja2                \
             click
 
-      - name: Compile
-        shell: bash
-        run: |
-          west build --sysbuild -p -b nrf52840dk/nrf52840 pouch/examples/ble_gatt
       - name: Run tests
         env:
           ZEPHYR_BASE: ${{ github.workspace }}/zephyr
           EXTRA_ZEPHYR_MODULES: ${{ github.workspace }}/pouch
         run: ./zephyr/scripts/twister -v -T pouch/tests
 
-      - name: Publish Test Report
+      - name: Publish Test Report (${{ inputs.manifest_yml }})
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:

--- a/.github/workflows/test-trigger.yml
+++ b/.github/workflows/test-trigger.yml
@@ -24,8 +24,27 @@ jobs:
       manifest_yml: ${{ matrix.manifest_yml }}
 
 
+  build-gateway:
+    name: build-gateway
+    uses: ./.github/workflows/build-gateway.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - gw_board: frdm_rw612
+            gw_version: f30be4530c17ce8543833c8bb3172f8e1b4510ff
+            gw_manifest_yml: west-zephyr
+            gw_blobs: hal_nxp
+    with:
+      gw_board: ${{ matrix.gw_board }}
+      gw_version: ${{ matrix.gw_version }}
+      gw_manifest_yml: ${{ matrix.gw_manifest_yml }}
+      gw_blobs: ${{ matrix.gw_blobs }}
+
+
   test-hil:
-    name: pouch-tests
+    name: Pouch HIL
+    needs: build-gateway
     uses: ./.github/workflows/test-hil.yml
     secrets: inherit
 
@@ -41,6 +60,7 @@ jobs:
             west_board: nrf52840dk/nrf52840
             manifest_yml: west-ncs
             binary_file: merged.hex
+            gw_board: frdm_rw612
 
     with:
       hil_board: ${{ matrix.hil_board }}
@@ -48,3 +68,4 @@ jobs:
       manifest_yml: ${{ matrix.manifest_yml }}
       binary_file: ${{ matrix.binary_file}}
       binary_blob: ${{ matrix.binary_blob }}
+      gw_board: ${{ matrix.gw_board || '' }}

--- a/.github/workflows/test-trigger.yml
+++ b/.github/workflows/test-trigger.yml
@@ -1,0 +1,50 @@
+name: Test Trigger
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-integration:
+    name: pouch-integration-tests
+    uses: ./.github/workflows/test-integration.yml
+    secrets: inherit
+
+    strategy:
+      matrix:
+        manifest_yml:
+          - west
+          - west-ncs
+      fail-fast: false
+
+    with:
+      manifest_yml: ${{ matrix.manifest_yml }}
+
+
+  test-hil:
+    name: pouch-tests
+    uses: ./.github/workflows/test-hil.yml
+    secrets: inherit
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - hil_board: nrf52840dk
+            west_board: nrf52840dk/nrf52840
+            manifest_yml: west
+            binary_file: zephyr.signed.hex
+          - hil_board: nrf52840dk
+            west_board: nrf52840dk/nrf52840
+            manifest_yml: west-ncs
+            binary_file: merged.hex
+
+    with:
+      hil_board: ${{ matrix.hil_board }}
+      west_board: ${{ matrix.west_board }}
+      manifest_yml: ${{ matrix.manifest_yml }}
+      binary_file: ${{ matrix.binary_file}}
+      binary_blob: ${{ matrix.binary_blob }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .DS_Store
 .vscode
 twister-out*/
+__pycache__/

--- a/examples/ble_gatt/pytest/conftest.py
+++ b/examples/ble_gatt/pytest/conftest.py
@@ -1,0 +1,130 @@
+import pytest
+import argparse
+import os
+from pathlib import Path
+import random
+import string
+import subprocess
+import trio
+
+from pytest_hil.frdmrw612 import FRDMRW612
+
+parser = argparse.ArgumentParser()
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    return "trio"
+
+
+def rand_str():
+    return ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase) for i in range(16))
+
+
+def pytest_addoption(parser):
+    parser.addoption("--gw-board", action="store", help="Gateway hil_board")
+    parser.addoption("--gw-port", action="store", help="Gateway serial port")
+    parser.addoption("--gw-fw-image", action="store", help="Gateway firmware binary")
+    parser.addoption("--gw-serial-number", type=str, action="store", help="Gateway programmer serial number")
+
+
+class DeviceCredential:
+    def __init__(self, name, psk_id, psk):
+        self.name = name
+        self.psk_id = psk_id
+        self.psk = psk
+
+
+@pytest.fixture(scope="module")
+async def certificate_cred(request, project):
+    # TODO: generate certificate here
+    device_name = 'salmon-itchy-bobcat'
+
+    yield DeviceCredential(
+        f"{device_name}",
+        f"{Path(request.config.rootdir, f'{device_name}.key.der')}",
+        f"{Path(request.config.rootdir, f'{device_name}.crt.der')}",
+    )
+
+    # TODO remove generated certificate here
+
+
+@pytest.fixture(scope="module")
+async def gateway(request, project):
+    assert request.config.getoption("--gw-board") == "frdm_rw612"
+
+    gw = FRDMRW612(
+        request.config.getoption("--gw-port"),
+        115200,
+        None,
+        None,
+        request.config.getoption("--gw-fw-image"),
+        serial_number=request.config.getoption("--gw-serial-number"),
+    )
+
+    name = f'gateway-{rand_str()}'
+    gw_device = await project.create_device(name, name)
+    gw_credentials = await gw_device.credentials.add(name, name)
+
+    async with gw.started():
+        await gw.set_golioth_psk_credentials(
+            gw_credentials["identity"],
+            gw_credentials["preSharedKey"],
+        )
+
+        await gw.send_cmd("kernel reboot")
+
+        assert None is not await gw.wait_for_regex_in_line(
+            ".*Scanning successfully started", timeout_s=120
+        )
+        yield gw
+
+    await project.delete_device(gw_device)
+
+
+@pytest.fixture(scope="module")
+async def ble_device(board, certificate_cred, gateway, project):
+    await board.wait_for_regex_in_line('.*Failed to load certificate', timeout_s=180.0)
+
+    await board.send_cmd('log halt')
+
+    # Set Golioth credential
+
+    subprocess.run(
+        [
+            "smpmgr",
+            "--port",
+            board.port,
+            "--mtu",
+            "128",
+            "file",
+            "upload",
+            certificate_cred.psk_id,
+            "/lfs1/credentials/key.der",
+        ]
+    )
+    subprocess.run(
+        [
+            "smpmgr",
+            "--port",
+            board.port,
+            "--mtu",
+            "128",
+            "file",
+            "upload",
+            certificate_cred.psk,
+            "/lfs1/credentials/crt.der",
+        ]
+    )
+
+    await board.send_cmd('log go')
+    await board.send_cmd('kernel reboot')
+
+    assert None is not await board.wait_for_regex_in_line(".*glth_dispatch: Beginning Golioth Uplink", timeout_s=180.0)
+
+    await trio.sleep(10) # Time for first uplink to arrive at server
+    ble_device = await project.device_by_name(certificate_cred.name)
+
+    yield ble_device
+
+    await project.delete_device_by_name(certificate_cred.name)

--- a/examples/ble_gatt/pytest/conftest.py
+++ b/examples/ble_gatt/pytest/conftest.py
@@ -34,11 +34,135 @@ class DeviceCredential:
         self.psk_id = psk_id
         self.psk = psk
 
-
 @pytest.fixture(scope="module")
 async def certificate_cred(request, project):
-    # TODO: generate certificate here
-    device_name = 'salmon-itchy-bobcat'
+    device_name = f"ble_{rand_str()}"
+    gateway_name = f"gw_{rand_str()}"
+
+    # Check cloud to verify device does not exist
+
+    with pytest.raises(Exception):
+        device = await project.device_by_name(device_name)
+
+    subprocess.run(
+        [
+            "openssl",
+            "ecparam",
+            "-name",
+            "prime256v1",
+            "-genkey",
+            "-noout",
+            "-out",
+            f"{gateway_name}.key.pem",
+        ],
+        cwd=request.config.rootdir,
+    )
+
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-new",
+            "-nodes",
+            "-key",
+            f'{gateway_name}.key.pem',
+            "-sha256",
+            "-subj",
+            f"/CN={gateway_name} CA",
+            "-days",
+            "10",
+            "-out",
+            f'{gateway_name}.crt.pem',
+        ],
+        cwd=request.config.rootdir,
+    )
+
+    # Pass root public key to Golioth server
+
+    with open(f"{gateway_name}.crt.pem", "rb") as f:
+        cert_pem = f.read()
+    root_cert = await project.certificates.add(cert_pem, "root")
+
+    # Device Cert
+
+    subprocess.run(
+        [
+            "openssl",
+            "ecparam",
+            "-name",
+            "prime256v1",
+            "-genkey",
+            "-noout",
+            "-out",
+            f"{device_name}.key.pem",
+        ],
+        cwd=request.config.rootdir,
+    )
+
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            f"{device_name}.key.pem",
+            "-subj",
+            f"/O={project.info['id']}/CN={device_name}",
+            "-out",
+            f"{device_name}.csr.pem",
+        ],
+        cwd=request.config.rootdir,
+    )
+
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            f"{device_name}.csr.pem",
+            "-CA",
+            f'{gateway_name}.crt.pem',
+            "-CAkey",
+            f'{gateway_name}.key.pem',
+            "-CAcreateserial",
+            "-out",
+            f"{device_name}.crt.pem",
+            "-days",
+            "7",
+            "-sha256",
+        ],
+        cwd=request.config.rootdir,
+    )
+
+    subprocess.run(
+        [
+            "openssl",
+            "ec",
+            "-in",
+            f"{device_name}.key.pem",
+            "-outform",
+            "DER",
+            "-out",
+            f"{device_name}.key.der",
+        ],
+        cwd=request.config.rootdir,
+    )
+
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-in",
+            f"{device_name}.crt.pem",
+            "-outform",
+            "DER",
+            "-out",
+            f"{device_name}.crt.der",
+        ],
+        cwd=request.config.rootdir,
+    )
 
     yield DeviceCredential(
         f"{device_name}",
@@ -46,7 +170,12 @@ async def certificate_cred(request, project):
         f"{Path(request.config.rootdir, f'{device_name}.crt.der')}",
     )
 
-    # TODO remove generated certificate here
+    await project.certificates.delete(root_cert["data"]["id"])
+
+    for p in Path(request.config.rootdir).glob(f"{gateway_name}.*"):
+        p.unlink()
+    for p in Path(request.config.rootdir).glob(f"{device_name}.*"):
+        p.unlink()
 
 
 @pytest.fixture(scope="module")

--- a/examples/ble_gatt/pytest/test_sample.py
+++ b/examples/ble_gatt/pytest/test_sample.py
@@ -1,0 +1,27 @@
+import pytest
+import trio
+import logging
+import subprocess
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.anyio
+
+LED_SETTING_KEY = 'LED'
+
+async def test_settings(ble_device, board, project):
+    # Get current LED setting
+    settings = await ble_device.settings.get_all()
+    led_setting_value = None
+    for setting in settings:
+        if setting['key'] == LED_SETTING_KEY:
+            led_setting_value = setting['value']
+    assert led_setting_value is not None
+
+    # Toggle LED setting
+    new_led_setting_value = not led_setting_value
+    await ble_device.settings.set(LED_SETTING_KEY, new_led_setting_value)
+    await board.wait_for_regex_in_line(f'.*LED setting: {int(new_led_setting_value)}', timeout_s=60.0)
+
+    await ble_device.settings.set(LED_SETTING_KEY, led_setting_value)
+    await board.wait_for_regex_in_line(f'.*LED setting: {int(led_setting_value)}', timeout_s=60.0)


### PR DESCRIPTION
Implement Hardware-in-the-Loop testing.

- Separate build from integration tests
- Add gateway build
- Add pytest for Settings service to `example/ble_gatt`

## Known Limitations

- Gateway
  - Currently the `frdm_rw612` using Ethernet is the only supported gateway device for HIL testing
  - While the gateway version may be specified, only one version may be used for any given test run
- HIL build won't start until the Gateway build finishes
  - To avoid building the gateway for every matrix strategy, the HIL build/test job `needs` the Gateway build to finish before the individual HIL build steps may begin. One alternative to this would be to split the HIL build/test steps into their own workflow. That approach was not used as it would have required the matrix stategy to be specified twice (once for each of those workflow calls).
- Initial implementation only supports node testing on NCS
  - HIL tests are run via pytest (no twister). Because of this, nrf52840 binaries built for vanilla Zephyr don't run on the device, likely because both mcuboot and application code needs to be flashed. This issue is [tracked here](https://github.com/golioth/firmware-issue-tracker/issues/908).
- Testing in Dev is currently not supported. This issue is [tracked here](https://github.com/golioth/firmware-issue-tracker/issues/905).

Resolves https://github.com/golioth/firmware-issue-tracker/issues/901
Resolves https://github.com/golioth/firmware-issue-tracker/issues/902