### PR TITLE
ESP-IDF: various cleanup

### DIFF
--- a/lib/zcbor_utils/zcbor_utils.c
+++ b/lib/zcbor_utils/zcbor_utils.c
@@ -7,6 +7,7 @@
 #include <pouch/port.h>
 POUCH_LOG_REGISTER(zcbor_util, CONFIG_POUCH_COMMON_LOG_LEVEL);
 
+#include <errno.h>
 #include <zcbor_utils.h>
 
 static struct zcbor_map_entry *map_entry_get(struct zcbor_map_entry *entries,
@@ -86,7 +87,7 @@ static int zcbor_map_key_decode(zcbor_state_t *zsd, struct zcbor_map_key *key)
             ok = zcbor_tstr_decode(zsd, &key->tstr);
             if (!ok)
             {
-                LOG_WRN("Failed to decode %s map key", "tstr");
+                POUCH_LOG_WRN("Failed to decode %s map key", "tstr");
                 return -EBADMSG;
             }
 
@@ -96,7 +97,7 @@ static int zcbor_map_key_decode(zcbor_state_t *zsd, struct zcbor_map_key *key)
             ok = zcbor_uint32_decode(zsd, &key->u32);
             if (!ok)
             {
-                LOG_WRN("Failed to decode %s map key", "u32");
+                POUCH_LOG_WRN("Failed to decode %s map key", "u32");
                 return -EBADMSG;
             }
 
@@ -120,7 +121,7 @@ int zcbor_map_decode(zcbor_state_t *zsd, struct zcbor_map_entry *entries, size_t
     ok = zcbor_map_start_decode(zsd);
     if (!ok)
     {
-        LOG_WRN("Did not start CBOR map correctly");
+        POUCH_LOG_WRN("Did not start CBOR map correctly");
         return -EBADMSG;
     }
 
@@ -168,7 +169,7 @@ map_end_decode:
     ok = zcbor_list_map_end_force_decode(zsd);
     if (!ok)
     {
-        LOG_WRN("Did not end CBOR map correctly");
+        POUCH_LOG_WRN("Did not end CBOR map correctly");
         return -EBADMSG;
     }
 

--- a/port/esp_idf/Kconfig
+++ b/port/esp_idf/Kconfig
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+menu "Pouch"
+
 menuconfig POUCH
   bool "Golioth Pouch protocol"
   select ZCBOR
@@ -84,3 +86,5 @@ endif
 
 # Libraries and SDK
 rsource "../../Kconfig"
+
+endmenu # Pouch

--- a/port/esp_idf/Kconfig
+++ b/port/esp_idf/Kconfig
@@ -67,12 +67,6 @@ config POUCH_ENCRYPTION_AES_GCM
 
 endchoice
 
-config MBEDTLS_USER_CONFIG_ENABLE
-  default y
-
-config MBEDTLS_USER_CONFIG_FILE
-  default "$(ZEPHYR_POUCH_MODULE_DIR)/src/saead/mbedtls_config.h"
-
 # Pouch sources
 rsource "../../src/saead/Kconfig"
 

--- a/port/esp_idf/components/pouch/CMakeLists.txt
+++ b/port/esp_idf/components/pouch/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 #########################
 
 if("${CONFIG_ZCBOR_UTILS}" STREQUAL "y")
-    list(APPEND POUCH_LIB_INC_DIRS ${POUCH_LIB}/zcbor_utils)
+    list(APPEND POUCH_LIB_INC_DIRS ${POUCH_LIB}/zcbor_utils/include)
     list(APPEND POUCH_LIB_SRCS ${POUCH_LIB}/zcbor_utils/zcbor_utils.c)
 endif()
 

--- a/port/freertos/freertos_port_layer.c
+++ b/port/freertos/freertos_port_layer.c
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <string.h>
 
-POUCH_LOG_REGISTER(esp - idf - port - layer, POUCH_LOG_LEVEL_DBG);
+POUCH_LOG_REGISTER(esp_idf_port_layer, POUCH_LOG_LEVEL_DBG);
 
 /*--------------------------------------------------
  * Atomic

--- a/port/include/pouch/port.h
+++ b/port/include/pouch/port.h
@@ -24,6 +24,10 @@
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
 #endif
 
+#ifndef IN_RANGE
+#define IN_RANGE(val, min, max) ((val) >= (min) && (val) <= (max))
+#endif
+
 #ifndef LOG2
 #define LOG2(x) (31 - __builtin_clz(x))
 #endif


### PR DESCRIPTION
- Fix Kconfig menu nesting
- Remove Zephyr mbedtls config symbols
- Port: add `IN_RANGE()` helper for testing HTTP status codes
- Freertos: underscores instead of dashes on logging handle
- zcbor_utils: use pouch logging
- ESP-IDF: fix include path for zcbor_utils