### PR TITLE
CI: ESP-IDF: add HIL test for http_client

### DIFF
--- a/.github/actions/safe-upload-artifacts/README.md
+++ b/.github/actions/safe-upload-artifacts/README.md
@@ -1,0 +1,33 @@
+# Safe Upload Artifacts Github Action
+
+Upload artifacts from a given set of paths. Before the archive is
+uploaded the files will be scanned for GitHub secrets and masked when
+found with `***NAME_OF_SECRET***`. This prevents secrets from appearing
+in publicly-downloadable archives attached to workflow runs.
+
+## Known Issues
+
+The regex used for the replacement cannot be applied to secrets that
+have linefeed characters in them. These secrets will be skipped without
+notice.
+
+## Usage
+
+```
+  - name: Safe upload artifacts
+    id: safe-upload-artifacts
+    if: always()
+    uses: ./.github/actions/safe-upload-artifacts
+    with:
+      secrets-json: ${{ toJson(secrets) }}
+      name: name-for-the-uploaded-archive
+      path: |
+        path-to/file-to-archive.log
+```
+
+- The `uses` path may change based on how your workflow checks out the
+  repository. (eg: `uses:
+  ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts`).
+- Secrets must be passed as serialized JSON as in the example above.
+  This is because actions cannot inherit secrets. Reusable workflows can
+  inherit secrets but they cannot be run as steps (only as jobs).

