### PR TITLE
examples: zephyr: http_client: add WiFi support for frdm_rw612

### DIFF
--- a/examples/zephyr/gateway/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/gateway/boards/frdm_rw612_wifi.conf
@@ -1,6 +1,6 @@
 # Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
 #   To use, add as extra conf file:
-#   west build -p -b frdm_rw612 <path_to>/gateway -- -DEXTRA_CONF_FILE=<path_to>/gateway/boards/frdm_rw612_wifi.conf
+#   west build -p -b frdm_rw612 <path_to>/gateway -- -DEXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
 
 CONFIG_GOLIOTH_SAMPLE_WIFI=y
 CONFIG_WIFI=y

--- a/examples/zephyr/http_client/CMakeLists.txt
+++ b/examples/zephyr/http_client/CMakeLists.txt
@@ -18,6 +18,11 @@ elseif(CONFIG_EXAMPLE_FW_UPDATE_FLASH)
     target_sources(app PRIVATE src/fw_update.c)
 endif()
 
+if(CONFIG_WIFI)
+    target_sources(app PRIVATE src/wifi.c)
+endif()
+
+
 if (NOT CONFIG_EXAMPLE_HTTP_CLIENT_TLS_LOAD_CA_FROM_FILESYSTEM)
     generate_inc_file_for_target(app src/isrgrootx1.der
         ${ZEPHYR_BINARY_DIR}/include/generated/pouch-ca-crt.inc)

--- a/examples/zephyr/http_client/README.md
+++ b/examples/zephyr/http_client/README.md
@@ -3,17 +3,44 @@
 The Pouch HTTP client example demonstrates how to create a Pouch application
 based on the HTTP client transport.
 
-## Building
+## Building and Flashing the Example
 
 The example should be built with west:
 
 ```bash
 west build -p -b <board> --sysbuild
+west flash
 ```
 
 The `<board>` should be the Zephyr board ID of your board. The example is
 primarily developed and tested on the `frdm_rw612` board, but any Zephyr
 board with HTTP, PSA, MbedTLS and LittleFS support should work.
+
+### Building frdm_rw612 with WiFi Support
+
+By default, the frdm_rw612 board will build for Ethernet but you may use
+WiFi by including the extra config file in the `boards` directory.
+
+<details>
+<summary>Click to unfold: WiFi with the frdm_rw612</summary>
+
+Build and flash the binary:
+
+```
+west build -p -b frdm_rw612 examples/zephyr/http_client -- -DEXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+west flash
+```
+
+Save your WiFi AP credentials
+
+```
+uart:~$ wifi cred add -s my_wifi_ap -p my_wifi_password -k 1
+uart:~$ wifi cred list
+  network ssid: "my_wifi_ap", ssid_len: 10, type: WPA2-PSK, password: "my_wifi_password", password_len: 16, MFP_OPTIONAL
+uart:~$ kernel reboot
+```
+
+</details>
 
 ## Authentication
 

--- a/examples/zephyr/http_client/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/http_client/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,37 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 <path_to>/examples/zephyr/http_client -- -DEXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+
+# Store credentials in settings, on filesystem
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_FILE_PATH="/lfs1/settings"
+
+# Ensure that filesystem initializes before settings
+CONFIG_FILE_SYSTEM_INIT_PRIORITY=89
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# WiFi Connection Callbacks
+CONFIG_NET_CONNECTION_MANAGER_CONNECTIVITY_WIFI_MGMT=y
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n

--- a/examples/zephyr/http_client/src/main.c
+++ b/examples/zephyr/http_client/src/main.c
@@ -9,6 +9,10 @@ LOG_MODULE_REGISTER(http_transport, CONFIG_EXAMPLE_HTTP_CLIENT_LOG_LEVEL);
 
 #include "credentials.h"
 
+#ifdef CONFIG_WIFI
+#include "wifi.h"
+#endif
+
 #include <zephyr/net/socket.h>
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/tls_credentials.h>
@@ -91,6 +95,8 @@ int main(void)
         LOG_ERR("Failed to load device key (err %d)", err);
         return 0;
     }
+
+    IF_ENABLED(CONFIG_WIFI, (wifi_connect()));
 
     err = pouch_http_client_init(CONFIG_EXAMPLE_HTTP_CLIENT_TLS_CREDENTIALS, K_FOREVER);
     if (0 != err)

--- a/examples/zephyr/http_client/src/wifi.c
+++ b/examples/zephyr/http_client/src/wifi.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Golioth
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(example_wifi);
+
+#include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/wifi_credentials.h>
+#include <zephyr/settings/settings.h>
+
+static K_SEM_DEFINE(wifi_connected, 0, 1);
+static struct net_mgmt_event_callback wifi_cb;
+
+static void connect_cb(void *cb_arg, const char *ssid, size_t ssid_len)
+{
+    struct net_if *iface = cb_arg;
+    struct wifi_credentials_personal creds = {0};
+
+    if (wifi_credentials_get_by_ssid_personal_struct(ssid, ssid_len, &creds) == 0)
+    {
+        struct wifi_connect_req_params params = {
+            .ssid = creds.header.ssid,
+            .ssid_length = creds.header.ssid_len,
+            .psk = creds.password,
+            .psk_length = creds.password_len,
+            .security = creds.header.type,
+        };
+        net_mgmt(NET_REQUEST_WIFI_CONNECT, iface, &params, sizeof(params));
+    }
+}
+
+static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
+                                    uint64_t mgmt_event,
+                                    struct net_if *iface)
+{
+    if (mgmt_event == NET_EVENT_WIFI_CONNECT_RESULT)
+    {
+        const struct wifi_status *status = (const struct wifi_status *) cb->info;
+
+        if (status->status)
+        {
+            LOG_ERR("WiFi connection failed (status %d)", status->status);
+        }
+        else
+        {
+            LOG_INF("WiFi connected");
+            k_sem_give(&wifi_connected);
+        }
+    }
+}
+
+void wifi_connect(void)
+{
+    net_mgmt_init_event_callback(&wifi_cb, wifi_mgmt_event_handler, NET_EVENT_WIFI_CONNECT_RESULT);
+    net_mgmt_add_event_callback(&wifi_cb);
+
+    LOG_INF("Initializing settings");
+    settings_subsys_init();
+    settings_load();
+
+    LOG_INF("Connecting to WiFi");
+    struct net_if *iface = net_if_get_wifi_sta();
+    if (wifi_credentials_is_empty())
+    {
+        LOG_ERR("No WiFi credentials available");
+        LOG_ERR("   After using `wifi cred add ...` to set, run `kernel reboot`");
+        k_sleep(K_FOREVER);
+    }
+    wifi_credentials_for_each_ssid(connect_cb, iface);
+
+    k_sem_take(&wifi_connected, K_FOREVER);
+}

--- a/examples/zephyr/http_client/src/wifi.h
+++ b/examples/zephyr/http_client/src/wifi.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+void wifi_connect(void);

--- a/golioth_sdk/settings.c
+++ b/golioth_sdk/settings.c
@@ -5,7 +5,7 @@
  */
 
 #include <pouch/port.h>
-POUCH_LOG_REGISTER(settings, CONFIG_GOLIOTH_LOG_LEVEL);
+POUCH_LOG_REGISTER(golioth_settings, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #include <errno.h>
 #include <pouch/types.h>


### PR DESCRIPTION
 Add WiFi support for the frdm_rw612 board which is enabled by building with the extra config file boards/frdm_rw612_wifi.conf. Credentials are stored using the Zephyr console provisioning command `wifi cred add`.
