### PR TITLE
Port: cleanup non-portable code preventing ESP-IDF platform builds

### DIFF
--- a/golioth_sdk/dispatch.c
+++ b/golioth_sdk/dispatch.c
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(glth_dispatch, CONFIG_GOLIOTH_LOG_LEVEL);
-
 #include <pouch/downlink.h>
 #include <pouch/events.h>
 #include <pouch/port.h>
 #include <pouch/uplink.h>
+#include <string.h>
 
 #include "dispatch.h"
+
+POUCH_LOG_REGISTER(glth_dispatch, CONFIG_GOLIOTH_LOG_LEVEL);
 
 static struct golioth_downlink_service *last_seen = NULL;
 
 static void pouch_downlink_start(unsigned int stream_id, const char *path, uint16_t content_type)
 {
-    LOG_DBG("Downlink start: %d, %s, %d", stream_id, path, content_type);
-    LOG_INF("Receiving Downlink entry on path %s", path);
+    POUCH_LOG_DBG("Downlink start: %d, %s, %d", stream_id, path, content_type);
+    POUCH_LOG_INF("Receiving Downlink entry on path %s", path);
 
     POUCH_STRUCT_SECTION_FOREACH(golioth_downlink_service, service)
     {
@@ -31,7 +31,7 @@ static void pouch_downlink_start(unsigned int stream_id, const char *path, uint1
         }
         if (0 == strncmp(service->path, path, path_len))
         {
-            LOG_DBG("Found match for path %s", path);
+            POUCH_LOG_DBG("Found match for path %s", path);
             last_seen = service;
             service->data->downlink_id = stream_id;
             if (NULL != service->start_cb)
@@ -49,13 +49,13 @@ static void pouch_downlink_start(unsigned int stream_id, const char *path, uint1
 
     if (NULL == last_seen)
     {
-        LOG_DBG("No handler registered for path %s", path);
+        POUCH_LOG_DBG("No handler registered for path %s", path);
     }
 }
 
 static void pouch_downlink_data(unsigned int stream_id, const void *data, size_t len, bool is_last)
 {
-    LOG_DBG("Downlink data: %d", stream_id);
+    POUCH_LOG_DBG("Downlink data: %d", stream_id);
 
     struct golioth_downlink_service *active_service = NULL;
 
@@ -80,7 +80,7 @@ static void pouch_downlink_data(unsigned int stream_id, const void *data, size_t
         active_service->data_cb(stream_id, data, len, is_last);
         if (is_last)
         {
-            LOG_INF("Finished entry for %s", active_service->path);
+            POUCH_LOG_INF("Finished entry for %s", active_service->path);
 
             active_service->data->downlink_id = DOWNLINK_ID_INVALID;
             last_seen = NULL;
@@ -88,7 +88,7 @@ static void pouch_downlink_data(unsigned int stream_id, const void *data, size_t
     }
     else
     {
-        LOG_DBG("Dropping message for stream_id %d", stream_id);
+        POUCH_LOG_DBG("Dropping message for stream_id %d", stream_id);
     }
 }
 

--- a/golioth_sdk/ota.c
+++ b/golioth_sdk/ota.c
@@ -6,8 +6,8 @@
 
 #include <string.h>
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ota, CONFIG_GOLIOTH_LOG_LEVEL);
+#include <pouch/port.h>
+POUCH_LOG_REGISTER(ota, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #include <pouch/types.h>
 #include <pouch/uplink.h>

--- a/golioth_sdk/ota_upper.c
+++ b/golioth_sdk/ota_upper.c
@@ -7,8 +7,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ota_upper, CONFIG_GOLIOTH_LOG_LEVEL);
 
-#include <zephyr/kernel.h>
-
 #include <pouch/golioth/ota.h>
 #include <pouch/port.h>
 

--- a/golioth_sdk/ota_upper.c
+++ b/golioth_sdk/ota_upper.c
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ota_upper, CONFIG_GOLIOTH_LOG_LEVEL);
-
+#include <errno.h>
 #include <pouch/golioth/ota.h>
 #include <pouch/port.h>
+#include <string.h>
 
 #include "ota.h"
+
+POUCH_LOG_REGISTER(ota_upper, CONFIG_GOLIOTH_LOG_LEVEL);
 
 /* Public interface to application */
 
@@ -50,10 +51,10 @@ int golioth_ota_mark_updating(const char *name)
 
 int golioth_ota_manifest_receive_one(const struct golioth_ota_component *component)
 {
-    LOG_DBG("Received one component:");
-    LOG_DBG("  package: %s", component->package);
-    LOG_DBG("  version: %s", component->version);
-    LOG_DBG("  size: %d", component->size);
+    POUCH_LOG_DBG("Received one component:");
+    POUCH_LOG_DBG("  package: %s", component->package);
+    POUCH_LOG_DBG("  version: %s", component->version);
+    POUCH_LOG_DBG("  size: %d", component->size);
 
     POUCH_STRUCT_SECTION_FOREACH(golioth_ota_registered_component, registered)
     {
@@ -101,7 +102,7 @@ int golioth_ota_receive_component(const char *name,
                                   size_t len,
                                   bool is_last)
 {
-    LOG_DBG("Received %d bytes at offset %d for %s@%s", len, offset, name, version);
+    POUCH_LOG_DBG("Received %zu bytes at offset %zu for %s@%s", len, offset, name, version);
 
     POUCH_STRUCT_SECTION_FOREACH(golioth_ota_registered_component, registered)
     {
@@ -113,7 +114,7 @@ int golioth_ota_receive_component(const char *name,
             }
             else
             {
-                LOG_WRN("Dropping OTA data for %s, download not requested", name);
+                POUCH_LOG_WRN("Dropping OTA data for %s, download not requested", name);
                 return -EINVAL;
             }
         }

--- a/golioth_sdk/settings.c
+++ b/golioth_sdk/settings.c
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(glth_settings, CONFIG_GOLIOTH_LOG_LEVEL);
-
-#include <zephyr/drivers/gpio.h>
+#include <pouch/port.h>
+POUCH_LOG_REGISTER(settings, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #include <pouch/types.h>
 #include <pouch/uplink.h>

--- a/golioth_sdk/settings_callbacks.c
+++ b/golioth_sdk/settings_callbacks.c
@@ -4,13 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(glth_settings);
-
-#include <errno.h>
-#include <stddef.h>
 #include <pouch/port.h>
+POUCH_LOG_REGISTER(settings_callbacks, CONFIG_GOLIOTH_LOG_LEVEL);
 
+#include <stddef.h>
 #include "settings.h"
 
 int golioth_settings_receive_one(const struct setting_value *value)

--- a/include/pouch/uplink.h
+++ b/include/pouch/uplink.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <pouch/port.h>
-#include <zephyr/kernel.h>
 
 /**
  * @file uplink.h

--- a/lib/pouch_gatt_common/Kconfig
+++ b/lib/pouch_gatt_common/Kconfig
@@ -14,8 +14,7 @@ config POUCH_GATT_ACK_TIMEOUT_MS
     The timeout, in milliseconds, that a receiver will wait
     for new packets before retransmitting an acknowledgement
 
-module = POUCH_GATT_COMMON
-module-str = Pouch GATT Common
-source "subsys/logging/Kconfig.template.log_config"
-
+config POUCH_GATT_COMMON_LOG_LEVEL
+    int "Pouch GATT Common Log Level"
+    default 3
 endif # POUCH_TRANSPORT_GATT_COMMON

--- a/lib/zcbor_utils/zcbor_utils.c
+++ b/lib/zcbor_utils/zcbor_utils.c
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(zcbor_util, CONFIG_POUCH_LOG_LEVEL);
-
-#include <errno.h>
+#include <pouch/port.h>
+POUCH_LOG_REGISTER(zcbor_util, CONFIG_POUCH_LOG_LEVEL);
 
 #include <zcbor_utils.h>
 

--- a/port/include/pouch/port.h
+++ b/port/include/pouch/port.h
@@ -36,6 +36,14 @@
 #define STRINGIFY(s) #s
 #endif
 
+#ifndef IS_ENABLED
+#define IS_ENABLED(config_macro) PORT_IS_ENABLED1(config_macro)
+#define _PORTXXXX1 _expand_to_comma,
+#define PORT_IS_ENABLED1(x) PORT_IS_ENABLED2(_PORTXXXX##x)
+#define PORT_IS_ENABLED2(one_or_two_args) PORT_IS_ENABLED3(one_or_two_args 1, 0)
+#define PORT_IS_ENABLED3(ignore, val, ...) val
+#endif
+
 #ifndef CONTAINER_OF
 
 /*

--- a/port/include/pouch/port.h
+++ b/port/include/pouch/port.h
@@ -16,12 +16,24 @@
 
 #define POUCH_STATIC_ASSERT(EXPR, ...) POUCH_STATIC_ASSERT_INTERNAL(EXPR, __VA_ARGS__)
 
-#ifndef STRINGIFY
-#define STRINGIFY(s) #s
+#ifndef __ASSERT_NO_MSG
+#define __ASSERT_NO_MSG(condition) configASSERT(condition)
 #endif
 
 #ifndef DIV_ROUND_UP
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+#endif
+
+#ifndef LOG2
+#define LOG2(x) (31 - __builtin_clz(x))
+#endif
+
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef STRINGIFY
+#define STRINGIFY(s) #s
 #endif
 
 #ifndef CONTAINER_OF

--- a/src/block.h
+++ b/src/block.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/util.h>
 #include "buf.h"
 
 #define BLOCK_ID_MASK 0x1f

--- a/src/buf.h
+++ b/src/buf.h
@@ -7,8 +7,6 @@
 #pragma once
 
 #include <pouch/port.h>
-#include <zephyr/kernel.h>
-
 
 /** Initial state of the buffer */
 #define POUCH_BUF_STATE_INITIAL ((pouch_buf_state_t) 0)

--- a/src/cert.c
+++ b/src/cert.c
@@ -9,6 +9,7 @@
 #include <psa/crypto.h>
 #include <pouch/port.h>
 #include <pouch/transport/certificate.h>
+#include <string.h>
 
 POUCH_LOG_REGISTER(cert, CONFIG_POUCH_LOG_LEVEL);
 

--- a/src/cert.c
+++ b/src/cert.c
@@ -121,7 +121,9 @@ static int authenticate_server_cert(mbedtls_x509_crt *cert)
                                       NULL);
     if (ret != 0)
     {
-        POUCH_LOG_ERR("Failed verifying server cert: 0x%x, %x", -ret, flags);
+        POUCH_LOG_ERR("Failed verifying server cert: 0x%" PRIx32 ", %" PRIx32,
+                      (uint32_t) -ret,
+                      flags);
         return -EPERM;
     }
 

--- a/src/cert.c
+++ b/src/cert.c
@@ -6,7 +6,6 @@
 
 #include "cert.h"
 #include <psa/crypto.h>
-#include <zephyr/kernel.h>
 #include <pouch/port.h>
 #include <pouch/transport/certificate.h>
 

--- a/src/cert.c
+++ b/src/cert.c
@@ -5,6 +5,7 @@
  */
 
 #include "cert.h"
+#include <errno.h>
 #include <psa/crypto.h>
 #include <pouch/port.h>
 #include <pouch/transport/certificate.h>

--- a/src/crypto_saead.c
+++ b/src/crypto_saead.c
@@ -5,6 +5,7 @@
  */
 
 #include "crypto.h"
+#include <errno.h>
 #include "saead/uplink.h"
 #include "saead/downlink.h"
 #include "cert.h"

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -46,7 +46,7 @@ int downlink_init(pouch_work_q_t *pouch_work_queue)
 static void decrypt_blocks(pouch_work_t *work)
 {
     struct pouch_buf *encrypted_block;
-    struct pouch_buf *decrypted_block = blockbuf_alloc(K_FOREVER);
+    struct pouch_buf *decrypted_block = blockbuf_alloc(POUCH_FOREVER);
     if (decrypted_block == NULL)
     {
         POUCH_LOG_ERR("Failed to allocate decrypt block");

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 
+#include <errno.h>
 #include <pouch/downlink.h>
 #include <pouch/port.h>
 #include <pouch/types.h>

--- a/src/downlink.h
+++ b/src/downlink.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <pouch/port.h>
-#include <zephyr/kernel.h>
 
 /** Initialize the pouch downlink handler */
 int downlink_init(pouch_work_q_t *pouch_work_queue);

--- a/src/entry.c
+++ b/src/entry.c
@@ -111,7 +111,7 @@ static void pouch_downlink_entries_push(struct pouch_bufview *v)
         memcpy(path_null_term, path, path_len);
         path_null_term[path_len] = '\0';
 
-        downlink_start(0, path_null_term, content_type);
+        downlink_start(0, (char *) path_null_term, content_type);
         downlink_data(0, data, data_len, true);
     }
 }
@@ -145,7 +145,7 @@ static void pouch_downlink_stream_push(struct pouch_bufview *v,
         memcpy(path_null_term, path, path_len);
         path_null_term[path_len] = '\0';
 
-        downlink_start(stream_id, path_null_term, content_type);
+        downlink_start(stream_id, (char *) path_null_term, content_type);
     }
 
     data_len = pouch_bufview_available(v);
@@ -189,7 +189,7 @@ static int write_entry(struct pouch_buf *block, const struct pouch_entry *entry)
     pouch_put_be16(entry->data_len, buf_claim(block, sizeof(uint16_t)));
     pouch_put_be16(entry->content_type, buf_claim(block, sizeof(uint16_t)));
     *buf_claim(block, 1) = pathlen;
-    buf_write(block, entry->path, pathlen);
+    buf_write(block, (uint8_t *) entry->path, pathlen);
     buf_write(block, entry->data, entry->data_len);
 
     return 0;

--- a/src/entry.c
+++ b/src/entry.c
@@ -8,6 +8,7 @@
 #include "block.h"
 #include "uplink.h"
 
+#include <errno.h>
 #include <string.h>
 #include <stdio.h>
 

--- a/src/entry.h
+++ b/src/entry.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <zephyr/sys_clock.h>
-
 #include "buf.h"
 
 void pouch_downlink_block_push(struct pouch_buf *pouch_buf);

--- a/src/header.c
+++ b/src/header.c
@@ -16,7 +16,6 @@
 
 #include <zcbor_encode.h>
 #include <zcbor_encode.h>
-#include <zephyr/kernel.h>
 
 #define POUCH_HEADER_VERSION 1
 

--- a/src/pouch.c
+++ b/src/pouch.c
@@ -12,9 +12,7 @@
 #include <pouch/port.h>
 #include <pouch/uplink.h>
 
-#include <zephyr/kernel.h>
-
-K_THREAD_STACK_DEFINE(pouch_stack, CONFIG_POUCH_THREAD_STACK_SIZE);
+POUCH_THREAD_STACK_DEFINE(pouch_stack, CONFIG_POUCH_THREAD_STACK_SIZE);
 
 static pouch_work_q_t pouch_work_q;
 static pouch_work_t event_work;

--- a/src/pouch.c
+++ b/src/pouch.c
@@ -46,7 +46,7 @@ static void pouch_module_init(void)
 
     pouch_work_queue_start(&pouch_work_q,
                            pouch_stack,
-                           K_THREAD_STACK_SIZEOF(pouch_stack),
+                           CONFIG_POUCH_THREAD_STACK_SIZE,
                            CONFIG_POUCH_THREAD_PRIORITY,
                            "pouch_work");
 

--- a/src/saead/downlink.c
+++ b/src/saead/downlink.c
@@ -8,6 +8,7 @@
 #include "uplink.h"
 #include "session.h"
 #include "../cert.h"
+#include <errno.h>
 #include <stdint.h>
 #include <pouch/port.h>
 #include <psa/crypto.h>

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -51,7 +51,7 @@ int session_id_generate(struct session_id *id)
         status = psa_generate_random(id->value.random, sizeof(id->value.random));
         if (status != PSA_SUCCESS)
         {
-            POUCH_LOG_ERR("Failed to generate session ID: %d", status);
+            POUCH_LOG_ERR("Failed to generate session ID: %d", (int) status);
             return -EIO;
         }
 
@@ -61,7 +61,7 @@ int session_id_generate(struct session_id *id)
     status = psa_generate_random(id->value.sequential.tag, sizeof(id->value.sequential.tag));
     if (status != PSA_SUCCESS)
     {
-        POUCH_LOG_ERR("Failed to generate session ID tag: %d", status);
+        POUCH_LOG_ERR("Failed to generate session ID tag: %d", (int) status);
         return -EIO;
     }
 
@@ -123,7 +123,7 @@ psa_key_id_t session_key_generate(const struct session_id *id,
         PSA_ALG_KEY_AGREEMENT(PSA_ALG_ECDH, PSA_ALG_HKDF(PSA_ALG_SHA_256)));
     if (status != PSA_SUCCESS)
     {
-        POUCH_LOG_ERR("Couldn't set up key derivation: %d", status);
+        POUCH_LOG_ERR("Couldn't set up key derivation: %d", (int) status);
         goto exit;
     }
 
@@ -135,7 +135,7 @@ psa_key_id_t session_key_generate(const struct session_id *id,
                                               pubkey->len);
     if (status != PSA_SUCCESS)
     {
-        POUCH_LOG_ERR("Failed key agreement: %d", status);
+        POUCH_LOG_ERR("Failed key agreement: %d", (int) status);
         goto exit;
     }
 
@@ -151,7 +151,7 @@ psa_key_id_t session_key_generate(const struct session_id *id,
         psa_key_derivation_input_bytes(&operation, PSA_KEY_DERIVATION_INPUT_INFO, info, info_len);
     if (status != PSA_SUCCESS)
     {
-        POUCH_LOG_ERR("Failed info input: %d", status);
+        POUCH_LOG_ERR("Failed info input: %d", (int) status);
         goto exit;
     }
 
@@ -164,7 +164,7 @@ psa_key_id_t session_key_generate(const struct session_id *id,
     status = psa_key_derivation_output_key(&key_attributes, &operation, &key);
     if (status != PSA_SUCCESS)
     {
-        POUCH_LOG_ERR("Failed key derivation: %d", status);
+        POUCH_LOG_ERR("Failed key derivation: %d", (int) status);
         goto exit;
     }
 
@@ -209,7 +209,7 @@ struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_bu
     uint8_t nonce[NONCE_LEN];
     nonce_generate(session, POUCH_ROLE_DEVICE, nonce);
 
-    POUCH_LOG_DBG("Session key: %d", session->key);
+    POUCH_LOG_DBG("Session key: %d", (int) session->key);
 
     struct pouch_bufview plaintext;
     pouch_bufview_init(&plaintext, block);
@@ -241,7 +241,7 @@ struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_bu
                          &ciphertext_len);
     if (status != PSA_SUCCESS)
     {
-        POUCH_LOG_ERR("Couldn't encrypt: %d", status);
+        POUCH_LOG_ERR("Couldn't encrypt: %d", (int) status);
         buf_free(encrypted);
         return NULL;
     }
@@ -302,7 +302,7 @@ int session_decrypt_block(struct session *session,
                          &plaintext_len);
     if (status != PSA_SUCCESS)
     {
-        POUCH_LOG_ERR("Failed decryption: %d", status);
+        POUCH_LOG_ERR("Failed decryption: %d", (int) status);
         return status;
     }
 

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -13,7 +13,6 @@
 #include <mbedtls/base64.h>
 #include <pouch/port.h>
 #include <psa/crypto.h>
-#include <zephyr/sys/util.h>
 
 POUCH_LOG_REGISTER(saead_session, CONFIG_POUCH_LOG_LEVEL);
 

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <errno.h>
 #include <mbedtls/base64.h>
 #include <pouch/port.h>
 #include <psa/crypto.h>

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -78,7 +78,7 @@ static ssize_t session_key_info_build(const struct session_id *id,
     char session_id[BASE64_STRLEN(SESSION_ID_LEN) + 1];
     size_t id_len = 0;
 
-    int err = mbedtls_base64_encode(session_id,
+    int err = mbedtls_base64_encode((unsigned char *) session_id,
                                     sizeof(session_id),
                                     &id_len,
                                     (const void *) &id->value,
@@ -140,7 +140,7 @@ psa_key_id_t session_key_generate(const struct session_id *id,
     }
 
     uint8_t info[INFO_MAX_LEN];
-    ssize_t info_len = session_key_info_build(id, algorithm, max_block_size_log, info);
+    ssize_t info_len = session_key_info_build(id, algorithm, max_block_size_log, (char *) info);
     if (info_len < 0)
     {
         POUCH_LOG_ERR("Failed session key build: %d", info_len);

--- a/src/saead/session.h
+++ b/src/saead/session.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "../pouch.h"
-#include <zephyr/kernel.h>
 #include <psa/crypto.h>
 #include <string.h>
 

--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -8,6 +8,7 @@
 #include "session.h"
 #include "../cert.h"
 #include "../block.h"
+#include <errno.h>
 #include <stdint.h>
 #include <psa/crypto.h>
 #include <pouch/port.h>

--- a/src/stream.c
+++ b/src/stream.c
@@ -38,7 +38,7 @@ static void write_stream_header(struct pouch_buf *block, uint16_t content_type, 
 
     pouch_put_be16(content_type, buf_claim(block, sizeof(uint16_t)));
     *buf_claim(block, 1) = path_len;
-    buf_write(block, path, path_len);
+    buf_write(block, (uint8_t *) path, path_len);
 }
 
 static uint8_t new_stream_id(void)

--- a/src/stream.c
+++ b/src/stream.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <errno.h>
 #include <pouch/port.h>
 #include <pouch/uplink.h>
 #include "buf.h"

--- a/src/uplink.c
+++ b/src/uplink.c
@@ -10,6 +10,7 @@
 #include "stream.h"
 #include "crypto.h"
 
+#include <errno.h>
 #include <pouch/uplink.h>
 #include <pouch/events.h>
 #include <pouch/port.h>


### PR DESCRIPTION
This PR makes changes throughout the tree to facilitate building on ESP-IDF. Highlights include:

- Logging
  - Using port logging calls
  - Explicitly defining Kconfig log levels in place of Zephyr-centered Kconfig includes
  - Casting variables to resolve type errors (`uint8_t *` vs. `char *`, etc)
- Remove erroneous Zephyr includes which are no longer needed but remained in some files
- Define `IS_ENABLED()` when not already defined
- Add explicit `#include <errno.h>` to files using posix error codes