### PR TITLE
ESP-IDF: http_client: add automatic certificate generation to pytest

### DIFF
--- a/examples/esp_idf/http_client/pytest/README.md
+++ b/examples/esp_idf/http_client/pytest/README.md
@@ -47,10 +47,10 @@ export GOLIOTH_API_URL="https://api.golioth.io"
 export GOLIOTH_API_KEY="your_project_api_key"
 export WIFI_SSID="your_wifi_ssid"
 export WIFI_PSK="your_wifi_psk"
-export DEVICE_CRT_DER_B64="base64_der_device_certificate"
-export DEVICE_KEY_DER_B64="base64_der_device_private_key"
+export DEVICE_CRT_DER_PATH="/path/to/device.crt.der"
+export DEVICE_KEY_DER_PATH="/path/to/device.key.der"
 
-# Optional override (otherwise derived from DEVICE_CRT_DER_B64 cert CN)
+# Optional override (otherwise derived from DEVICE_CRT_DER_PATH cert CN)
 export GOLIOTH_DEVICE_NAME="your_device_name"
 # Optional: set if API key can access multiple projects
 export GOLIOTH_PROJECT_ID="your_project_id"

--- a/examples/esp_idf/http_client/pytest/README.md
+++ b/examples/esp_idf/http_client/pytest/README.md
@@ -47,14 +47,26 @@ export GOLIOTH_API_URL="https://api.golioth.io"
 export GOLIOTH_API_KEY="your_project_api_key"
 export WIFI_SSID="your_wifi_ssid"
 export WIFI_PSK="your_wifi_psk"
+
+# Manual cert mode: provide DER file paths
 export DEVICE_CRT_DER_PATH="/path/to/device.crt.der"
 export DEVICE_KEY_DER_PATH="/path/to/device.key.der"
 
-# Optional override (otherwise derived from DEVICE_CRT_DER_PATH cert CN)
+# Optional override (otherwise derived from cert CN in DEVICE_CRT_DER_PATH)
 export GOLIOTH_DEVICE_NAME="your_device_name"
-# Optional: set if API key can access multiple projects
-export GOLIOTH_PROJECT_ID="your_project_id"
 ```
+
+The test also accepts `python-golioth-tools`/SDK-style pytest flags:
+
+- `--api-key` (fallback: `GOLIOTH_API_KEY`)
+- `--api-url` (fallback: `GOLIOTH_API_URL`, default: `https://api.golioth.io`)
+- `--device-name` (fallback: `GOLIOTH_DEVICE_NAME`)
+- `--wifi-ssid` (fallback: `WIFI_SSID`)
+- `--wifi-psk` (fallback: `WIFI_PSK`)
+
+To generate device certificates automatically during the test run,
+pass `--generate-certs` and omit manual cert inputs
+(`DEVICE_CRT_DER_PATH`/`DEVICE_KEY_DER_PATH`).
 
 Then run from the repository root (`pouch`):
 
@@ -69,9 +81,24 @@ pytest -vv -rs -s \
   --embedded-services esp,idf \
   --target esp32s3 \
   --port /dev/ttyUSB0 \
-  --flash-port /dev/ttyUSB0 \
   --app-path examples/esp_idf/http_client \
   --build-dir build \
   --erase-all n \
