### PR TITLE
port: esp_idf: initialize block after alloc

### DIFF
--- a/port/esp_idf/blockbuf.c
+++ b/port/esp_idf/blockbuf.c
@@ -14,6 +14,8 @@ struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout)
         return NULL;
     }
 
+    buf_restore(buf, POUCH_BUF_STATE_INITIAL);
+
     return buf;
 }
 


### PR DESCRIPTION
After allocation, blocks must be initialized so that buffer members start at known values.

Resolves: https://github.com/golioth/firmware-issue-tracker/issues/963