### PR TITLE
blockbuf: properly initialize buffers

### DIFF
--- a/port/esp_idf/blockbuf.c
+++ b/port/esp_idf/blockbuf.c
@@ -14,8 +14,7 @@ struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout)
         return NULL;
     }
 
-    buf_restore(buf, POUCH_BUF_STATE_INITIAL);
-
+    buf_init(buf);
     return buf;
 }
 

--- a/port/zephyr/blockbuf.c
+++ b/port/zephyr/blockbuf.c
@@ -22,7 +22,7 @@ struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout)
         return NULL;
     }
 
-    buf_restore(buf, POUCH_BUF_STATE_INITIAL);
+    buf_init(buf);
 
     return buf;
 }

--- a/src/buf.c
+++ b/src/buf.c
@@ -65,14 +65,19 @@ size_t buf_size_get(const struct pouch_buf *buf)
     return buf->bytes;
 }
 
+void buf_init(struct pouch_buf *buf)
+{
+    buf->bytes = POUCH_BUF_STATE_INITIAL;
+    pouch_slist_node_init(&buf->node);
+}
+
 struct pouch_buf *buf_alloc(size_t size)
 {
     struct pouch_buf *buf = malloc(sizeof(struct pouch_buf) + size);
     if (buf != NULL)
     {
         pouch_atomic_inc(&bufs);
-        buf->bytes = 0;
-        pouch_slist_node_init(&buf->node);
+        buf_init(buf);
     }
 
     return buf;

--- a/src/buf.h
+++ b/src/buf.h
@@ -31,6 +31,9 @@ typedef pouch_slist_t pouch_buf_queue_t;
 
 struct pouch_buf *buf_alloc(size_t size);
 
+/** Initialize a pre-allocated pouch buffer object */
+void buf_init(struct pouch_buf *buf);
+
 void buf_free(struct pouch_buf *buf);
 
 /**


### PR DESCRIPTION
New buffers must have their slist node initialized. The blockbuf_alloc was only initializing the `bytes` member. This didn't cause an issue with Zephyr because the slist nodes do not require initialization (this is a port implementation detail). However, in FreeRTOS, using an slist node without initialization is undefined behavior.

This has been resolved by creating a buf_init() function that initializes the slist node and resets the bytes value. Note that it is safe to re-initialize an slist node in FreeRTOS as long as that node is not already linked in a list. This may be important when we implement memory slabs on that platform.