### PR TITLE
Port: Zephyr: split common Kconfig into src directory

### DIFF
--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -18,50 +18,8 @@ rsource "Kconfig.port_log_levels"
 
 if POUCH
 
-config POUCH_BLOCK_SIZE
-  int "Block size"
-  default 512
-  help
-    The maximum block size to use for Pouch transfers.
-
-config POUCH_BLOCK_COUNT
-  int "Block count"
-  default 2
-  range 2 10000
-  help
-    Number of blocks that are allocated for assembling pouch packets.
-
-config POUCH_THREAD_STACK_SIZE
-  int "Pouch thread stack size"
-  default 2048
-  help
-    The size of the stack for the internal Pouch thread.
-
-config POUCH_THREAD_PRIORITY
-  int "Pouch thread priority"
-  default 5
-  help
-    The priority of the internal Pouch thread.
-
-config POUCH_EVENT_QUEUE_DEPTH
-  int "Maximum pending pouch events"
-  default 4
-  help
-    The maximum number of Pouch events that can queued to send to
-    the application.
-
-config POUCH_UPLINK_PROCESSING_STACK_SIZE
-  int "Pouch uplink processing stack size"
-  default 2048
-  help
-    The size of the stack for the internal Pouch uplink processing work
-    queue.
-
-config POUCH_UPLINK_PROCESSING_PRIORITY
-  int "Pouch uplink processing thread priority"
-  default 5
-  help
-    The priority of the internal Pouch uplink processing work queue.
+# Pouch common
+rsource "../../src/Kconfig"
 
 choice
   prompt "Pouch uplink encryption scheme"
@@ -99,11 +57,6 @@ config POUCH_ENCRYPTION_NONE
 
 endchoice
 
-config POUCH_AUTH_TAG_LEN
-  int
-  default 16 if POUCH_ENCRYPTION_SAEAD
-  default 0
-
 menu "Streaming AEAD encryption"
   depends on POUCH_ENCRYPTION_SAEAD
 
@@ -129,52 +82,19 @@ config POUCH_ENCRYPTION_AES_GCM
 
 endchoice
 
-config POUCH_SERVER_CERT_MAX_LEN
-  int "Server certificate maximum length"
-  default 4096
-  help
-    Maximum length of server certificate.
-
-menuconfig POUCH_VALIDATE_SERVER_CERT
-  bool "Validate server's certificate"
-  default y
-  help
-    Disabling this will disable the server certificate validation.
-    This should never be disabled in production.
-
-config POUCH_SERVER_CERT_CN
-  string "Server certificate common name"
-  default "pouch.golioth.io"
-  help
-    The expected common name or subject alternative name for the
-    server leaf certificate.
-
-if POUCH_VALIDATE_SERVER_CERT
-
-config POUCH_CA_CERT_FILENAME
-  string "CA certificate filename"
-  default "src/goliothrootx1.der"
-  help
-    The filename of the CA certificate to use for Pouch.
-    This is used to verify the server's identity.
-
-endif
-
 config MBEDTLS_USER_CONFIG_ENABLE
   default y
 
 config MBEDTLS_USER_CONFIG_FILE
   default "$(ZEPHYR_POUCH_MODULE_DIR)/src/saead/mbedtls_config.h"
 
+# Saead common
+rsource "../../src/saead/Kconfig"
+
 endmenu
 
 # Transport choices
 rsource "transport/Kconfig"
-
-# Use POUCH_COMMON over POUCH to avoid collision with port log levels
-module = POUCH_COMMON
-module-str = Pouch
-rsource "../../src/Kconfig.template.pouch_log_config"
 
 endif
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config POUCH_BLOCK_SIZE
+  int "Block size"
+  default 512
+  help
+    The maximum block size to use for Pouch transfers.
+
+config POUCH_BLOCK_COUNT
+  int "Block count"
+  default 2
+  range 2 10000
+  help
+    Number of blocks that are allocated for assembling pouch packets.
+
+config POUCH_THREAD_STACK_SIZE
+  int "Pouch thread stack size"
+  default 2048
+  help
+    The size of the stack for the internal Pouch thread.
+
+config POUCH_THREAD_PRIORITY
+  int "Pouch thread priority"
+  default 5
+  help
+    The priority of the internal Pouch thread.
+
+config POUCH_EVENT_QUEUE_DEPTH
+  int "Maximum pending pouch events"
+  default 4
+  help
+    The maximum number of Pouch events that can queued to send to
+    the application.
+
+config POUCH_UPLINK_PROCESSING_STACK_SIZE
+  int "Pouch uplink processing stack size"
+  default 2048
+  help
+    The size of the stack for the internal Pouch uplink processing work
+    queue.
+
+config POUCH_UPLINK_PROCESSING_PRIORITY
+  int "Pouch uplink processing thread priority"
+  default 5
+  help
+    The priority of the internal Pouch uplink processing work queue.
+
+config POUCH_AUTH_TAG_LEN
+  int
+  default 16 if POUCH_ENCRYPTION_SAEAD
+  default 0
+
+# Use POUCH_COMMON over POUCH to avoid collision with port log levels
+module = POUCH_COMMON
+module-str = Pouch
+rsource "Kconfig.template.pouch_log_config"

--- a/src/saead/Kconfig
+++ b/src/saead/Kconfig
@@ -1,0 +1,30 @@
+config POUCH_SERVER_CERT_MAX_LEN
+  int "Server certificate maximum length"
+  default 4096
+  help
+    Maximum length of server certificate.
+
+menuconfig POUCH_VALIDATE_SERVER_CERT
+  bool "Validate server's certificate"
+  default y
+  help
+    Disabling this will disable the server certificate validation.
+    This should never be disabled in production.
+
+config POUCH_SERVER_CERT_CN
+  string "Server certificate common name"
+  default "pouch.golioth.io"
+  help
+    The expected common name or subject alternative name for the
+    server leaf certificate.
+
+if POUCH_VALIDATE_SERVER_CERT
+
+config POUCH_CA_CERT_FILENAME
+  string "CA certificate filename"
+  default "src/goliothrootx1.der"
+  help
+    The filename of the CA certificate to use for Pouch.
+    This is used to verify the server's identity.
+
+endif


### PR DESCRIPTION
Split pouch common and saead common into Kconfig files that can be included from the port-specific Kconfig "root" files.