### PR TITLE
Uplink: add pouch_wait_for_queue()

### DIFF
--- a/include/pouch/transport/uplink.h
+++ b/include/pouch/transport/uplink.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <pouch/port.h>
 #include <stdint.h>
 #include <stddef.h>
 #include "types.h"
@@ -20,6 +21,9 @@ struct pouch_uplink;
 
 /** Start a new uplink session */
 struct pouch_uplink *pouch_uplink_start(void);
+
+/** Wait for a block to become available in the uplink queue */
+int pouch_wait_for_queue(struct pouch_uplink *uplink, pouch_timeout_t timeout);
 
 /** Fill the uplink buffer */
 enum pouch_result pouch_uplink_fill(struct pouch_uplink *uplink, uint8_t *dst, size_t *dst_len);

--- a/port/esp_idf/test/port_features/main/tests/test_semaphore.c
+++ b/port/esp_idf/test/port_features/main/tests/test_semaphore.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <unity.h>
+#include <pouch/port.h>
+
+#define SEM_INIT_COUNT 1
+#define SEM_LIMIT 2
+
+POUCH_SEM_DEFINE(static_sem, 0, 1);
+
+void test_sem_init_give_take(void)
+{
+    pouch_sem_t sem;
+    int ret;
+
+    // Initialize semaphore
+    ret = pouch_sem_init(&sem, SEM_INIT_COUNT, SEM_LIMIT);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    // Take should succeed (count goes from 1 to 0)
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    // Take again should fail (count is 0)
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    TEST_ASSERT_NOT_EQUAL(0, ret);
+
+    // Give should increment count
+    pouch_sem_give(&sem);
+
+    // Take should succeed again
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+void test_sem_reset(void)
+{
+    pouch_sem_t sem;
+    int ret;
+
+    ret = pouch_sem_init(&sem, 0, SEM_LIMIT);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    // Give to increment count
+    pouch_sem_give(&sem);
+
+    // Reset should set count to 0
+    pouch_sem_reset(&sem);
+
+    // Take should fail (count is 0)
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
+void test_sem_static_define(void)
+{
+    int ret;
+
+    // Give to increment count from 0 to 1
+    pouch_sem_give(&static_sem);
+
+    // Take should succeed (count goes from 1 to 0)
+    ret = pouch_sem_take(&static_sem, POUCH_NO_WAIT);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    // Take again should fail (count is 0)
+    ret = pouch_sem_take(&static_sem, POUCH_NO_WAIT);
+    TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
+void run_unity_semaphore_tests(void)
+{
+
+    UNITY_BEGIN();
+
+    RUN_TEST(test_sem_init_give_take);
+    RUN_TEST(test_sem_reset);
+    RUN_TEST(test_sem_static_define);
+
+    UNITY_END();
+}

--- a/port/esp_idf/test/port_features/main/tests/test_semaphore.h
+++ b/port/esp_idf/test/port_features/main/tests/test_semaphore.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void run_unity_semaphore_tests(void);

--- a/port/esp_idf/test/port_features/main/tests/unity_tests.c
+++ b/port/esp_idf/test/port_features/main/tests/unity_tests.c
@@ -2,6 +2,7 @@
 #include "test_linked_list.h"
 #include "test_msgq.h"
 #include "test_mutex.h"
+#include "test_semaphore.h"
 #include "test_work_queue.h"
 #include "unity.h"
 
@@ -14,5 +15,6 @@ void run_unity_tests(void)
     run_unity_linked_list_tests();
     run_unity_msgq_tests();
     run_unity_mutex_tests();
+    run_unity_semaphore_tests();
     run_unity_work_queue_tests();
 }

--- a/port/freertos/freertos_port_layer.c
+++ b/port/freertos/freertos_port_layer.c
@@ -7,6 +7,7 @@
 
 #include "errno.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include <pouch/port.h>
 #include "freertos_port_layer.h"
 #include <stdint.h>
@@ -295,8 +296,6 @@ void pouch_yield(void)
  * /port/freertos/freertos_port_layer.h
  */
 
-#include "freertos/semphr.h"
-
 void pouch_mutex_init(pouch_mutex_t *mutex)
 {
     *mutex = xSemaphoreCreateMutex();
@@ -310,6 +309,38 @@ bool pouch_mutex_lock(pouch_mutex_t *mutex, pouch_timeout_t timeout)
 bool pouch_mutex_unlock(pouch_mutex_t *mutex)
 {
     return xSemaphoreGive(*mutex);
+}
+
+/*--------------------------------------------------
+ * Semaphore
+ *------------------------------------------------*/
+
+int pouch_sem_init(pouch_sem_t *sem, unsigned int initial_count, unsigned int limit)
+{
+    sem->handle = xSemaphoreCreateCountingStatic(limit, initial_count, &sem->buf);
+    configASSERT(sem->handle != NULL);
+    return 0;
+}
+
+int pouch_sem_take(pouch_sem_t *sem, pouch_timeout_t timeout)
+{
+    bool success = xSemaphoreTake(sem->handle, timeout);
+    return (pdTRUE == success) ? 0 : -EBUSY;
+}
+
+void pouch_sem_give(pouch_sem_t *sem)
+{
+    xSemaphoreGive(sem->handle);
+}
+
+void pouch_sem_reset(pouch_sem_t *sem)
+{
+    int success = 0;
+
+    while (success == 0)
+    {
+        success = pouch_sem_take(sem, POUCH_NO_WAIT);
+    }
 }
 
 /*--------------------------------------------------

--- a/port/freertos/freertos_port_layer.h
+++ b/port/freertos/freertos_port_layer.h
@@ -67,6 +67,26 @@ typedef SemaphoreHandle_t pouch_mutex_internal_t;
     POUCH_APPLICATION_STARTUP_HOOK(static_mutex_init_##name)
 
 /*--------------------------------------------------
+ * Semaphore
+ *------------------------------------------------*/
+
+struct freertos_sem
+{
+    SemaphoreHandle_t handle;
+    StaticSemaphore_t buf;
+};
+
+typedef struct freertos_sem pouch_sem_internal_t;
+
+#define POUCH_SEM_DEFINE_INTERNAL(name, initial_count, count_limit) \
+    pouch_sem_t name;                                               \
+    static void static_semaphore_init_##name(void)                  \
+    {                                                               \
+        pouch_sem_init(&name, initial_count, count_limit);          \
+    }                                                               \
+    POUCH_APPLICATION_STARTUP_HOOK(static_semaphore_init_##name)
+
+/*--------------------------------------------------
  * Work Queue
  *------------------------------------------------*/
 

--- a/port/include/pouch/port.h
+++ b/port/include/pouch/port.h
@@ -601,6 +601,57 @@ bool pouch_mutex_lock(pouch_mutex_t *mutex, pouch_timeout_t timeout);
 bool pouch_mutex_unlock(pouch_mutex_t *mutex);
 
 /*--------------------------------------------------
+ * Semaphore
+ *------------------------------------------------*/
+
+typedef pouch_sem_internal_t pouch_sem_t;
+
+/**
+ * @brief Statically define and initialize a semaphore
+ *
+ * @param name Name of the semaphore
+ * @param initial_count Initial count of the semaphore
+ * @param count_limit Maximum value of the semaphore count
+ */
+#define POUCH_SEM_DEFINE(name, initial_count, count_limit) \
+    POUCH_SEM_DEFINE_INTERNAL(name, initial_count, count_limit)
+
+/**
+ * @brief Initialize a semaphore
+ *
+ * @param sem Semaphore to initialize
+ * @param initial_count Initial count of the semaphore
+ * @param limit Maximum value of the semaphore count
+ *
+ * @return 0 on success or a negative error value
+ */
+int pouch_sem_init(pouch_sem_t *sem, unsigned int initial_count, unsigned int limit);
+
+/**
+ * @brief Take a semaphore
+ *
+ * @param sem Semaphore to take
+ * @param timeout How long to wait for the semaphore
+ *
+ * @return 0 on success or a negative error value
+ */
+int pouch_sem_take(pouch_sem_t *sem, pouch_timeout_t timeout);
+
+/**
+ * @brief Give a semaphore
+ *
+ * @param sem Semaphore to give
+ */
+void pouch_sem_give(pouch_sem_t *sem);
+
+/**
+ * @brief Reset a semaphore count to zero
+ *
+ * @param sem Semaphore to reset
+ */
+void pouch_sem_reset(pouch_sem_t *sem);
+
+/*--------------------------------------------------
  * Work Queue
  *------------------------------------------------*/
 

--- a/port/zephyr/include/pouch_port_macros_internal.h
+++ b/port/zephyr/include/pouch_port_macros_internal.h
@@ -115,6 +115,15 @@ typedef struct k_mutex pouch_mutex_internal_t;
 #define POUCH_MUTEX_DEFINE_INTERNAL(name) K_MUTEX_DEFINE(name)
 
 /*--------------------------------------------------
+ * Semaphore
+ *------------------------------------------------*/
+
+typedef struct k_sem pouch_sem_internal_t;
+
+#define POUCH_SEM_DEFINE_INTERNAL(name, initial_count, count_limit) \
+    K_SEM_DEFINE(name, initial_count, count_limit)
+
+/*--------------------------------------------------
  * Time
  *------------------------------------------------*/
 

--- a/port/zephyr/zephyr_port_layer.c
+++ b/port/zephyr/zephyr_port_layer.c
@@ -206,6 +206,30 @@ bool pouch_mutex_unlock(pouch_mutex_t *mutex)
 }
 
 /*--------------------------------------------------
+ * Semaphore
+ *------------------------------------------------*/
+
+int pouch_sem_init(pouch_sem_t *sem, unsigned int initial_count, unsigned int limit)
+{
+    return k_sem_init(sem, initial_count, limit);
+}
+
+int pouch_sem_take(pouch_sem_t *sem, pouch_timeout_t timeout)
+{
+    return k_sem_take(sem, timeout);
+}
+
+void pouch_sem_give(pouch_sem_t *sem)
+{
+    k_sem_give(sem);
+}
+
+void pouch_sem_reset(pouch_sem_t *sem)
+{
+    k_sem_reset(sem);
+}
+
+/*--------------------------------------------------
  * Work Queue
  *------------------------------------------------*/
 

--- a/src/uplink.c
+++ b/src/uplink.c
@@ -47,6 +47,8 @@ struct pouch_uplink
         pouch_buf_queue_t queue;
         /** Buffer reader for the buffer currently being processed. */
         struct pouch_bufview reader;
+        /** Semaphore to signal available blocks in the queue */
+        pouch_sem_t has_queue_sem;
     } transport;
 };
 
@@ -91,6 +93,8 @@ static void process_blocks(pouch_work_t *work)
     {
         pouch_atomic_set_bit(uplink.flags, POUCH_CLOSED);
     }
+
+    pouch_sem_give(&uplink.transport.has_queue_sem);
 }
 
 static void end_session(void)
