### PR TITLE
Move plaintext block allocation to slabs

### DIFF
--- a/include/pouch/uplink.h
+++ b/include/pouch/uplink.h
@@ -77,10 +77,13 @@ int pouch_uplink_close(pouch_timeout_t timeout);
  *
  * @param path The path to write the entry to.
  * @param content_type The content type of the entry.
+ * @param timeout The timeout for opening the stream.
  *
  * @return A stream handle or NULL on error.
  */
-struct pouch_stream *pouch_uplink_stream_open(const char *path, uint16_t content_type);
+struct pouch_stream *pouch_uplink_stream_open(const char *path,
+                                              uint16_t content_type,
+                                              pouch_timeout_t timeout);
 
 /**
  * Write data to a stream.

--- a/port/include/pouch/blockbuf.h
+++ b/port/include/pouch/blockbuf.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <pouch/port.h>
+
+struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout);
+void blockbuf_free(struct pouch_buf *buf);

--- a/port/zephyr/CMakeLists.txt
+++ b/port/zephyr/CMakeLists.txt
@@ -33,6 +33,7 @@ if(CONFIG_POUCH)
     zephyr_library_sources(
         ${CMAKE_CURRENT_BINARY_DIR}/core/header_decode.c
         ${CMAKE_CURRENT_BINARY_DIR}/core/header_encode.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/blockbuf.c
     )
 
     zephyr_library_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -21,6 +21,13 @@ config POUCH_BLOCK_SIZE
   help
     The maximum block size to use for Pouch transfers.
 
+config POUCH_BLOCK_COUNT
+  int "Block count"
+  default 2
+  range 2 10000
+  help
+    Number of blocks that are allocated for assembling pouch packets.
+
 config POUCH_THREAD_STACK_SIZE
   int "Pouch thread stack size"
   default 2048

--- a/port/zephyr/blockbuf.c
+++ b/port/zephyr/blockbuf.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <pouch/blockbuf.h>
+#include "../../src/block.h"
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+K_MEM_SLAB_DEFINE(blockbuf,
+                  WB_UP(POUCH_BUF_OVERHEAD + MAX_PLAINTEXT_BLOCK_SIZE),
+                  CONFIG_POUCH_BLOCK_COUNT,
+                  4);
+
+struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout)
+{
+    struct pouch_buf *buf = NULL;
+    int err = k_mem_slab_alloc(&blockbuf, (void **) &buf, timeout);
+    if (err || buf == NULL)
+    {
+        return NULL;
+    }
+
+    buf_restore(buf, POUCH_BUF_STATE_INITIAL);
+
+    return buf;
+}
+
+void blockbuf_free(struct pouch_buf *buf)
+{
+    k_mem_slab_free(&blockbuf, buf);
+}

--- a/src/block.c
+++ b/src/block.c
@@ -5,6 +5,7 @@
  */
 
 #include "block.h"
+#include <pouch/blockbuf.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pouch/port.h>
@@ -79,9 +80,9 @@ void block_size_write(struct pouch_buf *block, uint16_t size)
     pouch_put_be16(size, buf_claim(block, sizeof(uint16_t)));
 }
 
