### PR TITLE
examples: esp_idf: add actual temperature readings

### DIFF
--- a/examples/esp_idf/http_client/main/CMakeLists.txt
+++ b/examples/esp_idf/http_client/main/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND EXAMPLE_SRCS
         "credentials_nvs.c"
         "fw_update.c"
         "main.c"
+        "temperature.c"
         "wifi.c"
 )
 
@@ -31,6 +32,7 @@ idf_component_register(SRCS
 
                        PRIV_REQUIRES
                          console
+                         esp_driver_tsens
 
                        REQUIRES
                          esp_wifi

--- a/examples/esp_idf/http_client/main/main.c
+++ b/examples/esp_idf/http_client/main/main.c
@@ -24,9 +24,13 @@
 #include <pouch/uplink.h>
 #include <string.h>
 
+#include "temperature.h"
+
 static void do_uplink(void)
 {
-    const char *payload = "{\"temp\":22}";
+    char payload[32];
+    snprintf(payload, sizeof(payload), "{\"temp\":%f}", read_temperature());
+
     pouch_uplink_entry_write(".s/sensor",
                              POUCH_CONTENT_TYPE_JSON,
                              payload,

--- a/examples/esp_idf/http_client/main/temperature.c
+++ b/examples/esp_idf/http_client/main/temperature.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <driver/temperature_sensor.h>
+
+static bool initialized = false;
+static temperature_sensor_handle_t temp_handle = NULL;
+static temperature_sensor_config_t temp_sensor_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(10, 50);
+
+float read_temperature(void)
+{
+    if (false == initialized)
+    {
+        ESP_ERROR_CHECK(temperature_sensor_install(&temp_sensor_config, &temp_handle));
+        initialized = true;
+    }
+
+    float tsens_out = 0;
+
+    ESP_ERROR_CHECK(temperature_sensor_enable(temp_handle));
+    ESP_ERROR_CHECK(temperature_sensor_get_celsius(temp_handle, &tsens_out));
+    ESP_ERROR_CHECK(temperature_sensor_disable(temp_handle));
+
+    return tsens_out;
+}

--- a/examples/esp_idf/http_client/main/temperature.h
+++ b/examples/esp_idf/http_client/main/temperature.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+float read_temperature(void);


### PR DESCRIPTION
The ESP32 line all have internal temperature sensors. Add helper function to read that sensor and use it when streaming data.