@@ -132,6 +136,8 @@ void uplink_init(void)
                            CONFIG_POUCH_UPLINK_PROCESSING_STACK_SIZE,
                            CONFIG_POUCH_UPLINK_PROCESSING_PRIORITY,
                            "uplink_workq");
+
+    pouch_sem_init(&uplink.transport.has_queue_sem, 0, 1);
 }
 
 uint32_t uplink_session_id(void)
@@ -202,6 +208,11 @@ struct pouch_uplink *pouch_uplink_start(void)
     }
 
     return &uplink;
+}
+
+int pouch_wait_for_queue(struct pouch_uplink *uplink, pouch_timeout_t timeout)
+{
+    return pouch_sem_take(&uplink->transport.has_queue_sem, timeout);
 }
 
 enum pouch_result pouch_uplink_fill(struct pouch_uplink *uplink, uint8_t *dst, size_t *len)

--- a/tests/pouch/port_zephyr/CMakeLists.txt
+++ b/tests/pouch/port_zephyr/CMakeLists.txt
@@ -7,6 +7,7 @@ project(port_zephyr_test)
 
 target_sources(app PRIVATE
   src/test_atomic.c
+  src/test_semaphore.c
 )
 
 add_subdirectory(../common common)

--- a/tests/pouch/port_zephyr/src/test_semaphore.c
+++ b/tests/pouch/port_zephyr/src/test_semaphore.c
@@ -1,0 +1,69 @@
+#include <zephyr/ztest.h>
+#include <pouch/port.h>
+
+#define SEM_INIT_COUNT 1
+#define SEM_LIMIT 2
+
+POUCH_SEM_DEFINE(static_sem, 0, 1);
+
+ZTEST(semaphore_api, test_sem_init_give_take)
+{
+    pouch_sem_t sem;
+    int ret;
+
+    /* Initialize semaphore */
+    ret = pouch_sem_init(&sem, SEM_INIT_COUNT, SEM_LIMIT);
+    zassert_equal(ret, 0, "pouch_sem_init failed");
+
+    /* Take should succeed (count goes from 1 to 0) */
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    zassert_equal(ret, 0, "pouch_sem_take failed");
+
+    /* Take again should fail (count is 0) */
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    zassert_not_equal(ret, 0, "pouch_sem_take should fail when count is 0");
+
+    /* Give should increment count */
+    pouch_sem_give(&sem);
+
+    /* Take should succeed again */
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    zassert_equal(ret, 0, "pouch_sem_take after give failed");
+}
+
+ZTEST(semaphore_api, test_sem_reset)
+{
+    pouch_sem_t sem;
+    int ret;
+
+    ret = pouch_sem_init(&sem, 0, SEM_LIMIT);
+    zassert_equal(ret, 0, "pouch_sem_init failed");
+
+    /* Give to increment count */
+    pouch_sem_give(&sem);
+
+    /* Reset should set count to 0 */
+    pouch_sem_reset(&sem);
+
+    /* Take should fail (count is 0) */
+    ret = pouch_sem_take(&sem, POUCH_NO_WAIT);
+    zassert_not_equal(ret, 0, "pouch_sem_take should fail after reset");
+}
+
+ZTEST(semaphore_api, test_sem_static_define)
+{
+    int ret;
+
+    /* Give to increment count from 0 to 1 */
+    pouch_sem_give(&static_sem);
+
+    /* Take should succeed (count goes from 1 to 0) */
+    ret = pouch_sem_take(&static_sem, POUCH_NO_WAIT);
+    zassert_equal(ret, 0, "pouch_sem_take failed");
+
+    /* Take again should fail (count is 0) */
+    ret = pouch_sem_take(&static_sem, POUCH_NO_WAIT);
+    zassert_not_equal(ret, 0, "pouch_sem_take should fail when count is 0");
+}
+
+ZTEST_SUITE(semaphore_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
When a transport is consuming uplink blocks faster than they are being produced, `pouch_wait_for_queue()` may be used to wait for the next block using a configurable timeout.

