### PR TITLE
requirements: pin cbor2<6.0.0 for zcbor compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cbor2
+cbor2<6.0.0
 typer
 zcbor==0.9.1


### PR DESCRIPTION
zcbor==0.9.1 is using '>=5.4.2.post1' version, while 6.0.0 version breaks
API compatibility. Pin that to <6.0.0, so that it works.