### PR TITLE
Port: include server CA cert as a header file

### DIFF
--- a/port/esp_idf/pouch_ca_cert.c
+++ b/port/esp_idf/pouch_ca_cert.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pouch/pouch_ca_cert.h>
+#include <pouch/types.h>
+#include <pouch/port.h>
+
+extern const uint8_t pouch_ca_cert_der_start[] asm("_binary_pouch_ca_cert_der_start");
+extern const uint8_t pouch_ca_cert_der_end[] asm("_binary_pouch_ca_cert_der_end");
+
+struct pouch_cert raw_ca_cert;
+
+static void populate_ca_cert_struct(void)
+{
+    raw_ca_cert.buffer = pouch_ca_cert_der_start;
+    raw_ca_cert.size = pouch_ca_cert_der_end - pouch_ca_cert_der_start;
+};
+POUCH_APPLICATION_STARTUP_HOOK(populate_ca_cert_struct);
+
+struct pouch_cert *pouch_ca_cert = &raw_ca_cert;

--- a/port/include/pouch/pouch_ca_cert.h
+++ b/port/include/pouch/pouch_ca_cert.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <pouch/types.h>
+
+extern struct pouch_cert *pouch_ca_cert;

--- a/port/zephyr/CMakeLists.txt
+++ b/port/zephyr/CMakeLists.txt
@@ -25,7 +25,9 @@ if(CONFIG_POUCH)
 
         generate_inc_file_for_target(pouch
             ${ca_cert}
-            ${ZEPHYR_BINARY_DIR}/include/generated/golioth_ca_cert.inc)
+            ${ZEPHYR_BINARY_DIR}/include/generated/pouch_ca_cert.inc)
+
+        zephyr_library_sources(pouch_ca_cert.c)
     endif()
 
     add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../.. core)

--- a/port/zephyr/pouch_ca_cert.c
+++ b/port/zephyr/pouch_ca_cert.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pouch/pouch_ca_cert.h>
+#include <pouch/types.h>
+
+static const uint8_t raw_ca_cert_der[] = {
+#include "pouch_ca_cert.inc"
+};
+
+struct pouch_cert raw_ca_cert = {
+    .buffer = raw_ca_cert_der,
+    .size = sizeof(raw_ca_cert_der),
+};
+
+struct pouch_cert *pouch_ca_cert = &raw_ca_cert;

--- a/src/cert.c
+++ b/src/cert.c
@@ -13,11 +13,12 @@
 
 POUCH_LOG_REGISTER(cert, CONFIG_POUCH_LOG_LEVEL);
 
-static const uint8_t raw_ca_cert[] = {
 #if IS_ENABLED(CONFIG_POUCH_VALIDATE_SERVER_CERT)
-#include "golioth_ca_cert.inc"
+#include <pouch/pouch_ca_cert.h>
+#else
+static const struct pouch_cert empty_cert = {.buffer = NULL, .size = 0};
+static const struct pouch_cert *pouch_ca_cert = &empty_cert;
 #endif
-};
 
 static struct
 {
@@ -69,12 +70,7 @@ static mbedtls_x509_crt *load_ca_cert(void)
         return &ca_cert;
     }
 
-    const struct pouch_cert ca_cert_data = {
-        .buffer = raw_ca_cert,
-        .size = sizeof(raw_ca_cert),
-    };
-
-    int err = parse_x509_cert(&ca_cert_data, &ca_cert);
+    int err = parse_x509_cert(pouch_ca_cert, &ca_cert);
     if (err)
     {
         return NULL;


### PR DESCRIPTION
Make the server CA cert available as a `pouch_cert` struct via header inclusion.