### PR TITLE
ci: test-reporting: bump to v16 and pin to commit hash

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -60,7 +60,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish Test Report
-        uses: phoenix-actions/test-reporting@v15
+        uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # v16
         if: success() || failure()
         with:
           name: Firmware Test Summary


### PR DESCRIPTION
Updates to Node24 which fixes `Node.js 20 actions are deprecated.` warnings.