+  examples/esp_idf/http_client/pytest/test_sample.py
+```
+
+Example generated-cert run:
+
+```bash
+pytest -vv -rs -s \
+  -c examples/esp_idf/http_client/pytest.ini \
+  --rootdir examples/esp_idf/http_client \
+  --embedded-services esp,idf \
+  --target esp32s3 \
+  --port /dev/ttyUSB0 \
+  --app-path examples/esp_idf/http_client \
+  --build-dir build \
+  --erase-all n \
+  --generate-certs \
   examples/esp_idf/http_client/pytest/test_sample.py
 ```

--- a/examples/esp_idf/http_client/pytest/conftest.py
+++ b/examples/esp_idf/http_client/pytest/conftest.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations
-
 import os
+import secrets
+import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -14,17 +15,71 @@ import pytest
 # Patch esptool v4.* for underscore/dash conflict with v5.*
 import esptool_v4_shim  # noqa: F401
 
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[4] / "scripts" / "pytest-pouch")
+)
 
-def _device_name_from_cert_cn() -> str | None:
-    cert_der_path = os.getenv("DEVICE_CRT_DER_PATH")
-    if not cert_der_path:
+pytest_plugins = ["pytest_pouch.plugin"]
+
+
+@dataclass
+class WifiCreds:
+    ssid: str
+    psk: str
+
+
+@dataclass
+class DeviceCertBundle:
+    crt_der: bytes
+    key_der: bytes
+
+
+@dataclass
+class ProvisioningCreds:
+    wifi: WifiCreds
+    certs: DeviceCertBundle
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--wifi-ssid",
+        type=str,
+        help="WiFi SSID",
+    )
+    parser.addoption(
+        "--wifi-psk",
+        type=str,
+        help="WiFi PSK",
+    )
+    parser.addoption(
+        "--generate-certs",
+        action="store_true",
+        default=False,
+        help="Generate test PKI credentials during test setup",
+    )
+
+
+def _option_or_env(request, option_name: str, env_name: str) -> str | None:
+    return request.config.getoption(option_name) or os.getenv(env_name)
+
+
+def _device_name_from_cert_cn(cert_der: bytes | None = None) -> str | None:
+    if cert_der is None:
+        cert_der_path = os.getenv("DEVICE_CRT_DER_PATH")
+        if not cert_der_path:
+            return None
+        try:
+            cert_der = Path(cert_der_path).read_bytes()
+        except OSError:
+            return None
+
+    if not cert_der:
         return None
 
     try:
         from cryptography import x509
         from cryptography.x509.oid import NameOID
 
-        cert_der = Path(cert_der_path).read_bytes()
         cert = x509.load_der_x509_certificate(cert_der)
         common_names = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
         if not common_names:
@@ -40,52 +95,126 @@ def _device_name_from_cert_cn() -> str | None:
 
 
 @pytest.fixture(scope="module")
-def provisioning_creds() -> dict[str, str | bytes]:
-    required_env_vars = (
-        "WIFI_SSID",
-        "WIFI_PSK",
-        "DEVICE_CRT_DER_PATH",
-        "DEVICE_KEY_DER_PATH",
-    )
+def wifi_creds(request) -> WifiCreds:
+    wifi_ssid = _option_or_env(request, "--wifi-ssid", "WIFI_SSID")
+    wifi_psk = _option_or_env(request, "--wifi-psk", "WIFI_PSK")
 
-    missing = [name for name in required_env_vars if not os.getenv(name)]
+    missing = []
+    if not wifi_ssid:
+        missing.append("WIFI_SSID/--wifi-ssid")
+    if not wifi_psk:
+        missing.append("WIFI_PSK/--wifi-psk")
     if missing:
-        missing_str = ", ".join(missing)
-        pytest.skip(f"Missing provisioning env vars: {missing_str}")
+        pytest.fail(f"Missing provisioning inputs: {', '.join(missing)}")
 
-    return {
-        "WIFI_SSID": os.environ["WIFI_SSID"],
-        "WIFI_PSK": os.environ["WIFI_PSK"],
-        "DEVICE_CRT_DER": Path(os.environ["DEVICE_CRT_DER_PATH"]).read_bytes(),
-        "DEVICE_KEY_DER": Path(os.environ["DEVICE_KEY_DER_PATH"]).read_bytes(),
-    }
+    return WifiCreds(ssid=wifi_ssid, psk=wifi_psk)
 
 
 @pytest.fixture(scope="module")
-def cloud_config() -> dict[str, str | None]:
-    required_env_vars = (
-        "GOLIOTH_API_URL",
-        "GOLIOTH_API_KEY",
+def device_name(request) -> str:
+    configured_device_name = _option_or_env(
+        request, "--device-name", "GOLIOTH_DEVICE_NAME"
     )
 
-    missing = [name for name in required_env_vars if not os.getenv(name)]
-    if missing:
-        missing_str = ", ".join(missing)
-        pytest.skip(f"Missing cloud env vars: {missing_str}")
+    if configured_device_name is not None and configured_device_name != "":
+        return configured_device_name
 
-    device_name = os.getenv("GOLIOTH_DEVICE_NAME")
-    if not device_name:
-        device_name = _device_name_from_cert_cn()
+    if request.config.getoption("--generate-certs"):
+        return f"esp-idf-http-client-{secrets.token_hex(4)}"
 
+    device_name = _device_name_from_cert_cn()
     if not device_name:
-        pytest.skip(
+        pytest.fail(
             "Missing cloud device identity. Set GOLIOTH_DEVICE_NAME or provide "
             "DEVICE_CRT_DER_PATH with a certificate CN matching the cloud device name"
         )
 
+    return device_name
+
+
+@pytest.fixture(scope="module")
+async def device(project, device_name):
+    created = False
+
+    devices = await project.get_devices({"deviceName": device_name})
+    if devices:
+        cloud_device = devices[0]
+    else:
+        cloud_device = await project.create_device(device_name, device_name)
+        created = True
+
+    yield cloud_device
+
+    if created:
+        await project.delete_device(cloud_device)
+
+
+@pytest.fixture(scope="module")
+def cloud_config(request, device_name) -> dict[str, str]:
+    api_url = _option_or_env(request, "--api-url", "GOLIOTH_API_URL")
+    if not api_url:
+        api_url = "https://api.golioth.io"
+
+    api_key = _option_or_env(request, "--api-key", "GOLIOTH_API_KEY")
+    if not api_key:
+        pytest.fail("Missing cloud input: GOLIOTH_API_KEY/--api-key")
+
     return {
-        "api_url": os.environ["GOLIOTH_API_URL"],
-        "api_key": os.environ["GOLIOTH_API_KEY"],
+        "api_url": api_url,
+        "api_key": api_key,
         "device_name": device_name,
-        "project_id": os.getenv("GOLIOTH_PROJECT_ID"),
     }
+
+
+@pytest.fixture(scope="module")
+def cert_paths(request, creds_dir):
+    if request.config.getoption("--generate-certs"):
+        request.getfixturevalue("creds")
+
+    return {
+        "crt_der_path": creds_dir / "crt.der",
+        "key_der_path": creds_dir / "key.der",
+    }
+
+
+@pytest.fixture(scope="module")
+def device_cert_bundle(request, cert_paths) -> DeviceCertBundle:
+    crt_der = b""
+    key_der = b""
+
+    if request.config.getoption("--generate-certs"):
+        crt_der = Path(cert_paths["crt_der_path"]).read_bytes()
+        key_der = Path(cert_paths["key_der_path"]).read_bytes()
+    else:
+        crt_path = os.getenv("DEVICE_CRT_DER_PATH")
+        key_path = os.getenv("DEVICE_KEY_DER_PATH")
+
+        missing = []
+        if not crt_path:
+            missing.append("DEVICE_CRT_DER_PATH")
+        if not key_path:
+            missing.append("DEVICE_KEY_DER_PATH")
+        if missing:
+            pytest.fail(
+                "Missing certificate inputs. Set DEVICE_CRT_DER_PATH and "
+                f"DEVICE_KEY_DER_PATH. Missing: {', '.join(missing)}"
+            )
+
+        try:
+            crt_der = Path(crt_path).read_bytes()
+        except OSError as exc:
+            pytest.fail(f"Unable to read DEVICE_CRT_DER_PATH '{crt_path}': {exc}")
+        try:
+            key_der = Path(key_path).read_bytes()
+        except OSError as exc:
+            pytest.fail(f"Unable to read DEVICE_KEY_DER_PATH '{key_path}': {exc}")
+
+    return DeviceCertBundle(crt_der=crt_der, key_der=key_der)
+
+
+@pytest.fixture(scope="module")
+def provisioning_creds(wifi_creds, device_cert_bundle) -> ProvisioningCreds:
+    return ProvisioningCreds(
+        wifi=wifi_creds,
+        certs=device_cert_bundle,
+    )

--- a/examples/esp_idf/http_client/pytest/conftest.py
+++ b/examples/esp_idf/http_client/pytest/conftest.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import os
-import base64
+from pathlib import Path
 
 import pytest
 
@@ -16,15 +16,15 @@ import esptool_v4_shim  # noqa: F401
 
 
 def _device_name_from_cert_cn() -> str | None:
-    cert_der_b64 = os.getenv("DEVICE_CRT_DER_B64")
-    if not cert_der_b64:
+    cert_der_path = os.getenv("DEVICE_CRT_DER_PATH")
+    if not cert_der_path:
         return None
 
     try:
         from cryptography import x509
         from cryptography.x509.oid import NameOID
 
-        cert_der = base64.b64decode(cert_der_b64, validate=True)
+        cert_der = Path(cert_der_path).read_bytes()
         cert = x509.load_der_x509_certificate(cert_der)
         common_names = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
         if not common_names:
@@ -40,12 +40,12 @@ def _device_name_from_cert_cn() -> str | None:
 
 
 @pytest.fixture(scope="module")
-def provisioning_creds() -> dict[str, str]:
+def provisioning_creds() -> dict[str, str | bytes]:
     required_env_vars = (
         "WIFI_SSID",
         "WIFI_PSK",
-        "DEVICE_CRT_DER_B64",
-        "DEVICE_KEY_DER_B64",
+        "DEVICE_CRT_DER_PATH",
+        "DEVICE_KEY_DER_PATH",
     )
 
     missing = [name for name in required_env_vars if not os.getenv(name)]
@@ -53,7 +53,12 @@ def provisioning_creds() -> dict[str, str]:
         missing_str = ", ".join(missing)
         pytest.skip(f"Missing provisioning env vars: {missing_str}")
 
-    return {name: os.environ[name] for name in required_env_vars}
+    return {
+        "WIFI_SSID": os.environ["WIFI_SSID"],
+        "WIFI_PSK": os.environ["WIFI_PSK"],
+        "DEVICE_CRT_DER": Path(os.environ["DEVICE_CRT_DER_PATH"]).read_bytes(),
+        "DEVICE_KEY_DER": Path(os.environ["DEVICE_KEY_DER_PATH"]).read_bytes(),
+    }
 
 
 @pytest.fixture(scope="module")
@@ -75,7 +80,7 @@ def cloud_config() -> dict[str, str | None]:
     if not device_name:
         pytest.skip(
             "Missing cloud device identity. Set GOLIOTH_DEVICE_NAME or provide "
-            "DEVICE_CRT_DER_B64 with a certificate CN matching the cloud device name"
+            "DEVICE_CRT_DER_PATH with a certificate CN matching the cloud device name"
         )
 
     return {

--- a/examples/esp_idf/http_client/pytest/test_sample.py
+++ b/examples/esp_idf/http_client/pytest/test_sample.py
@@ -86,19 +86,19 @@ def _wait_for_boot_state(dut) -> bool:
     ) from last_exception
 
 
-def _provision_and_boot(dut, provisioning_creds) -> None:
-    crt_der_b64 = base64.b64encode(provisioning_creds["DEVICE_CRT_DER"]).decode("ascii")
-    key_der_b64 = base64.b64encode(provisioning_creds["DEVICE_KEY_DER"]).decode("ascii")
+async def _provision_and_boot(dut, provisioning_creds) -> None:
+    crt_der_b64 = base64.b64encode(provisioning_creds.certs.crt_der).decode("ascii")
+    key_der_b64 = base64.b64encode(provisioning_creds.certs.key_der).decode("ascii")
 
     print("Provisioning WiFi and credentials")
     _send_and_expect_store(
         dut,
-        f"ssid {provisioning_creds['WIFI_SSID']}",
+        f"ssid {provisioning_creds.wifi.ssid}",
         r".*Successfully stored WiFi SSID",
     )
     _send_and_expect_store(
         dut,
-        f"psk {provisioning_creds['WIFI_PSK']}",
+        f"psk {provisioning_creds.wifi.psk}",
         r".*Successfully stored WiFi PSK",
     )
     _send_and_expect_store(

--- a/examples/esp_idf/http_client/pytest/test_sample.py
+++ b/examples/esp_idf/http_client/pytest/test_sample.py
@@ -6,6 +6,7 @@
 
 import asyncio
 import datetime
+import base64
 import re
 import time
 
@@ -86,6 +87,9 @@ def _wait_for_boot_state(dut) -> bool:
 
 
 def _provision_and_boot(dut, provisioning_creds) -> None:
+    crt_der_b64 = base64.b64encode(provisioning_creds["DEVICE_CRT_DER"]).decode("ascii")
+    key_der_b64 = base64.b64encode(provisioning_creds["DEVICE_KEY_DER"]).decode("ascii")
+
     print("Provisioning WiFi and credentials")
     _send_and_expect_store(
         dut,
@@ -99,12 +103,12 @@ def _provision_and_boot(dut, provisioning_creds) -> None:
     )
     _send_and_expect_store(
         dut,
-        f"crt {provisioning_creds['DEVICE_CRT_DER_B64']}",
+        f"crt {crt_der_b64}",
         r".*Successfully stored Device CRT",
     )
     _send_and_expect_store(
         dut,
-        f"key {provisioning_creds['DEVICE_KEY_DER_B64']}",
+        f"key {key_der_b64}",
         r".*Successfully stored Device KEY",
     )
 

--- a/examples/esp_idf/http_client/pytest/test_sample.py
+++ b/examples/esp_idf/http_client/pytest/test_sample.py
@@ -4,15 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-import asyncio
 import datetime
 import base64
+from dataclasses import dataclass
 import re
 import time
 
+import anyio
 import pytest
-from golioth.golioth import Client, Project
 from pexpect.exceptions import TIMEOUT as PexpectTimeout
+
+pytestmark = pytest.mark.anyio
 
 CONNECT_TIMEOUT_S = 20.0
 STORE_TIMEOUT_S = 20.0
@@ -23,12 +25,20 @@ BOOT_STATE_TIMEOUT_S = 90.0
 STREAM_POLL_ATTEMPTS = 24
 STREAM_POLL_DELAY_S = 5.0
 BOOT_INITIALIZED_TEXT = "Pouch successfully initialized"
-BOOT_STATE_PATTERN = (
+BOOT_STATE_PATTERN = re.compile(
     r".*(Failed to load credentials|credentials_nvs: Failed to|"
     r"Failed to read (wifi_ssid|wifi_psk|crt_der|key_der) len|"
     r"Failed to load .* from NVS|Failed to Load|Returned from app_main|"
     r"Pouch successfully initialized)"
 )
+
+
+@dataclass
+class CloudSession:
+    dut: object
+    project: object
+    cloud_device: object
+    initial_led: bool
 
 
 def _match_text(match) -> str:
@@ -38,9 +48,22 @@ def _match_text(match) -> str:
     return str(text)
 
 
-def _send_and_expect_store(dut, command: str, expected_log: str) -> None:
-    dut.write(command)
-    match = dut.expect(
+async def _dut_write(dut, command: str) -> None:
+    await anyio.to_thread.run_sync(dut.write, command)
+
+
+async def _dut_expect(dut, pattern, timeout: float):
+    return await anyio.to_thread.run_sync(lambda: dut.expect(pattern, timeout=timeout))
+
+
+async def _dut_hard_reset(dut) -> None:
+    await anyio.to_thread.run_sync(dut.serial.hard_reset)
+
+
+async def _send_and_expect_store(dut, command: str, expected_log: str) -> None:
+    await _dut_write(dut, command)
+    match = await _dut_expect(
+        dut,
         r".*(Successfully stored .+|Failed to store .+|Failed to set .+|Failed to decode base64.*)",
         timeout=STORE_TIMEOUT_S,
     )
@@ -52,18 +75,20 @@ def _send_and_expect_store(dut, command: str, expected_log: str) -> None:
         )
 
 
-def _detect_boot_state(dut, banner_timeout_s: float) -> bool:
+async def _detect_boot_state(dut, banner_timeout_s: float) -> bool:
     """Return True when boot logs indicate credentials must be provisioned."""
 
-    dut.expect(r".*Pouch HTTP Client Example", timeout=banner_timeout_s)
-    state_match = dut.expect(BOOT_STATE_PATTERN, timeout=BOOT_STATE_TIMEOUT_S)
+    await _dut_expect(dut, r".*Pouch HTTP Client Example", timeout=banner_timeout_s)
+    state_match = await _dut_expect(
+        dut, BOOT_STATE_PATTERN, timeout=BOOT_STATE_TIMEOUT_S
+    )
     if BOOT_INITIALIZED_TEXT not in _match_text(state_match):
         print("Missing credentials detected; provisioning immediately")
         return True
     return False
 
 
-def _wait_for_boot_state(dut) -> bool:
+async def _wait_for_boot_state(dut) -> bool:
     """Return True when provisioning is required; reset once if boot state goes undetected"""
 
     last_exception = None
@@ -74,10 +99,10 @@ def _wait_for_boot_state(dut) -> bool:
     ):
         if do_reset:
             print("Boot state not detected, forcing hard reset")
-            dut.serial.hard_reset()
+            await _dut_hard_reset(dut)
 
         try:
-            return _detect_boot_state(dut, timeout_s)
+            return await _detect_boot_state(dut, timeout_s)
         except (PexpectTimeout, AssertionError) as exc:
             last_exception = exc
 
@@ -91,50 +116,44 @@ async def _provision_and_boot(dut, provisioning_creds) -> None:
     key_der_b64 = base64.b64encode(provisioning_creds.certs.key_der).decode("ascii")
 
     print("Provisioning WiFi and credentials")
-    _send_and_expect_store(
+    await _send_and_expect_store(
         dut,
         f"ssid {provisioning_creds.wifi.ssid}",
         r".*Successfully stored WiFi SSID",
     )
-    _send_and_expect_store(
+    await _send_and_expect_store(
         dut,
         f"psk {provisioning_creds.wifi.psk}",
         r".*Successfully stored WiFi PSK",
     )
-    _send_and_expect_store(
+    await _send_and_expect_store(
         dut,
         f"crt {crt_der_b64}",
         r".*Successfully stored Device CRT",
     )
-    _send_and_expect_store(
+    await _send_and_expect_store(
         dut,
         f"key {key_der_b64}",
         r".*Successfully stored Device KEY",
     )
 
     print("Rebooting after provisioning")
-    dut.write("reset")
-    dut.expect(r".*Pouch HTTP Client Example", timeout=REBOOT_TIMEOUT_S)
-    dut.expect(r".*Pouch successfully initialized", timeout=REBOOT_TIMEOUT_S)
-
-
-def _require_cloud_objects(cloud_config: dict[str, str | None]):
-    client = Client(
-        api_url=cloud_config["api_url"],
-        api_key=cloud_config["api_key"],
+    await _dut_write(dut, "reset")
+    await _dut_expect(dut, r".*Pouch HTTP Client Example", timeout=REBOOT_TIMEOUT_S)
+    await _dut_expect(
+        dut, r".*Pouch successfully initialized", timeout=REBOOT_TIMEOUT_S
     )
 
-    project = asyncio.run(Project.get_by_id(client, cloud_config["project_id"]))
-    device = asyncio.run(project.device_by_name(cloud_config["device_name"]))
 
-    return project, device
+async def _require_cloud_device(project, cloud_config: dict[str, str]):
+    return await project.device_by_name(cloud_config["device_name"])
 
 
 def _iso8601_utc(timestamp: datetime.datetime) -> str:
     return timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-def _wait_for_sensor_uplink(device, start_time: datetime.datetime) -> dict:
+async def _wait_for_sensor_uplink(device, start_time: datetime.datetime) -> dict:
     latest_payload = None
     latest_payload_with_temp = None
 
@@ -142,11 +161,9 @@ def _wait_for_sensor_uplink(device, start_time: datetime.datetime) -> dict:
     # gateway to propagate to the server while also filtering values that arrived before the test
     # began.
     for _ in range(STREAM_POLL_ATTEMPTS):
-        response = asyncio.run(
-            device.stream.get(
-                start=_iso8601_utc(start_time),
-                per_page=20,
-            )
+        response = await device.stream.get(
+            start=_iso8601_utc(start_time),
+            per_page=20,
         )
         entries = response.get("list", [])
 
@@ -158,7 +175,7 @@ def _wait_for_sensor_uplink(device, start_time: datetime.datetime) -> dict:
                     latest_payload_with_temp = payload
                     return payload
 
-        time.sleep(STREAM_POLL_DELAY_S)
+        await anyio.sleep(STREAM_POLL_DELAY_S)
 
     assert latest_payload is not None, "No stream entries found in cloud"
     assert latest_payload_with_temp is not None, (
@@ -167,8 +184,9 @@ def _wait_for_sensor_uplink(device, start_time: datetime.datetime) -> dict:
     return latest_payload_with_temp
 
 
-def _wait_for_led_setting(dut, timeout_s: float) -> bool:
-    index = dut.expect(
+async def _wait_for_led_setting(dut, timeout_s: float) -> bool:
+    index = await _dut_expect(
+        dut,
         [
             r".*Received LED setting: 0",
             r".*Received LED setting: 1",
@@ -178,10 +196,10 @@ def _wait_for_led_setting(dut, timeout_s: float) -> bool:
     return bool(index)
 
 
-def _get_device_led_setting(device) -> bool | None:
+async def _get_device_led_setting(device) -> bool | None:
     device_id = str(getattr(device, "id", "") or "")
 
-    settings = asyncio.run(device.settings.get_all())
+    settings = await device.settings.get_all()
     if isinstance(settings, dict):
         settings = settings.get("list", [])
 
@@ -206,37 +224,37 @@ def _get_device_led_setting(device) -> bool | None:
 
 
 @pytest.fixture(scope="function")
-def connected_cloud_session(cloud_config, provisioning_creds, dut):
-    needs_provisioning = _wait_for_boot_state(dut)
+async def connected_cloud_session(cloud_config, provisioning_creds, dut, project):
+    needs_provisioning = await _wait_for_boot_state(dut)
 
     if needs_provisioning:
-        _provision_and_boot(dut, provisioning_creds)
+        await _provision_and_boot(dut, provisioning_creds)
 
-    project, cloud_device = _require_cloud_objects(cloud_config)
-    initial_led = _wait_for_led_setting(dut, timeout_s=SYNC_TIMEOUT_S)
+    cloud_device = await _require_cloud_device(project, cloud_config)
+    initial_led = await _wait_for_led_setting(dut, timeout_s=SYNC_TIMEOUT_S)
 
-    yield {
-        "dut": dut,
-        "project": project,
-        "cloud_device": cloud_device,
-        "initial_led": initial_led,
-    }
+    yield CloudSession(
+        dut=dut,
+        project=project,
+        cloud_device=cloud_device,
+        initial_led=initial_led,
+    )
 
 
-def test_sensor_uplink_contains_temp(connected_cloud_session):
-    cloud_device = connected_cloud_session["cloud_device"]
+async def test_sensor_uplink_contains_temp(connected_cloud_session):
+    cloud_device = connected_cloud_session.cloud_device
     start_time = datetime.datetime.now(datetime.UTC)
 
-    _wait_for_sensor_uplink(cloud_device, start_time)
+    await _wait_for_sensor_uplink(cloud_device, start_time)
 
 
-def test_led_setting_downlink(connected_cloud_session):
-    dut = connected_cloud_session["dut"]
-    cloud_device = connected_cloud_session["cloud_device"]
-    initial_led = connected_cloud_session["initial_led"]
+async def test_led_setting_downlink(connected_cloud_session):
+    dut = connected_cloud_session.dut
+    cloud_device = connected_cloud_session.cloud_device
+    initial_led = connected_cloud_session.initial_led
 
     print(f"Initial LED observed on DUT: {int(initial_led)}")
-    current_led = _get_device_led_setting(cloud_device)
+    current_led = await _get_device_led_setting(cloud_device)
     if current_led is None:
         current_led = initial_led
         print(
@@ -249,10 +267,10 @@ def test_led_setting_downlink(connected_cloud_session):
     next_led = not current_led
     write_start = time.monotonic()
     print(f"Setting device-level LED override to: {int(next_led)}")
-    asyncio.run(cloud_device.settings.set("LED", next_led))
+    await cloud_device.settings.set("LED", next_led)
     expected_pattern = (
         r".*Received LED setting: 1" if next_led else r".*Received LED setting: 0"
     )
-    dut.expect(expected_pattern, timeout=LED_TIMEOUT_S)
+    await _dut_expect(dut, expected_pattern, timeout=LED_TIMEOUT_S)
     elapsed = time.monotonic() - write_start
     print(f"Device received LED setting {int(next_led)} after {elapsed:.1f}s")


### PR DESCRIPTION
- Migrate from accepting base64 certs as env vars to accepting paths to the der files
- Convert sync functions to async to make using pouch-pytest plugin easier
- Use pouch-pytest plug to automatically generate certificates