--- a/.github/actions/safe-upload-artifacts/README.md
+++ b/.github/actions/safe-upload-artifacts/README.md
@@ -27,7 +27,7 @@ notice.
 
 - The `uses` path may change based on how your workflow checks out the
   repository. (eg: `uses:
-  ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts`).
+  ./pouch/.github/actions/safe-upload-artifacts`).
 - Secrets must be passed as serialized JSON as in the example above.
   This is because actions cannot inherit secrets. Reusable workflows can
   inherit secrets but they cannot be run as steps (only as jobs).

--- a/.github/actions/safe-upload-artifacts/action.yml
+++ b/.github/actions/safe-upload-artifacts/action.yml
@@ -1,0 +1,71 @@
+name: Mask secrets in files
+
+description: |
+  Search all files in a given path(s) and replace any GitHub secrets with ***NAME_OF_SECRET***
+
+inputs:
+  secrets-json:
+    description: 'Secrets context to be masked, in JSON format'
+    required: true
+  name:
+    description: 'String to use as the archive name'
+    required: true
+  path:
+    description: 'Path(s) to the files to be include in the upload'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check for installed commands
+      shell: bash
+      run: |
+        if ! command -v jq; then
+          apt update && apt install -y jq
+
+          if ! command -v jq; then
+            echo "Could not install command: jq"
+            exit 1
+          fi
+        fi
+
+    - name: Find and mask
+      id: find-and-mask
+      shell: bash
+      env:
+        SECRETS_CONTEXT: '${{ inputs.secrets-json }}'
+      run: |
+        rm -rf __grep_search_output.txt
+
+        # Enable globbing
+        shopt -s globstar
+
+        for key in $(jq -r "keys[]" <<< "$SECRETS_CONTEXT");
+        do
+          secret_val=$(jq -r ".$key" <<< "$SECRETS_CONTEXT")
+
+          if [[ ! $secret_val =~ "\n" ]]; then
+            # This approach to escaping the regex found: https://stackoverflow.com/a/29613573/922013
+            ESCAPED_SECRET=$(sed 's/[^^]/[&]/g; s/\^/\\^/g' <<< "$secret_val")
+
+            # Iterate list of input path patterns and use grep to create a list of files that
+            # contain secrets
+            while IFS= read -r search_path || [[ -n $search_path ]];
+            do
+              [ $(grep -Rl $ESCAPED_SECRET $search_path 2>/dev/null >> \
+                __grep_search_output.txt) >= 0 ]
+            done < <(printf '%s' "${{ inputs.path }}")
+
+            if [ -s __grep_search_output.txt ]; then
+              uniq __grep_search_output.txt | xargs -I{} sed -i "s/$ESCAPED_SECRET/***$key***/g" {}
+            fi
+
+            rm -rf __grep_search_output.txt
+          fi
+        done
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}

--- a/.github/actions/safe-upload-artifacts/action.yml
+++ b/.github/actions/safe-upload-artifacts/action.yml
@@ -65,7 +65,7 @@ runs:
         done
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -32,6 +32,15 @@ jobs:
     name: Run ESP-IDF Unit Test
     uses: ./.github/workflows/test-esp-idf.yml
     secrets: inherit
+  trigger-esp-idf-hil:
+    name: Run ESP-IDF HTTP Client HIL
+    uses: ./.github/workflows/test-esp-idf-hil.yml
+    with:
+      hil_board: esp32s3_devkitc
+      idf_target: esp32s3
+      api_url: https://api.golioth.io
+      api_key_id: PROD_CI_PROJECT_API_KEY
+    secrets: inherit
   trigger-nsim:
     name: Run Native Simulator and BabbleSim Tests
     uses: ./.github/workflows/test-nsim.yml
@@ -45,6 +54,7 @@ jobs:
     if: success() || failure()
     needs:
       - trigger-esp-idf
+      - trigger-esp-idf-hil
       - trigger-twister
       - trigger-nsim
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -1,0 +1,231 @@
+name: ESP-IDF HTTP Client HIL
+
+on:
+  workflow_dispatch:
+    inputs:
+      hil_board:
+        description: Self-hosted runner label for HIL board
+        required: true
+        type: string
+      idf_target:
+        description: ESP-IDF target (for example esp32s3)
+        required: true
+        type: string
+      api_url:
+        description: API gateway URL for Golioth backend services
+        required: true
+        type: string
+      api_key_id:
+        description: Name of GitHub secret containing project API key
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      hil_board:
+        description: Self-hosted runner label for HIL board
+        required: true
+        type: string
+      idf_target:
+        description: ESP-IDF target (for example esp32s3)
+        required: true
+        type: string
+      api_url:
+        description: API gateway URL for Golioth backend services
+        required: true
+        type: string
+      api_key_id:
+        description: Name of GitHub secret containing project API key
+        required: true
+        type: string
+
+jobs:
+  prepare-matrix:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set sample matrix
+        id: set-matrix
+        run: |
+          echo 'matrix={"sample":[{"name":"http_client","dir":"examples/esp_idf/http_client"}]}' >> "$GITHUB_OUTPUT"
+
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    needs: prepare-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+    container: espressif/idf@sha256:9b8c4b573f6eb7aa65be6b34817590ad85b4f7176273522094a2bf465dc9263f
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build firmware and merged image
+        shell: bash
+        run: |
+          . "$IDF_PATH/export.sh"
+
+          # Install Pouch dependencies
+          pip install -r requirements-ci-esp-idf.txt --require-hashes
+
+          idf.py -C "${{ matrix.sample.dir }}" set-target "${{ inputs.idf_target }}"
+          idf.py -C "${{ matrix.sample.dir }}" build
+          idf.py -C "${{ matrix.sample.dir }}" merge-bin -o merged.bin
+
+          cd "${{ matrix.sample.dir }}"
+          shopt -s globstar nullglob
+
+          artifact_files=(
+            build/flasher_args.json
+            build/**/*.bin
+            build/*.elf
+          )
+
+          tar -cf build-artifacts.tar "${artifact_files[@]}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: esp-idf-${{ matrix.sample.name }}-${{ inputs.idf_target }}-build
+          path: ${{ matrix.sample.dir }}/build-artifacts.tar
+
+  hil-test:
+    permissions:
+      contents: read
+
+    needs:
+      - prepare-matrix
+      - build
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+
+    runs-on:
+      - is_active
+      - has_${{ inputs.hil_board }}
+
+    container:
+      image: golioth/golioth-hil-base:bda7b71
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
+    env:
+      HIL_BOARD: ${{ inputs.hil_board }}
+      GOLIOTH_API_URL: ${{ inputs.api_url }}
+      GOLIOTH_API_KEY: ${{ secrets[inputs.api_key_id] }}
+      IDF_TARGET: ${{ inputs.idf_target }}
+      SAMPLE_DIR: ${{ matrix.sample.dir }}
+      UNITY_REPORT_NAME: integration-esp-idf-${{ matrix.sample.name }}-hil.xml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Clean stale run assets
+        run: |
+          rm -rf "$SAMPLE_DIR/build"
+          rm -f "$UNITY_REPORT_NAME" "pytest-${{ matrix.sample.name }}-hil.log"
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: esp-idf-${{ matrix.sample.name }}-${{ inputs.idf_target }}-build
+          path: esp-idf-${{ matrix.sample.name }}
+
+      - name: Extract build artifact
+        run: |
+          tar -xf "esp-idf-${{ matrix.sample.name }}/build-artifacts.tar" -C "$SAMPLE_DIR"
+
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
+
+      - name: Install pytest dependencies
+        run: |
+          uv pip install \
+            -r requirements-ci-esp-idf.txt \
+            --require-hashes
+
+          uv pip install \
+            "golioth@git+https://github.com/golioth/python-golioth-tools@v0.8.1"
+
+      - name: Run HTTP client HIL pytest
+        shell: bash
+        run: |
+          # Config so we can use tee to keep a copy of pytest logs
+          set -o pipefail
+
+          source /opt/credentials/runner_env.sh
+          PORT_VAR=CI_${HIL_BOARD^^}_PORT
+          if [ -z "${!PORT_VAR}" ]; then
+            echo "Runner environment variable '$PORT_VAR' is not set"
+            exit 1
+          fi
+
+          pytest -vv -rs -s                  \
+            -c "$SAMPLE_DIR/pytest.ini"      \
+            --rootdir "$SAMPLE_DIR"          \
+            --embedded-services esp,idf      \
+            --target "$IDF_TARGET"           \
+            --port "${!PORT_VAR}"            \
+            --app-path "$SAMPLE_DIR"         \
+            --build-dir build                \
+            --erase-all n                    \
+            --api-url "$GOLIOTH_API_URL"     \
+            --api-key "$GOLIOTH_API_KEY"     \
+            --wifi-ssid "${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}" \
+            --wifi-psk "${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}"   \
+            --generate-certs                 \
+            --junit-xml "$UNITY_REPORT_NAME" \
+            "$SAMPLE_DIR/pytest/test_sample.py" | tee pytest-${{ matrix.sample.name }}-hil.log
+
+      - name: Post-process JUnit XML
+        if: success() || failure()
+        run: |
+          python3 tests/esp_idf/port/junit_post_process.py "$UNITY_REPORT_NAME"
+
+      - name: Upload CI report summary
+        uses: ./.github/actions/safe-upload-artifacts
+        if: success() || failure()
+        with:
+          secrets-json: ${{ toJson(secrets) }}
+          name: ci-summary-integration-esp-idf-${{ matrix.sample.name }}-hil
+          path: ${{ env.UNITY_REPORT_NAME }}
+
+      - name: Upload HIL run artifacts
+        uses: ./.github/actions/safe-upload-artifacts
+        if: success() || failure()
+        with:
+          secrets-json: ${{ toJson(secrets) }}
+          name: esp-idf-${{ matrix.sample.name }}-hil-artifacts
+          path: |
+            pytest-${{ matrix.sample.name }}-hil.log
+            ${{ env.UNITY_REPORT_NAME }}
+
+      - name: Erase flash
+        if: always()
+        shell: bash
+        run: |
+          source /opt/credentials/runner_env.sh
+          PORT_VAR=CI_${HIL_BOARD^^}_PORT
+          if [ -z "${!PORT_VAR}" ]; then
+            echo "Runner environment variable '$PORT_VAR' is not set"
+            exit 1
+          fi
+          esptool.py --port "${!PORT_VAR}" erase_flash
+
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -73,6 +73,9 @@ jobs:
           # Install Pouch dependencies
           pip install -r requirements-ci-esp-idf.txt --require-hashes
 
+          # Enable shorter 10s sync delay for Hil testing
+          export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults"
+
           idf.py -C "${{ matrix.sample.dir }}" set-target "${{ inputs.idf_target }}"
           idf.py -C "${{ matrix.sample.dir }}" build
           idf.py -C "${{ matrix.sample.dir }}" merge-bin -o merged.bin

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Safe upload twister artifacts
         if: success() || failure()
-        uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
+        uses: ./pouch/.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}
           name: twister-run-artifacts-bsim

--- a/examples/esp_idf/http_client/pytest/README.md
+++ b/examples/esp_idf/http_client/pytest/README.md
@@ -24,6 +24,14 @@ uv pip install --python "$IDF_PYTHON_ENV_PATH" -r requirements-ci-esp-idf.txt --
 uv pip install --python "$IDF_PYTHON_ENV_PATH" "golioth@git+https://github.com/golioth/python-golioth-tools@v0.8.1"
 ```
 
