### PR TITLE
buf: add guard to pouch_buf_queue_t

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -114,23 +114,32 @@ size_t buf_trim_end(struct pouch_buf *buf, size_t bytes)
 
 void buf_queue_init(pouch_buf_queue_t *queue)
 {
-    pouch_slist_init(queue);
+    pouch_slist_init(&queue->slist);
+    pouch_mutex_init(&queue->lock);
 }
 
 void buf_queue_submit(pouch_buf_queue_t *queue, struct pouch_buf *buf)
 {
-    pouch_slist_append(queue, &buf->node);
+    pouch_mutex_lock(&queue->lock, POUCH_FOREVER);
+    pouch_slist_append(&queue->slist, &buf->node);
+    pouch_mutex_unlock(&queue->lock);
 }
 
 struct pouch_buf *buf_queue_get(pouch_buf_queue_t *queue)
 {
-    pouch_slist_node_t *n = pouch_slist_get(queue);
+    pouch_mutex_lock(&queue->lock, POUCH_FOREVER);
+    pouch_slist_node_t *n = pouch_slist_get(&queue->slist);
+    pouch_mutex_unlock(&queue->lock);
+
     return n ? CONTAINER_OF(n, struct pouch_buf, node) : NULL;
 }
 
 struct pouch_buf *buf_queue_peek(pouch_buf_queue_t *queue)
 {
-    pouch_slist_node_t *n = pouch_slist_peek_head(queue);
+    pouch_mutex_lock(&queue->lock, POUCH_FOREVER);
+    pouch_slist_node_t *n = pouch_slist_peek_head(&queue->slist);
+    pouch_mutex_unlock(&queue->lock);
+
     return n ? CONTAINER_OF(n, struct pouch_buf, node) : NULL;
 }
 

--- a/src/buf.h
+++ b/src/buf.h
@@ -27,7 +27,11 @@ struct pouch_bufview
 typedef size_t pouch_buf_state_t;
 
 /** Buffer queue */
-typedef pouch_slist_t pouch_buf_queue_t;
+typedef struct pouch_buf_queue
+{
+    pouch_slist_t slist;
+    pouch_mutex_t lock;
+} pouch_buf_queue_t;
 
 struct pouch_buf *buf_alloc(size_t size);
 


### PR DESCRIPTION
pouch_list_*() functions are not thread safe. Guard against concurrent access by adding a lock to the pouch_buf_queue_t.

This resolves the concurrency issues between the uplink_workq thread and the pouch_work thread (when apps register uplink handlers that call pouch_uplink_entry_write), and also between the uplink_workq thread and the transport thread/context.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/981