### PR TITLE
esp-idf: replace link hooks with WHOLE_ARCHIVE option

### DIFF
--- a/golioth_sdk/components/golioth_sdk/CMakeLists.txt
+++ b/golioth_sdk/components/golioth_sdk/CMakeLists.txt
@@ -2,13 +2,11 @@ set(GOLIOTH_SDK_ROOT ../..)
 
 list(APPEND GOLIOTH_SDK_SRCS ${GOLIOTH_SDK_ROOT}/dispatch.c)
 list(APPEND GOLIOTH_SDK_LINKER_FILES ${GOLIOTH_SDK_ROOT}/dispatch.lf)
-list(APPEND POUCH_FORCE_LINK dispatch_c)
 
 if ("${CONFIG_GOLIOTH_SETTINGS}" STREQUAL "y")
     list(APPEND GOLIOTH_SDK_SRCS ${GOLIOTH_SDK_ROOT}/settings.c)
     list(APPEND GOLIOTH_SDK_SRCS ${GOLIOTH_SDK_ROOT}/settings_callbacks.c)
     list(APPEND GOLIOTH_SDK_LINKER_FILES ${GOLIOTH_SDK_ROOT}/settings_callbacks.lf)
-    list(APPEND POUCH_FORCE_LINK settings_c)
 endif()
 
 if ("${CONFIG_GOLIOTH_OTA}" STREQUAL "y")
@@ -18,7 +16,6 @@ if ("${CONFIG_GOLIOTH_OTA}" STREQUAL "y")
         ${GOLIOTH_SDK_ROOT}/ota_upper.c
     )
     list(APPEND GOLIOTH_SDK_LINKER_FILES ${GOLIOTH_SDK_ROOT}/ota.lf)
-    list(APPEND POUCH_FORCE_LINK ota_c)
 endif()
 
 idf_component_register(SRCS
@@ -34,7 +31,6 @@ idf_component_register(SRCS
                          pouch
                        )
 
-# Force linking by searching for `void link_hook_filename_c(void) { }` hooks
-foreach(NAME ${POUCH_FORCE_LINK})
-    target_link_libraries(${COMPONENT_LIB} INTERFACE "-u link_hook_${NAME}")
-endforeach()
+# Force linking of files that don't have any global references (eg: dispatch.c, settings.c, ota.c)
+# https://github.com/espressif/esp-idf/tree/release/v5.4/examples/build_system/cmake/plugins#ensuring-that-the-plugin-code-is-included-into-the-executable
+idf_component_set_property(${COMPONENT_NAME} WHOLE_ARCHIVE TRUE)

--- a/golioth_sdk/dispatch.c
+++ b/golioth_sdk/dispatch.c
@@ -93,8 +93,3 @@ static void pouch_downlink_data(unsigned int stream_id, const void *data, size_t
 }
 
 POUCH_DOWNLINK_HANDLER(pouch_downlink_start, pouch_downlink_data);
-
-/*
- * Add a hook used by ESP-IDF CMakeLists.txt to ensure this file is not optimized out
- */
-void link_hook_dispatch_c(void) {}

--- a/golioth_sdk/ota.c
+++ b/golioth_sdk/ota.c
@@ -324,8 +324,3 @@ GOLIOTH_DOWNLINK_HANDLER(ota_component,
                          ota_receive_component_start,
                          ota_receive_component_data);
 POUCH_UPLINK_HANDLER(ota_uplink);
-
-/*
- * Add a hook used by ESP-IDF CMakeLists.txt to ensure this file is not optimized out
- */
-void link_hook_ota_c(void) {}

--- a/golioth_sdk/settings.c
+++ b/golioth_sdk/settings.c
@@ -213,8 +213,3 @@ static void settings_uplink(void)
 
 GOLIOTH_DOWNLINK_HANDLER(settings, SETTINGS_DOWNLINK_PATH, NULL, settings_downlink);
 POUCH_UPLINK_HANDLER(settings_uplink);
-
-/*
- * Add a hook used by ESP-IDF CMakeLists.txt to ensure this file is not optimized out
- */
-void link_hook_settings_c(void) {}


### PR DESCRIPTION
Replace the link hook symbols used to ensure files are submitted to the linker with the WHOLE_ARCHIVE option which instructs the build system to share all object files with the linker, even if there are no globally referenced symbols in those object files.

The linker still runs garbage collection when this option is selected, so unused code will still not be added to the final binary. But the code added by iterable sections will be included in the build because our linker fragment files use KEEP().