### PR TITLE
CI: add post-processing for ESP-IDF unit test Junit report

### DIFF
--- a/.github/workflows/test-esp-idf.yml
+++ b/.github/workflows/test-esp-idf.yml
@@ -62,6 +62,13 @@ jobs:
             --app-path ./build           \
             --junit-xml=${UNITY_REPORT_NAME}
 
+      - name: Post-process Junit XML
+        if: success() || failure()
+        run: |
+          . $IDF_PATH/export.sh
+          cd ${UNIT_TEST_APP_PATH}
+          ./junit_post_process.py ${UNITY_REPORT_NAME}
+
       - name: Upload CI report summary
         uses: actions/upload-artifact@v7
         if: success() || failure()

--- a/tests/esp_idf/port/junit_post_process.py
+++ b/tests/esp_idf/port/junit_post_process.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+
+def process_report(xml_path):
+    if not os.path.exists(xml_path):
+        print(f"Error: {xml_path} not found.")
+        return
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    # Update the top-level <testsuites> name based on the report filename
+    report_filename = Path(xml_path).stem
+    root.set("name", report_filename)
+
+    # Find and extract all test cases from the original generic suite
+    original_suite = root.find("testsuite")
+    if original_suite is None:
+        print("Error: original_suite not found.")
+        return
+
+    all_cases = list(original_suite.findall("testcase"))
+    groups = defaultdict(list)
+
+    # Initialize global totals for the <testsuites> header
+    total_tests = 0
+    total_failures = 0
+    total_errors = 0
+    total_skipped = 0
+    orig_time = original_suite.get("time", None)
+
+    for tc in all_cases:
+        c_file = tc.get("file", "unknown")
+        suite_name = Path(c_file).stem
+        tc.set("classname", suite_name)
+        groups[suite_name].append(tc)
+        original_suite.remove(tc)
+
+    for suite_name, cases in groups.items():
+        new_suite = ET.SubElement(root, "testsuite", name=suite_name)
+        s_failures = 0
+        s_errors = 0
+        s_skipped = 0
+
+        for tc in cases:
+            # Catch the ignored test message
+            sysout = tc.find("system-out")
+            is_ignored = False
+
+            # Check if system-out contains our "Skipped:" message
+            if sysout is not None and "Skipped:" in (sysout.get("message") or ""):
+                is_ignored = True
+
+            # Inject <skipped> tag if found
+            if is_ignored and tc.find("skipped") is None:
+                skipped_tag = ET.SubElement(tc, "skipped")
+                skipped_tag.set("message", sysout.get("message"))
+
+            # Update suite counters
+            if tc.find("failure") is not None:
+                s_failures += 1
+            if tc.find("error") is not None:
+                s_errors += 1
+            if tc.find("skipped") is not None:
+                s_skipped += 1
+
+            new_suite.append(tc)
+
+        # Set suite attributes
+        new_suite.set("tests", str(len(cases)))
+        new_suite.set("failures", str(s_failures))
+        new_suite.set("errors", str(s_errors))
+        new_suite.set("skipped", str(s_skipped))
+        new_suite.set("time", str(0))
+
+        # Accumulate global totals
+        total_tests += len(cases)
+        total_failures += s_failures
+        total_errors += s_errors
+        total_skipped += s_skipped
+
+    # Update the <testsuites> global attributes
+    root.set("tests", str(total_tests))
+    root.set("failures", str(total_failures))
+    root.set("errors", str(total_errors))
+    root.set("skipped", str(total_skipped))
+    root.set("time", orig_time)
+
+    # Remove the now-empty original suite
+    root.remove(original_suite)
+
+    # Save the finalized report
+    try:
+        tree.write(xml_path, encoding="utf-8", xml_declaration=True)
+        print(f"Report updated: {total_tests} tests in {len(groups)} suites.")
+    except Exception as e:
+        print(f"Failed to save the Junit xml file: {e}")
+        return
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        process_report(sys.argv[1])

--- a/tests/esp_idf/port/tests/test_atomic.c
+++ b/tests/esp_idf/port/tests/test_atomic.c
@@ -77,7 +77,7 @@ void atomic_worker_task(void *pvParameters)
 void test_atomic_concurrency(void)
 {
 #ifdef linux
-    TEST_IGNORE();
+    TEST_IGNORE_MESSAGE("Skipped: not supported by Linux");
 #endif
 
     pouch_atomic_t counter;


### PR DESCRIPTION
- Repackage singe testsuite into individual suites by filename
- Report ignored tests as skipped
  - Unity indicates that there was a skipped test but which test was skipped is not propagated in the Junit report (only the count) and instead the test appears as passing. This commit adds a message via `TEST_IGNORE_MESSAGE` that begins with `Skipped:` which can be parsed by the post-processing script. This is brittle as it relies on the content of the message but the failure mode (if the message doesn't contain a match) is the same as not having this change.

### Before

<img width="548" height="207" alt="image" src="https://github.com/user-attachments/assets/bf1780c5-694b-401b-91ff-6d8aa9270950" />

### After

<img width="591" height="418" alt="image" src="https://github.com/user-attachments/assets/3ae638bf-1486-470a-a47a-64adea2e514d" />