### PR TITLE
port: esp-idf: zcbor: add Kconfig symbols

### DIFF
--- a/port/esp_idf/components/zcbor/CMakeLists.txt
+++ b/port/esp_idf/components/zcbor/CMakeLists.txt
@@ -1,12 +1,26 @@
-set(zcbor_dir ${CMAKE_CURRENT_LIST_DIR}/zcbor)
+set(ZCBOR_DIR ${CMAKE_CURRENT_LIST_DIR}/zcbor)
 
 idf_component_register(
     INCLUDE_DIRS
-        "${zcbor_dir}/include"
+        "${ZCBOR_DIR}/include"
     SRCS
-        "${zcbor_dir}/src/zcbor_common.c"
-        "${zcbor_dir}/src/zcbor_decode.c"
-        "${zcbor_dir}/src/zcbor_encode.c"
+        "${ZCBOR_DIR}/src/zcbor_common.c"
+        "${ZCBOR_DIR}/src/zcbor_decode.c"
+        "${ZCBOR_DIR}/src/zcbor_encode.c"
 )
+
+# These mappings adapted from the Zephyr-centric approach:
+# https://github.com/zephyrproject-rtos/zephyr/blob/v4.3.0/modules/zcbor/CMakeLists.txt
+if(CONFIG_ZCBOR_CANONICAL)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE ZCBOR_CANONICAL)
+endif(CONFIG_ZCBOR_CANONICAL)
+
+if(CONFIG_ZCBOR_STOP_ON_ERROR)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE ZCBOR_STOP_ON_ERROR)
+endif(CONFIG_ZCBOR_STOP_ON_ERROR)
+
+if(CONFIG_ZCBOR_BIG_ENDIAN)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE ZCBOR_BIG_ENDIAN)
+endif(CONFIG_ZCBOR_BIG_ENDIAN)
 
 component_compile_options("-Wno-strict-aliasing" "-Wno-uninitialized")

--- a/port/esp_idf/components/zcbor/Kconfig
+++ b/port/esp_idf/components/zcbor/Kconfig
@@ -1,0 +1,46 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright (c) 2026 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Based on:
+# https://github.com/zephyrproject-rtos/zephyr/blob/v4.3.0/modules/zcbor/Kconfig
+
+config ZCBOR
+	bool "zcbor CBOR library"
+	help
+	  zcbor CBOR encoder/decoder library
+
+if ZCBOR
+
+config ZCBOR_CANONICAL
+	bool "Produce canonical CBOR"
+	help
+	  Enabling this will prevent zcbor from creating lists and maps with
+	  indefinite-length arrays.
+	  Enabling this also enables the state->constant_state->enforce_canonical
+	  flag in all zcbor states. This flag controls validation of canonical
+	  data when decoding. If you only want canonical encoding, please set
+	  the enforce_canonical flag to false in all new state structs after
+	  initialization.
+
+config ZCBOR_STOP_ON_ERROR
+	bool "Stop on error when processing (Must also be enabled in state var)"
+	help
+	  Make the stop_on_error functionality available. Note that it still
+	  needs to be enabled in the state variable
+	  (`state->constant_state->stop_on_error`).
+	  This makes all functions abort their execution if called when an error
+	  has already happened.
+
+config ZCBOR_VERBOSE
+	bool "Make zcbor code print messages via printf"
+
+config ZCBOR_MAX_STR_LEN
+	int "Default max length when calling zcbor_tstr_put_term()"
+	default 256
+	help
+	  This can be manually used if no other value is readily available, but
+	  using this is discouraged.
+
+endif # ZCBOR


### PR DESCRIPTION
Zephyr uses [some wrapper magic](https://github.com/zephyrproject-rtos/zephyr/tree/dd105923a4cf67d0cdabad78be72b0e76533fe95/modules/zcbor) to translate Kconfig symbols to the constants expected by the ZCBOR library. This commit implements the wrapper approach for the settings we may need in pouch.

This resolves the configuration warnings we see in ESP-IDF:

```
-- Project sdkconfig file /home/mike/canonical-compile/pouch-workspace/pouch/port/esp_idf/test/http_client/sdkconfig
warning: ZCBOR_UTILS (defined at /home/mike/canonical-compile/pouch-workspace/pouch/port/esp_idf/components/pouch/../../../../lib/zcbor_utils/Kconfig:5) has direct dependencies ZCBOR with value n, but is currently being y-selected by the following symbols:
 - GOLIOTH_SETTINGS (defined at /home/mike/canonical-compile/pouch-workspace/pouch/golioth_sdk/components/golioth_sdk/../../Kconfig:11), with value y, direct dependencies GOLIOTH (value: y), and select condition GOLIOTH (value: y)
 - GOLIOTH_OTA (defined at /home/mike/canonical-compile/pouch-workspace/pouch/golioth_sdk/components/golioth_sdk/../../Kconfig:36), with value y, direct dependencies GOLIOTH (value: y), and select condition GOLIOTH (value: y)
```