### PR TITLE
port: freertos: add Kconfig setting for work queue size

### DIFF
--- a/port/esp_idf/Kconfig
+++ b/port/esp_idf/Kconfig
@@ -76,6 +76,15 @@ rsource "transport/Kconfig"
 
 endif
 
+config POUCH_FREERTOS_WORK_Q_SIZE
+    int "Work queue size"
+    default 10
+    help
+        Maximum number of pouch_work_t pointers that may be added to a
+        work queue. When this limit is reached,
+        pouch_work_submit_to_queue() will return an error code until a
+        work item is processed and removed from the queue.
+
 # Libraries and SDK
 rsource "../../Kconfig"
 

--- a/port/freertos/freertos_port_layer.h
+++ b/port/freertos/freertos_port_layer.h
@@ -90,7 +90,6 @@ typedef struct freertos_sem pouch_sem_internal_t;
  * Work Queue
  *------------------------------------------------*/
 
-#define POUCH_FREERTOS_WORK_Q_DEFAULT_QUEUE_LENGTH 10
 #define POUCH_FREERTOS_WORK_FLAG_QUEUED 0
 
 typedef struct pouch_freertos_work_q pouch_work_q_internal_t;
@@ -108,7 +107,7 @@ struct pouch_freertos_work_q
 
     QueueHandle_t items;
     StaticQueue_t priv_static_queue;
-    uint8_t priv_storage[POUCH_FREERTOS_WORK_Q_DEFAULT_QUEUE_LENGTH * sizeof(pouch_work_t *)];
+    uint8_t priv_storage[CONFIG_POUCH_FREERTOS_WORK_Q_SIZE * sizeof(pouch_work_t *)];
 };
 
 struct pouch_freertos_work


### PR DESCRIPTION
Adds CONFIG_POUCH_FREERTOS_WORK_Q_SIZE to make the size of work queues in FreeRTOS configurable. This symbol is not honored in the Zephyr port.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/953