+4. Enable the required Golioth pipeline route for stream validation:
+
+   The stream test (`test_sensor_uplink_contains_temp`) expects JSON data
+   sent on `.s/sensor` to be routed into LightDB Stream. Enable the pipeline
+   from this file in your Golioth project before running the test:
+
+   - `examples/esp_idf/http_client/pytest/json-sensor-path-to-lightdb-stream.txt`
+
 ## Build Firmware
 
 From the repository root (`pouch`):

--- a/examples/esp_idf/http_client/pytest/json-sensor-path-to-lightdb-stream.txt
+++ b/examples/esp_idf/http_client/pytest/json-sensor-path-to-lightdb-stream.txt
@@ -1,0 +1,8 @@
+filter:
+  path: "/sensor"
+  content_type: application/json
+steps:
+  - name: send-to-lightdb-stream
+    destination:
+      type: lightdb-stream
+      version: v1


### PR DESCRIPTION
Add a Hardware-in-the-Loop test for the ESP-IDF http_client example that tests stream and settings.

As logs will contain secrets, the safe-upload-artifacts action is used. We don't have access to the golioth-firmware-sdk module for ESP-IDF tests so I copied the action into this repository and updated the underlying action and pinned it.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/986
resolves: https://github.com/golioth/firmware-issue-tracker/issues/974