### PR TITLE
examples: zephyr: http: fix load CA from fs kconfig description

### DIFF
--- a/examples/zephyr/http_client/Kconfig
+++ b/examples/zephyr/http_client/Kconfig
@@ -23,7 +23,7 @@ config EXAMPLE_HTTP_CLIENT_TLS_CREDENTIALS
     default 515765868
 
 config EXAMPLE_HTTP_CLIENT_TLS_LOAD_CA_FROM_FILESYSTEM
-    bool "Load the cerver CA cert from LFS"
+    bool "Load the server CA cert from LFS"
     default n
     help
         Optionally load the CA certificate used for TLS/mTLS from EXAMPLE_CREDENTIALS_DIR/ca.der. If


### PR DESCRIPTION
Fixes misspelling of server in kconfig description.