### PR TITLE
examples: zephyr: http_client: wrap Kconfig in menu

### DIFF
--- a/examples/zephyr/http_client/Kconfig
+++ b/examples/zephyr/http_client/Kconfig
@@ -4,6 +4,8 @@
 
 source "$ZEPHYR_BASE/Kconfig"
 
+menu "Example: Pouch HTTP Client"
+
 config EXAMPLE_HTTP_CLIENT_LOG_LEVEL
     int "HTTP client example log level"
     default 4
@@ -62,3 +64,4 @@ config EXAMPLE_FW_UPDATE_SHA256_VERIFY
         to flash. The resulting hash is logged to the console for verification.
 
 endchoice
+endmenu # Example: Pouch HTTP Client


### PR DESCRIPTION
Wrap the example app Kconfig symbols in a menu for better organization.

### Before

<img width="640" height="245" alt="image" src="https://github.com/user-attachments/assets/7c902d99-7fb9-4a3f-869a-0931afcea6b6" />

### After

<img width="465" height="182" alt="image" src="https://github.com/user-attachments/assets/b416358b-388c-4fdb-9d95-d4485f6f7e95" />
