### PR TITLE
downlink: remove redundant NULL test

### DIFF
--- a/src/downlink.c
+++ b/src/downlink.c
@@ -208,7 +208,7 @@ void pouch_downlink_push(const void *buf, size_t buf_len)
                     LOG_ERR("Failed to allocate pouch buf");
                 }
 
-                if (pouch_buf && pouch_bufview_available(&v) > block_size)
+                if (pouch_bufview_available(&v) > block_size)
                 {
                     const uint8_t *remaining = pouch_bufview_read(&v, 0);
                     remaining += block_size;


### PR DESCRIPTION
pouch_buf is checked for NULL (with return) immediately before the it was being checked a second time. No behavior is changed by this commit.