### PR TITLE
Sar sender ACK error handling

### DIFF
--- a/port/zephyr/transport/gatt/peripheral.c
+++ b/port/zephyr/transport/gatt/peripheral.c
@@ -90,6 +90,19 @@ static struct pouch_characteristic *pouch_characteristic(const struct bt_gatt_at
     return attr->user_data;
 }
 
+static int recv(const struct pouch_characteristic *c, const void *buf, size_t len)
+{
+    switch (c->type)
+    {
+        case CHAR_RECEIVER:
+            return pouch_receiver_recv(c->receiver, buf, len);
+        case CHAR_SENDER:
+            return pouch_sender_recv(c->sender, buf, len);
+    }
+
+    return -EINVAL;
+}
+
 static int data_write(struct bt_conn *conn,
                       const struct bt_gatt_attr *attr,
                       const void *buf,
@@ -100,15 +113,13 @@ static int data_write(struct bt_conn *conn,
     const struct pouch_characteristic *c = pouch_characteristic(attr);
     LOG_DBG("%p: rx: %u", c, len);
     LOG_HEXDUMP_DBG(buf, len, "rx");
-    switch (c->type)
+    int err = recv(c, buf, len);
+    if (err)
     {
-        case CHAR_RECEIVER:
-            return pouch_receiver_recv(c->receiver, buf, len);
-        case CHAR_SENDER:
-            return pouch_sender_recv(c->sender, buf, len);
+        return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
     }
 
-    return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+    return 0;
 }
 
 static int open(struct pouch_characteristic *c)

--- a/src/transport/sar/packet.h
+++ b/src/transport/sar/packet.h
@@ -13,6 +13,7 @@
 #define POUCH_SAR_RX_PKT_LEN 3
 #define POUCH_SAR_SEQ_MAX 0xff
 #define POUCH_SAR_SEQ_MASK POUCH_SAR_SEQ_MAX
+#define POUCH_SAR_WINDOW_MAX 127
 
 enum pouch_sar_rx_pkt_code
 {

--- a/src/transport/sar/sender.c
+++ b/src/transport/sar/sender.c
@@ -20,6 +20,14 @@ enum state
     STATE_FIN,
 };
 
+static void end(struct pouch_sender *sender, bool success)
+{
+    if (sender->endpoint->end)
+    {
+        sender->endpoint->end(success);
+    }
+}
+
 static void send_fin(struct pouch_sender *p)
 {
     struct pouch_sar_tx_pkt pkt = {
@@ -159,6 +167,22 @@ int pouch_sender_recv(struct pouch_sender *sender, const uint8_t *buf, size_t le
         return err;
     }
 
+    if (ack.code != POUCH_RECEIVER_CODE_ACK)
+    {
+        LOG_ERR("Received NACK");
+        sender->state = STATE_IDLE;
+        end(sender, false);
+        return -EIO;
+    }
+
+    if (ack.window > POUCH_SAR_WINDOW_MAX)
+    {
+        LOG_ERR("Invalid window");
+        sender->state = STATE_IDLE;
+        end(sender, false);
+        return -EINVAL;
+    }
+
     sender->window = ack.seq + ack.window + 1;
 
     LOG_DBG("Received ack (%x window: %u. New target seq: %x)",
@@ -173,10 +197,7 @@ int pouch_sender_recv(struct pouch_sender *sender, const uint8_t *buf, size_t le
     else if (((ack.seq + 1) & POUCH_SAR_SEQ_MASK) == sender->seq)
     {
         send_fin(sender);
-        if (sender->endpoint->end)
-        {
-            sender->endpoint->end(sender);
-        }
+        end(sender, true);
     }
 
     return 0;


### PR DESCRIPTION
- If the SAR sender receives a nack or an invalid window, cancel the transfer.
- Translate errno errors to BT errors in the data_write callback