### PR TITLE
transport: sar: skip ACK resend when not connected

### DIFF
--- a/src/transport/sar/receiver.c
+++ b/src/transport/sar/receiver.c
@@ -54,6 +54,12 @@ static void send_ack(pouch_work_delayable_t *dwork)
     int err = pouch_bearer_send(p->bearer, buf, sizeof(buf));
     if (err)
     {
+        if (err == -ENOTCONN)
+        {
+            POUCH_LOG_DBG("TX skipped (%d), not connected", err);
+            return;
+        }
+
         // try again later:
         POUCH_LOG_ERR("TX failed (%d)", err);
         schedule_ack(p);


### PR DESCRIPTION
send_ack() will keep retrying after receiving an error. But if there is no connection available, the ACK will continue to be rescheduled with no hope of success. Check to see if the bearer returned -ENOTCONN and skip rescheduling when found.