### PR TITLE
Port: ESP-IDF: support blockbuf by temporarily using malloc

### DIFF
--- a/port/esp_idf/blockbuf.c
+++ b/port/esp_idf/blockbuf.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <pouch/blockbuf.h>
+#include "../../src/block.h"
+
+struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout)
+{
+    struct pouch_buf *buf = malloc(POUCH_BUF_OVERHEAD + MAX_PLAINTEXT_BLOCK_SIZE);
+    if (buf == NULL)
+    {
+        return NULL;
+    }
+
+    return buf;
+}
+
+void blockbuf_free(struct pouch_buf *buf)
+{
+    free(buf);
+}


### PR DESCRIPTION
When we merged #148 we knew that there was no equivalent ESP-IDF mechanism for memory slab. We plan to do this work soon in https://github.com/golioth/firmware-issue-tracker/issues/960 but until then, this PR replaces slab allocation with malloc.