### PR TITLE
ESP-IDF: Add BLE GATT Transport

### DIFF
--- a/port/esp_idf/Kconfig
+++ b/port/esp_idf/Kconfig
@@ -97,7 +97,7 @@ if POUCH_DELAYABLE_WORK
 
 config POUCH_DELAYABLE_WORK_STACK_SIZE
     int "Delayable work thread stack size"
-    default 1024
+    default 2048
     help
         Stack size for the dedicated delayable work thread (pouch_dwork).
         This thread executes delayed work handlers such as SAR ACK

--- a/port/esp_idf/components/pouch/CMakeLists.txt
+++ b/port/esp_idf/components/pouch/CMakeLists.txt
@@ -32,12 +32,12 @@ list(APPEND POUCH_PORT_SRCS
 # Pouch Core
 #########################
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../include)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
 list(APPEND POUCH_CORE_INC_DIRS
       ${POUCH_ROOT}/include
 
       # Generated Headers
-      ${CMAKE_CURRENT_BINARY_DIR}/../include
+      ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
 list(APPEND POUCH_CORE_SRCS
@@ -81,7 +81,7 @@ if(NOT CMAKE_BUILD_EARLY_EXPANSION)
             ${CMAKE_CURRENT_BINARY_DIR}/header_decode.c
             ${CMAKE_CURRENT_BINARY_DIR}/header_encode.c
         COMMAND zcbor code -c ${POUCH_ROOT}/src/header.cddl -t pouch_header -sde
-            --include-prefix cddl/ --oc header.c --oh ../include/cddl/header.h
+            --include-prefix cddl/ --oc header.c --oh include/cddl/header.h
         BYPRODUCTS
             ${CMAKE_CURRENT_BINARY_DIR}/include/cddl/header_decode.h
             ${CMAKE_CURRENT_BINARY_DIR}/include/cddl/header_encode.h

--- a/port/esp_idf/components/pouch/CMakeLists.txt
+++ b/port/esp_idf/components/pouch/CMakeLists.txt
@@ -121,9 +121,9 @@ endif()
 if("${CONFIG_POUCH_TRANSPORT_BLE_GATT}" STREQUAL "y")
 
     list(APPEND POUCH_TRANSPORT_SRCS
-        ${POUCH_TRANSPORT_COMMON}/endpoints/info.c
-        ${POUCH_TRANSPORT_COMMON}/endpoints/uplink.c
-        ${POUCH_TRANSPORT_COMMON}/endpoints/downlink.c
+        ${POUCH_TRANSPORT_COMMON}/endpoints/device/info.c
+        ${POUCH_TRANSPORT_COMMON}/endpoints/device/uplink.c
+        ${POUCH_TRANSPORT_COMMON}/endpoints/device/downlink.c
         ${POUCH_TRANSPORT_COMMON}/sar/sender.c
         ${POUCH_TRANSPORT_COMMON}/sar/receiver.c
         ${POUCH_TRANSPORT_COMMON}/sar/packet.c
@@ -132,10 +132,16 @@ if("${CONFIG_POUCH_TRANSPORT_BLE_GATT}" STREQUAL "y")
 
     if ("${CONFIG_POUCH_ENCRYPTION_SAEAD}" STREQUAL "y")
         list(APPEND POUCH_TRANSPORT_SRCS
-            ${POUCH_TRANSPORT_COMMON}/endpoints/device_cert.c
-            ${POUCH_TRANSPORT_COMMON}/endpoints/server_cert.c
+            ${POUCH_TRANSPORT_COMMON}/endpoints/device/device_cert.c
+            ${POUCH_TRANSPORT_COMMON}/endpoints/device/server_cert.c
         )
     endif()
+
+    list(APPEND POUCH_TRANSPORT_INC_DIRS
+        ${POUCH_ROOT}/src
+        ${POUCH_TRANSPORT_COMMON}
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
 
     if(NOT CMAKE_BUILD_EARLY_EXPANSION)
 
@@ -148,11 +154,6 @@ if("${CONFIG_POUCH_TRANSPORT_BLE_GATT}" STREQUAL "y")
             BYPRODUCTS include/cddl/info_encode.h include/cddl/info_encode_types.h
 
             DEPENDS ${POUCH_TRANSPORT_COMMON}/info.cddl)
-
-        list(APPEND POUCH_TRANSPORT_INC_DIRS
-            ${POUCH_TRANSPORT_COMMON}
-            ${CMAKE_CURRENT_BINARY_DIR}/include
-        )
 
     endif()
 
@@ -167,6 +168,13 @@ if("${CONFIG_POUCH_TRANSPORT_HTTP_CLIENT}" STREQUAL "y")
     list(APPEND POUCH_PRIV_REQUIRES
         esp_http_client
         esp-tls
+    )
+endif()
+
+if("${CONFIG_POUCH_TRANSPORT_BLE_GATT}" STREQUAL "y")
+    list(APPEND POUCH_TRANSPORT_SRCS ${POUCH_PORT}/esp_idf/transport/gatt/peripheral.c)
+    list(APPEND POUCH_PRIV_REQUIRES
+        bt
     )
 endif()
 

--- a/port/esp_idf/include/pouch/transport/ble_gatt/peripheral.h
+++ b/port/esp_idf/include/pouch/transport/ble_gatt/peripheral.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+struct ble_gap_event;
+
+/**
+ * Handle a GAP event from the NimBLE host.
+ *
+ * The application's GAP event handler should call this function to delegate
+ * connection, subscription, and MTU events to the Pouch GATT transport.
+ *
+ * @param event GAP event from NimBLE.
+ * @param arg   Callback argument passed by NimBLE.
+ * @return 0 on success, NimBLE error code on failure.
+ */
+int pouch_gatt_gap_event(struct ble_gap_event *event, void *arg);
+
+/**
+ * Initialize the Pouch GATT service and register it with NimBLE.
+ *
+ * Must be called after nimble_port_init() and before the NimBLE host task
+ * is started.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int pouch_gatt_init(void);

--- a/port/esp_idf/transport/Kconfig
+++ b/port/esp_idf/transport/Kconfig
@@ -16,6 +16,21 @@ config POUCH_TRANSPORT_HTTP_CLIENT
   help
     HTTP transport for Pouch
 
+config POUCH_TRANSPORT_BLE_GATT
+  bool "BLE GATT"
+  help
+    BLE GATT peripheral transport for Pouch.
+    The device exposes a GATT service that a gateway
+    can connect to for transferring Pouch data.
+
 endchoice
 
+config POUCH_TRANSPORT_ACK_TIMEOUT_MS
+    int "Pouch Transport ACK timeout (ms)"
+    default 1000
+    help
+        The timeout, in milliseconds, that a receiver will wait
+        for new packets before retransmitting an acknowledgement
+
 rsource "http/Kconfig"
+rsource "gatt/Kconfig"

--- a/port/esp_idf/transport/gatt/Kconfig
+++ b/port/esp_idf/transport/gatt/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Pouch BLE GATT Transport"
+    visible if POUCH_TRANSPORT_BLE_GATT
+
+config POUCH_TRANSPORT_GATT_WINDOW_SIZE
+    int "Receiver window size"
+    range 1 127
+    default 3
+    help
+        The number of unacknowledged packets that can be received by
+        the device. Larger numbers can increase throughput but will
+        use more RAM.
+
+config POUCH_TRANSPORT_GATT_MTU_SIZE
+    int "Maximum ATT MTU size"
+    range 23 517
+    default 517
+    help
+        The maximum ATT MTU size to negotiate. Larger values allow
+        bigger packets per BLE transaction, improving throughput.
+
+endmenu

--- a/port/esp_idf/transport/gatt/common.h
+++ b/port/esp_idf/transport/gatt/common.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Pouch GATT UUID definitions for ESP-IDF (NimBLE)
+ *
+ * NimBLE stores 128-bit UUIDs in little-endian byte order. To convert a
+ * standard UUID string to the byte array below, write it as a continuous hex
+ * string and reverse the byte order. For example:
+ *
+ *   UUID:  89a316ae-89b7-4ef6-b1d3-5c9a6e27d272
+ *   Hex:   89 a3 16 ae 89 b7 4e f6 b1 d3 5c 9a 6e 27 d2 72
+ *   LE:    72 d2 27 6e 9a 5c d3 b1 f6 4e b7 89 ae 16 a3 89
+ */
+
+#pragma once
+
+#include "host/ble_uuid.h"
+
+#define BT_ATT_OVERHEAD 3 /* opcode (1) + handle (2) */
+
+/* clang-format off */
+
+/* Pouch GATT Service UUID: 89a316ae-89b7-4ef6-b1d3-5c9a6e27d272 */
+#define POUCH_GATT_UUID_SVC_VAL \
+    BLE_UUID128_INIT(0x72, 0xd2, 0x27, 0x6e, 0x9a, 0x5c, 0xd3, 0xb1, \
+                     0xf6, 0x4e, 0xb7, 0x89, 0xae, 0x16, 0xa3, 0x89)
+
+/* Pouch Uplink Characteristic UUID: 89a316ae-89b7-4ef6-b1d3-5c9a6e27d273 */
+#define POUCH_GATT_UUID_UPLINK_CHRC_VAL \
+    BLE_UUID128_INIT(0x73, 0xd2, 0x27, 0x6e, 0x9a, 0x5c, 0xd3, 0xb1, \
+                     0xf6, 0x4e, 0xb7, 0x89, 0xae, 0x16, 0xa3, 0x89)
+
+/* Pouch Downlink Characteristic UUID: 89a316ae-89b7-4ef6-b1d3-5c9a6e27d274 */
+#define POUCH_GATT_UUID_DOWNLINK_CHRC_VAL \
+    BLE_UUID128_INIT(0x74, 0xd2, 0x27, 0x6e, 0x9a, 0x5c, 0xd3, 0xb1, \
+                     0xf6, 0x4e, 0xb7, 0x89, 0xae, 0x16, 0xa3, 0x89)
+
+/* Pouch Info Characteristic UUID: 89a316ae-89b7-4ef6-b1d3-5c9a6e27d275 */
+#define POUCH_GATT_UUID_INFO_CHRC_VAL \
+    BLE_UUID128_INIT(0x75, 0xd2, 0x27, 0x6e, 0x9a, 0x5c, 0xd3, 0xb1, \
+                     0xf6, 0x4e, 0xb7, 0x89, 0xae, 0x16, 0xa3, 0x89)
+
+/* Pouch Server Certificate Characteristic UUID: 89a316ae-89b7-4ef6-b1d3-5c9a6e27d276 */
+#define POUCH_GATT_UUID_SERVER_CERT_CHRC_VAL \
+    BLE_UUID128_INIT(0x76, 0xd2, 0x27, 0x6e, 0x9a, 0x5c, 0xd3, 0xb1, \
+                     0xf6, 0x4e, 0xb7, 0x89, 0xae, 0x16, 0xa3, 0x89)
+
+/* Pouch Device Certificate Characteristic UUID: 89a316ae-89b7-4ef6-b1d3-5c9a6e27d277 */
+#define POUCH_GATT_UUID_DEVICE_CERT_CHRC_VAL \
+    BLE_UUID128_INIT(0x77, 0xd2, 0x27, 0x6e, 0x9a, 0x5c, 0xd3, 0xb1, \
+                     0xf6, 0x4e, 0xb7, 0x89, 0xae, 0x16, 0xa3, 0x89)
+
+/* clang-format on */

--- a/port/esp_idf/transport/gatt/peripheral.c
+++ b/port/esp_idf/transport/gatt/peripheral.c
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <errno.h>
+#include <stdbool.h>
+
+#include "esp_log.h"
+#include "host/ble_hs.h"
+#include "services/gatt/ble_svc_gatt.h"
+
+#include <pouch/port.h>
+
+#include "common.h"
+#include "transport/sar/receiver.h"
+#include "transport/sar/sender.h"
+#include "transport/endpoints/device/endpoints.h"
+
+static const char *TAG = "pouch_gatt";
+
+static uint16_t _pouch_mtu = BLE_ATT_MTU_DFLT;
+static uint16_t _conn_handle = BLE_HS_CONN_HANDLE_NONE;
+
+/***************************************************
+ * Init macros
+ **************************************************/
+
+/* Forward declarations */
+static int bearer_send(struct pouch_bearer *bearer, const uint8_t *buf, size_t len);
+static void bearer_close(struct pouch_bearer *bearer, bool success);
+static void bearer_ready(struct pouch_bearer *bearer);
+
+#define CHAR_INIT_RECEIVER(_endpoint)                                    \
+    {                                                                    \
+        .bearer =                                                        \
+            {                                                            \
+                .send = bearer_send,                                     \
+                .close = bearer_close,                                   \
+                .ready = bearer_ready,                                   \
+            },                                                           \
+        .type = CHAR_RECEIVER,                                           \
+        .receiver = &((struct pouch_receiver){.endpoint = (_endpoint)}), \
+    }
+
+#define CHAR_INIT_SENDER(_endpoint)                                  \
+    {                                                                \
+        .bearer =                                                    \
+            {                                                        \
+                .send = bearer_send,                                 \
+                .close = bearer_close,                               \
+                .ready = bearer_ready,                               \
+            },                                                       \
+        .type = CHAR_SENDER,                                         \
+        .sender = &((struct pouch_sender){.endpoint = (_endpoint)}), \
+    }
+
+#define DEFINE_GATT_CHAR(_char_ptr, _uuid_ptr, _cb, _flags) \
+    {                                                       \
+        .uuid = _uuid_ptr,                                  \
+        .access_cb = _cb,                                   \
+        .arg = (_char_ptr),                                 \
+        .val_handle = &((_char_ptr)->val_handle),           \
+        .flags = _flags,                                    \
+    }
+
+/***************************************************
+ * Types
+ **************************************************/
+
+enum characteristic_type
+{
+    CHAR_RECEIVER,
+    CHAR_SENDER,
+};
+
+struct pouch_characteristic
+{
+    struct pouch_bearer bearer;
+
+    /* Session context */
+    bool subscribed;
+    uint16_t val_handle;
+
+    /* Higher level handler */
+    enum characteristic_type type;
+    union
+    {
+        struct pouch_sender *sender;
+        struct pouch_receiver *receiver;
+    };
+};
+
+/***************************************************
+ * Bearer callbacks
+ **************************************************/
+
+static int bearer_send(struct pouch_bearer *bearer, const uint8_t *buf, size_t len)
+{
+    struct pouch_characteristic *c = CONTAINER_OF(bearer, struct pouch_characteristic, bearer);
+
+    struct os_mbuf *om = ble_hs_mbuf_from_flat(buf, len);
+    if (NULL == om)
+    {
+        ESP_LOGE(TAG, "Failed to allocate mbuf for notification");
+        return -ENOMEM;
+    }
+
+    int rc = ble_gatts_notify_custom(_conn_handle, c->val_handle, om);
+    if (0 != rc)
+    {
+        ESP_LOGE(TAG, "Failed to send notification: %d", rc);
+        return -EIO;
+    }
+
+    return 0;
+}
+
+static void bearer_close(struct pouch_bearer *bearer, bool success)
+{
+    struct pouch_characteristic *c = CONTAINER_OF(bearer, struct pouch_characteristic, bearer);
+
+    if (!success)
+    {
+        ESP_LOGD(TAG, "%p: close", c);
+        ble_gap_terminate(_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
+    }
+}
+
+static void bearer_ready(struct pouch_bearer *bearer)
+{
+    struct pouch_characteristic *c = CONTAINER_OF(bearer, struct pouch_characteristic, bearer);
+
+    ESP_LOGD(TAG, "%p: ready", c);
+    switch (c->type)
+    {
+        case CHAR_RECEIVER:
+            return pouch_receiver_ready(c->receiver);
+        case CHAR_SENDER:
+            return pouch_sender_ready(c->sender);
+    }
+}
+
+/***************************************************
+ * Helpers
+ **************************************************/
+
+static int recv(const struct pouch_characteristic *c, const void *buf, size_t len)
+{
+    switch (c->type)
+    {
+        case CHAR_RECEIVER:
+            return pouch_receiver_recv(c->receiver, buf, len);
+        case CHAR_SENDER:
+            return pouch_sender_recv(c->sender, buf, len);
+    }
+
+    return -EINVAL;
+}
+
+static int data_write(uint16_t conn_handle,
+                      uint16_t attr_handle,
+                      struct ble_gatt_access_ctxt *ctxt,
+                      void *arg)
+{
+    struct pouch_characteristic *c = (struct pouch_characteristic *) arg;
+
+    switch (ctxt->op)
+    {
+        case BLE_GATT_ACCESS_OP_WRITE_CHR:
+        {
+            uint16_t om_len = OS_MBUF_PKTLEN(ctxt->om);
+            uint8_t buf[CONFIG_POUCH_TRANSPORT_GATT_MTU_SIZE - BT_ATT_OVERHEAD];
+
+            if (om_len > sizeof(buf))
+            {
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+            }
+
+            int rc = ble_hs_mbuf_to_flat(ctxt->om, buf, sizeof(buf), &om_len);
+            if (0 != rc)
+            {
+                return BLE_ATT_ERR_UNLIKELY;
+            }
+
+            int err = recv(c, buf, om_len);
+            if (err)
+            {
+                ESP_LOGD(TAG, "recv failed: %d", err);
+            }
+            return 0;
+        }
+
+        default:
+            return BLE_ATT_ERR_UNLIKELY;
+    }
+}
+
+static int open(struct pouch_characteristic *c)
+{
+    switch (c->type)
+    {
+        case CHAR_RECEIVER:
+            return pouch_receiver_open(c->receiver,
+                                       &c->bearer,
+                                       CONFIG_POUCH_TRANSPORT_GATT_WINDOW_SIZE);
+        case CHAR_SENDER:
+            return pouch_sender_open(c->sender, &c->bearer);
+    }
+
+    return -ENOTSUP;
+}
+
+static int close(struct pouch_characteristic *c)
+{
+    switch (c->type)
+    {
+        case CHAR_RECEIVER:
+            pouch_receiver_close(c->receiver);
+            return 0;
+        case CHAR_SENDER:
+            pouch_sender_close(c->sender);
+            return 0;
+    }
+
+    return -ENOTSUP;
+}
+
+/***************************************************
+ * Pouch characteristic contexts
+ **************************************************/
+
+enum pouch_characteristic_type
+{
+    POUCH_CHAR_DOWNLINK,
+    POUCH_CHAR_UPLINK,
+    POUCH_CHAR_INFO,
+#if CONFIG_POUCH_ENCRYPTION_SAEAD
+    POUCH_CHAR_SERVER_CERT,
+    POUCH_CHAR_DEVICE_CERT,
+#endif
+    POUCH_CHAR_COUNT
+};
+
+static struct pouch_characteristic all_chars[POUCH_CHAR_COUNT] = {
+    [POUCH_CHAR_DOWNLINK] = CHAR_INIT_RECEIVER(&pouch_device_endpoint_downlink),
+    [POUCH_CHAR_UPLINK] = CHAR_INIT_SENDER(&pouch_device_endpoint_uplink),
+    [POUCH_CHAR_INFO] = CHAR_INIT_SENDER(&pouch_device_endpoint_info),
+#if CONFIG_POUCH_ENCRYPTION_SAEAD
+    [POUCH_CHAR_SERVER_CERT] = CHAR_INIT_RECEIVER(&pouch_device_endpoint_server_cert),
+    [POUCH_CHAR_DEVICE_CERT] = CHAR_INIT_SENDER(&pouch_device_endpoint_device_cert),
+#endif
+};
+
+/***************************************************
+ * Handle lookup
+ **************************************************/
+
+static struct pouch_characteristic *char_find_by_val_handle(uint16_t val_handle)
+{
+    for (size_t i = 0; i < POUCH_CHAR_COUNT; i++)
+    {
+        if (all_chars[i].val_handle == val_handle)
+        {
+            return &all_chars[i];
+        }
+    }
+
+    return NULL;
+}
+
+/***************************************************
+ * GATT Service Definition (NimBLE)
+ **************************************************/
+
+static const ble_uuid128_t pouch_svc_uuid = POUCH_GATT_UUID_SVC_VAL;
+static const ble_uuid128_t pouch_downlink_uuid = POUCH_GATT_UUID_DOWNLINK_CHRC_VAL;
+static const ble_uuid128_t pouch_uplink_uuid = POUCH_GATT_UUID_UPLINK_CHRC_VAL;
+static const ble_uuid128_t pouch_info_uuid = POUCH_GATT_UUID_INFO_CHRC_VAL;
+
+#if CONFIG_POUCH_ENCRYPTION_SAEAD
+static const ble_uuid128_t pouch_server_cert_uuid = POUCH_GATT_UUID_SERVER_CERT_CHRC_VAL;
+static const ble_uuid128_t pouch_device_cert_uuid = POUCH_GATT_UUID_DEVICE_CERT_CHRC_VAL;
+#endif
+
+#define CHR_FLAGS (BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_NOTIFY | BLE_GATT_CHR_F_WRITE_ENC)
+
+static const struct ble_gatt_svc_def pouch_gatt_svcs[] = {
+    {
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = &pouch_svc_uuid.u,
+        .characteristics =
+            (struct ble_gatt_chr_def[]){
+                DEFINE_GATT_CHAR(&all_chars[POUCH_CHAR_DOWNLINK],
+                                 &pouch_downlink_uuid.u,
+                                 data_write,
+                                 CHR_FLAGS),
+                DEFINE_GATT_CHAR(&all_chars[POUCH_CHAR_UPLINK],
+                                 &pouch_uplink_uuid.u,
+                                 data_write,
+                                 CHR_FLAGS),
+                DEFINE_GATT_CHAR(&all_chars[POUCH_CHAR_INFO],
+                                 &pouch_info_uuid.u,
+                                 data_write,
+                                 CHR_FLAGS),
+#if CONFIG_POUCH_ENCRYPTION_SAEAD
+                DEFINE_GATT_CHAR(&all_chars[POUCH_CHAR_SERVER_CERT],
+                                 &pouch_server_cert_uuid.u,
+                                 data_write,
+                                 CHR_FLAGS),
+                DEFINE_GATT_CHAR(&all_chars[POUCH_CHAR_DEVICE_CERT],
+                                 &pouch_device_cert_uuid.u,
+                                 data_write,
+                                 CHR_FLAGS),
+#endif
+                {0}, /* Terminator */
+            },
+    },
+    {0}, /* Terminator */
+};
+
+/***************************************************
+ * GAP event handler
+ **************************************************/
+
+int pouch_gatt_gap_event(struct ble_gap_event *event, void *arg)
+{
+    switch (event->type)
+    {
+        case BLE_GAP_EVENT_CONNECT:
+            if (0 == event->connect.status)
+            {
+                ESP_LOGI(TAG, "Client connected, conn_handle=%u", event->connect.conn_handle);
+            }
+            break;
+
+        case BLE_GAP_EVENT_DISCONNECT:
+            ESP_LOGI(TAG, "Client disconnected, reason=%d", event->disconnect.reason);
+
+            _pouch_mtu = BLE_ATT_MTU_DFLT;
+            _conn_handle = BLE_HS_CONN_HANDLE_NONE;
+
+            for (size_t i = 0; i < POUCH_CHAR_COUNT; i++)
+            {
+                if (all_chars[i].subscribed)
+                {
+                    close(&all_chars[i]);
+                    all_chars[i].subscribed = false;
+                }
+            }
+            break;
+
+        case BLE_GAP_EVENT_SUBSCRIBE:
+        {
+            struct pouch_characteristic *c = char_find_by_val_handle(event->subscribe.attr_handle);
+            if (NULL == c)
+            {
+                break;
+            }
+
+            if (event->subscribe.cur_notify)
+            {
+                ESP_LOGD(TAG, "%p: subscribe (notify) handle=%u", c, event->subscribe.attr_handle);
+                _conn_handle = event->subscribe.conn_handle;
+                c->subscribed = true;
+                c->bearer.maxlen = _pouch_mtu - BT_ATT_OVERHEAD;
+
+                int err = open(c);
+                if (err)
+                {
+                    ESP_LOGE(TAG, "Failed to open characteristic: %d", err);
+                }
+            }
+            else
+            {
+                ESP_LOGD(TAG, "%p: unsubscribe handle=%u", c, event->subscribe.attr_handle);
+                close(c);
+                c->subscribed = false;
+            }
+            break;
+        }
+
+        case BLE_GAP_EVENT_MTU:
+            _pouch_mtu = event->mtu.value;
+            ESP_LOGI(TAG, "MTU updated: %u", _pouch_mtu);
+            break;
+
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+/***************************************************
+ * Initialization
+ **************************************************/
+
+int pouch_gatt_init(void)
+{
+    int rc;
+
+    ble_svc_gatt_init();
+
+    rc = ble_gatts_count_cfg(pouch_gatt_svcs);
+    if (0 != rc)
+    {
+        ESP_LOGE(TAG, "ble_gatts_count_cfg failed: %d", rc);
+        return rc;
+    }
+
+    rc = ble_gatts_add_svcs(pouch_gatt_svcs);
+    if (0 != rc)
+    {
+        ESP_LOGE(TAG, "ble_gatts_add_svcs failed: %d", rc);
+        return rc;
+    }
+
+    ESP_LOGI(TAG, "Pouch GATT service registered");
+    return 0;
+}

--- a/port/zephyr/transport/gatt/peripheral.c
+++ b/port/zephyr/transport/gatt/peripheral.c
@@ -19,7 +19,7 @@
 LOG_MODULE_REGISTER(pouch_gatt, CONFIG_POUCH_GATT_LOG_LEVEL);
 
 
-#define CHAR_INIT_RECVEIVER(_endpoint)                                   \
+#define CHAR_INIT_RECEIVER(_endpoint)                                    \
     {                                                                    \
         .bearer =                                                        \
             {                                                            \
@@ -219,13 +219,13 @@ static void ccc_changed(const struct bt_gatt_attr *ccc_attr, uint16_t value)
  * Pouch characteristics contexts:
  **************************************************/
 
-static struct pouch_characteristic downlink = CHAR_INIT_RECVEIVER(&pouch_device_endpoint_downlink);
+static struct pouch_characteristic downlink = CHAR_INIT_RECEIVER(&pouch_device_endpoint_downlink);
 static struct pouch_characteristic uplink = CHAR_INIT_SENDER(&pouch_device_endpoint_uplink);
 static struct pouch_characteristic info = CHAR_INIT_SENDER(&pouch_device_endpoint_info);
 
 #if IS_ENABLED(CONFIG_POUCH_ENCRYPTION_SAEAD)
 static struct pouch_characteristic server_cert =
-    CHAR_INIT_RECVEIVER(&pouch_device_endpoint_server_cert);
+    CHAR_INIT_RECEIVER(&pouch_device_endpoint_server_cert);
 static struct pouch_characteristic device_cert =
     CHAR_INIT_SENDER(&pouch_device_endpoint_device_cert);
 #endif


### PR DESCRIPTION
Add a BLE GATT peripheral transport to the ESP-IDF port based on NimBLE.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/976