### PR TITLE
SAR sender: Make use of full transmit window

### DIFF
--- a/src/transport/sar/sender.c
+++ b/src/transport/sar/sender.c
@@ -154,7 +154,8 @@ int pouch_sender_recv(struct pouch_sender *sender, const uint8_t *buf, size_t le
         return err;
     }
 
-    sender->window = ack.seq + ack.window;
+    sender->window = ack.seq + ack.window + 1;
+
     LOG_DBG("Received ack (%x window: %u. New target seq: %x)",
             ack.seq,
             ack.window,


### PR DESCRIPTION
The SAR sender stops sending when the next sequence number matches the stored window seq, but we're not accounting for that extra number when storing the window from the ack.

Add one, to make use of the full reported window.