### PR TITLE
treewide: cleanup stale included headers

### DIFF
--- a/src/cert.c
+++ b/src/cert.c
@@ -7,7 +7,9 @@
 #include "cert.h"
 #include <errno.h>
 #include <psa/crypto.h>
+#include <mbedtls/x509_crt.h>
 #include <pouch/port.h>
+#include <pouch/certificate.h>
 #include <pouch/transport/certificate.h>
 #include <string.h>
 

--- a/src/cert.h
+++ b/src/cert.h
@@ -6,10 +6,8 @@
 
 #pragma once
 
-#include <pouch/certificate.h>
 #include <pouch/types.h>
 #include <stdbool.h>
-#include <mbedtls/x509_crt.h>
 #include "pouch.h"
 
 #define CERT_REF_HASH_ALG PSA_ALG_SHA_256

--- a/src/transport/endpoints/device/server_cert.c
+++ b/src/transport/endpoints/device/server_cert.c
@@ -9,7 +9,6 @@
 #include <string.h>
 
 #include <pouch/types.h>
-#include <pouch/certificate.h>
 #include <pouch/transport/certificate.h>
 #include "endpoints.h"
 

--- a/src/transport/sar/packet.h
+++ b/src/transport/sar/packet.h
@@ -5,7 +5,6 @@
  */
 #pragma once
 
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Cleans up a handful of header includes that are no longer used.