-struct pouch_buf *block_alloc(void)
+struct pouch_buf *block_alloc(pouch_timeout_t timeout)
 {
-    struct pouch_buf *block = buf_alloc(MAX_PLAINTEXT_BLOCK_SIZE);
+    struct pouch_buf *block = blockbuf_alloc(timeout);
     if (block != NULL)
     {
         write_block_header(block, 0, BLOCK_ID_ENTRY, FIRST_DATA_MASK | LAST_DATA_MASK);
@@ -90,9 +91,9 @@ struct pouch_buf *block_alloc(void)
     return block;
 }
 
-struct pouch_buf *block_alloc_stream(uint8_t stream_id, bool first)
+struct pouch_buf *block_alloc_stream(uint8_t stream_id, bool first, pouch_timeout_t timeout)
 {
-    struct pouch_buf *block = buf_alloc(MAX_PLAINTEXT_BLOCK_SIZE);
+    struct pouch_buf *block = blockbuf_alloc(timeout);
     if (block != NULL)
     {
         write_block_header(block, 0, stream_id, first ? FIRST_DATA_MASK : 0);
@@ -103,7 +104,7 @@ struct pouch_buf *block_alloc_stream(uint8_t stream_id, bool first)
 
 void block_free(struct pouch_buf *block)
 {
-    buf_free(block);
+    blockbuf_free(block);
 }
 
 static void finish(struct pouch_buf *block, uint8_t id, uint8_t flags)

--- a/src/block.h
+++ b/src/block.h
@@ -32,9 +32,9 @@ void block_decode_hdr(struct pouch_bufview *v,
                       bool *is_first,
                       bool *is_last);
 
-struct pouch_buf *block_alloc(void);
+struct pouch_buf *block_alloc(pouch_timeout_t timeout);
 
-struct pouch_buf *block_alloc_stream(uint8_t stream_id, bool first);
+struct pouch_buf *block_alloc_stream(uint8_t stream_id, bool first, pouch_timeout_t timeout);
 
 void block_free(struct pouch_buf *block);
 

--- a/src/buf.c
+++ b/src/buf.c
@@ -20,6 +20,9 @@ struct pouch_buf
     uint8_t buf[];
 };
 
+POUCH_STATIC_ASSERT(sizeof(struct pouch_buf) == POUCH_BUF_OVERHEAD,
+                    "Invalid overhead in pouch buf");
+
 void buf_write(struct pouch_buf *buf, const uint8_t *data, size_t len)
 {
     memcpy(buf_claim(buf, len), data, len);

--- a/src/buf.h
+++ b/src/buf.h
@@ -12,6 +12,8 @@
 
 /** Initial state of the buffer */
 #define POUCH_BUF_STATE_INITIAL ((pouch_buf_state_t) 0)
+/** Size of overhead required by pouch buffers, in addition to the usable memory area */
+#define POUCH_BUF_OVERHEAD (sizeof(pouch_slist_node_t) + sizeof(size_t))
 
 /** Single pouch buffer */
 struct pouch_buf;

--- a/src/crypto_none.c
+++ b/src/crypto_none.c
@@ -75,5 +75,17 @@ int crypto_decrypt_block(const struct pouch_buf *block, struct pouch_buf *decryp
 
 struct pouch_buf *crypto_encrypt_block(struct pouch_buf *block)
 {
-    return block;
+    // Have to copy this to get a buffer from the heap for transport:
+    struct pouch_buf *encrypted = buf_alloc(MAX_CIPHERTEXT_BLOCK_SIZE);
+    if (encrypted != NULL)
+    {
+        struct pouch_bufview v;
+        pouch_bufview_init(&v, block);
+
+        size_t size = pouch_bufview_available(&v);
+        pouch_bufview_memcpy(&v, buf_claim(encrypted, size), size);
+    }
+    block_free(block);
+
+    return encrypted;
 }

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -13,6 +13,7 @@
 #include "cddl/header_decode.h"
 
 #include "block.h"
+#include <pouch/blockbuf.h>
 #include "buf.h"
 #include "crypto.h"
 #include "downlink.h"
@@ -27,7 +28,6 @@ static struct
 {
     pouch_buf_queue_t queue;
     pouch_work_t work;
-    struct pouch_buf *decrypted;
     pouch_work_q_t *work_queue;
 } decrypt;
 
@@ -39,26 +39,26 @@ int downlink_init(pouch_work_q_t *pouch_work_queue)
     pouch_work_init(&decrypt.work, decrypt_blocks);
     decrypt.work_queue = pouch_work_queue;
 
-    decrypt.decrypted = crypto_block_buf_alloc();
-    if (!decrypt.decrypted)
-    {
-        POUCH_LOG_ERR("Failed to allocate decrypt buf");
-        return -ENOMEM;
-    }
-
     return 0;
 }
 
 static void decrypt_blocks(pouch_work_t *work)
 {
     struct pouch_buf *encrypted_block;
+    struct pouch_buf *decrypted_block = blockbuf_alloc(K_FOREVER);
+    if (decrypted_block == NULL)
+    {
+        POUCH_LOG_ERR("Failed to allocate decrypt block");
+        return;
+    }
+
     while ((encrypted_block = buf_queue_get(&decrypt.queue)) != NULL)
     {
         // Reset the target buffer
-        buf_restore(decrypt.decrypted, POUCH_BUF_STATE_INITIAL);
+        buf_restore(decrypted_block, POUCH_BUF_STATE_INITIAL);
 
         /* Decrypt this block */
-        int err = crypto_decrypt_block(encrypted_block, decrypt.decrypted);
+        int err = crypto_decrypt_block(encrypted_block, decrypted_block);
 
         /* Encrypted block was consumed; free buffer no matter the outcome */
         /* buffers were allocated then enqueued in pouch_downlink_push() */
@@ -69,13 +69,15 @@ static void decrypt_blocks(pouch_work_t *work)
         {
             POUCH_LOG_ERR("Failed to decrypt block: %d", err);
             // TODO: Abort the downlink
-            return;
+            break;
         }
 
-        pouch_downlink_block_push(decrypt.decrypted);
+        pouch_downlink_block_push(decrypted_block);
 
         pouch_yield();  // let other threads run
     }
+
+    blockbuf_free(decrypted_block);
 }
 
 static int block_downlink_push(struct pouch_buf *pouch_buf)

--- a/src/entry.c
+++ b/src/entry.c
@@ -180,7 +180,7 @@ void pouch_downlink_block_push(struct pouch_buf *pouch_buf)
 static int write_entry(struct pouch_buf *block, const struct pouch_entry *entry)
 {
     size_t pathlen = strlen(entry->path);
-    if (block_space_get(block) < ENTRY_HEADER_OVERHEAD + pathlen + entry->data_len)
+    if (block == NULL || block_space_get(block) < ENTRY_HEADER_OVERHEAD + pathlen + entry->data_len)
     {
         return -ENOMEM;
     }
@@ -205,24 +205,15 @@ int pouch_uplink_entry_write(const char *path,
         return -EINVAL;
     }
 
-    int err = 0;
-    bool block_is_new = false;
+    /* We're using the timeout for successive blocking calls, so we have to
+     * use timepoints to move it along:
+     */
+    pouch_timepoint_t end = pouch_timepoint_get(timeout);
 
-    bool unlocked = pouch_mutex_lock(&mut, timeout);
-    if (false == unlocked)
+    bool ok = pouch_mutex_lock(&mut, pouch_timepoint_timeout(end));
+    if (!ok)
     {
         return -EAGAIN;
-    }
-
-    if (block == NULL)
-    {
-        block_is_new = true;
-        block = block_alloc();
-        if (block == NULL)
-        {
-            err = -ENOMEM;
-            goto end;
-        }
     }
 
     const struct pouch_entry entry = {
@@ -232,15 +223,18 @@ int pouch_uplink_entry_write(const char *path,
         .data = data,
     };
 
-    err = write_entry(block, &entry);
-    if (err && !block_is_new)
+    int err = write_entry(block, &entry);
+    if (err)
     {
-        // block is full
-        block_finish(block);
-        uplink_enqueue(block);
+        if (block != NULL)
+        {
+            // block is full
+            block_finish(block);
+            uplink_enqueue(block);
+        }
 
-        // try again with a new block:
-        block = block_alloc();
+        // allocate a new block:
+        block = block_alloc(pouch_timepoint_timeout(end));
         if (block == NULL)
         {
             err = -ENOMEM;
@@ -263,10 +257,17 @@ int entry_block_close(pouch_timeout_t timeout)
         return -EAGAIN;
     }
 
-    if (block && block_size_get(block) > 0)
+    if (block)
     {
-        block_finish(block);
-        uplink_enqueue(block);
+        if (block_size_get(block) > 0)
+        {
+            block_finish(block);
+            uplink_enqueue(block);
+        }
+        else
+        {
+            block_free(block);
+        }
         block = NULL;
     }
 

--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -106,13 +106,13 @@ struct pouch_buf *saead_uplink_encrypt_block(struct pouch_buf *block)
     if (!pouch_atomic_test_bit(&uplink.flags, SESSION_ACTIVE))
     {
         POUCH_LOG_WRN("Not in a session");
-        buf_free(block);
+        block_free(block);
         return NULL;
     }
 
     struct pouch_buf *encrypted = session_encrypt_block(&uplink, block);
 
-    buf_free(block);
+    block_free(block);
 
     return encrypted;
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -52,7 +52,9 @@ static uint8_t new_stream_id(void)
     return id;
 }
 
-struct pouch_stream *pouch_uplink_stream_open(const char *path, uint16_t content_type)
+struct pouch_stream *pouch_uplink_stream_open(const char *path,
+                                              uint16_t content_type,
+                                              pouch_timeout_t timeout)
 {
     if (pouch_atomic_inc(&open_streams) >= POUCH_STREAMS_MAX)
     {
@@ -71,7 +73,7 @@ struct pouch_stream *pouch_uplink_stream_open(const char *path, uint16_t content
     stream->bytes = 0;
     stream->session_id = uplink_session_id();
 
-    stream->buf = block_alloc_stream(stream->id, true);
+    stream->buf = block_alloc_stream(stream->id, true, timeout);
     if (stream->buf == NULL)
     {
         free(stream);
@@ -108,7 +110,7 @@ size_t pouch_stream_write(struct pouch_stream *stream,
              * stream as a result of this failed write instead of having to allocate an empty block
              * for this.
              */
-            struct pouch_buf *buf = block_alloc_stream(stream->id, false);
+            struct pouch_buf *buf = block_alloc_stream(stream->id, false, timeout);
             if (buf == NULL)
             {
                 break;

--- a/tests/pouch/common/src/transport.c
+++ b/tests/pouch/common/src/transport.c
@@ -40,10 +40,11 @@ void transport_reset(void *unused)
     if (!uplink)
     {
         uplink = pouch_uplink_start();
-        pouch_uplink_close(POUCH_NO_WAIT);
-        // let processing run:
-        k_sleep(K_MSEC(1));
     }
+
+    pouch_uplink_close(K_NO_WAIT);
+    // let processing run:
+    k_sleep(K_MSEC(1));
 
     while (true)
     {

--- a/tests/pouch/uplink/prj.conf
+++ b/tests/pouch/uplink/prj.conf
@@ -3,3 +3,5 @@ CONFIG_POUCH=y
 CONFIG_POUCH_ENCRYPTION_NONE=y
 # Some of the tests require more threads waiting on the same mutex than the basic wait queue can handle
 CONFIG_WAITQ_SCALABLE=y
+# enough to exhaust the max stream ID:
+CONFIG_POUCH_BLOCK_COUNT=128

--- a/tests/pouch/uplink/src/uplink.c
+++ b/tests/pouch/uplink/src/uplink.c
@@ -85,7 +85,7 @@ static void uplink_handler(void)
     if (uplink_handler_enabled)
     {
         k_mutex_lock(&handler_mut, K_FOREVER);
-        write_entry(10, K_FOREVER);
+        write_entry(10, K_MSEC(10));
         k_mutex_unlock(&handler_mut);
         // disabled by default:
         uplink_handler_enabled = false;
@@ -247,6 +247,12 @@ ZTEST(uplink, test_pull_partial)
     }
 
     zassert_equal(offset, 46, "expected to read 46 bytes, got %d", offset);
+    pouch_uplink_close(K_NO_WAIT);
+
+    // let uplink handler and processing run:
+    k_sleep(K_MSEC(1));
+
+    transport_reset(NULL);
 
     free(buf);
 }
@@ -348,7 +354,7 @@ ZTEST(uplink, test_stream_basic)
     transport_session_start();
 
     struct pouch_stream *stream =
-        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream, "Failed to open stream");
 
     const uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
@@ -385,7 +391,7 @@ ZTEST(uplink, test_stream_multiblock)
     transport_session_start();
 
     struct pouch_stream *stream =
-        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream, "Failed to open stream");
 
     // write more data than a single block can hold:
@@ -464,11 +470,11 @@ ZTEST(uplink, test_stream_multi_stream)
     transport_session_start();
 
     struct pouch_stream *stream1 =
-        pouch_uplink_stream_open("test/path1", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path1", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream1, "Failed to open stream");
 
     struct pouch_stream *stream2 =
-        pouch_uplink_stream_open("test/path2", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path2", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream2, "Failed to open stream");
 
     const uint8_t data1[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
@@ -522,11 +528,11 @@ ZTEST(uplink, test_stream_multi_block_multi_stream)
     transport_session_start();
 
     struct pouch_stream *stream1 =
-        pouch_uplink_stream_open("test/path1", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path1", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream1, "Failed to open stream");
 
     struct pouch_stream *stream2 =
-        pouch_uplink_stream_open("test/path2", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path2", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream2, "Failed to open stream");
 
     // write more data than a single block can hold:
@@ -613,7 +619,6 @@ ZTEST(uplink, test_stream_multi_block_multi_stream)
     }
 }
 
-
 ZTEST(uplink, test_stream_max_count)
 {
     transport_session_start();
@@ -621,12 +626,13 @@ ZTEST(uplink, test_stream_max_count)
     struct pouch_stream *streams[POUCH_STREAMS_MAX];
     for (int i = 0; i < POUCH_STREAMS_MAX; i++)
     {
-        streams[i] = pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
-        zassert_not_null(streams[i], "Failed to open stream");
+        streams[i] =
+            pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM, K_NO_WAIT);
+        zassert_not_null(streams[i], "Failed to open stream %d", i);
     }
 
     struct pouch_stream *stream =
-        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM, K_NO_WAIT);
     zassert_is_null(stream, "Expected to fail to open stream");
 
     for (int i = 0; i < POUCH_STREAMS_MAX; i++)
@@ -643,7 +649,7 @@ ZTEST(uplink, test_stream_empty)
     transport_session_start();
 
     struct pouch_stream *stream =
-        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream, "Failed to open stream");
 
     zassert_ok(pouch_stream_close(stream, POUCH_NO_WAIT));
@@ -659,7 +665,7 @@ ZTEST(uplink, test_stream_empty)
 ZTEST(uplink, test_stream_fail_to_close_stream)
 {
     struct pouch_stream *stream =
-        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream, "Failed to open stream");
 
     zassert_true(pouch_stream_is_valid(stream), "Expected stream to be valid");
@@ -695,7 +701,7 @@ ZTEST(uplink, test_stream_length_aligned_to_block_size)
     transport_session_start();
 
     struct pouch_stream *stream =
-        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM);
+        pouch_uplink_stream_open("test/path", POUCH_CONTENT_TYPE_OCTET_STREAM, K_FOREVER);
     zassert_not_null(stream, "Failed to open stream");
 
     // Write data that is exactly aligned to the size of two blocks. Need to account for the size


### PR DESCRIPTION
Replaces the calls to malloc with blocking calls to slab based block allocation. This introduces a timeout parameter to the `stream_open` API, which will now block on the allocation of the first block.

The plain text blocks are used for both uplink and downlink plaintext blocks, with the assumption that uplink normally completes before downlink starts. The number of available blocks are controlled by a kconfig symbol, and defaults to 2 - one for the entry block, and one for any stream blocks.

I have only provided an implementation of this for Zephyr for now - is there an equivalent in esp_idf? We could arguably move the platform abstraction to the raw slab mechanism too, so that we could reuse this for the stream contexts, for instance. We could also implement our own slabs very easily - they're really just an array, a semaphore and an atomic bitmap.