### PR TITLE
downlink: drain decrypt work before ending crypto session

### DIFF
--- a/port/freertos/freertos_port_layer.c
+++ b/port/freertos/freertos_port_layer.c
@@ -422,6 +422,32 @@ int pouch_work_submit_to_queue(pouch_work_q_t *queue, pouch_work_t *work)
     return -ENOMEM;
 }
 
+struct work_flush_sync
+{
+    pouch_work_t work;
+    pouch_sem_t sem;
+};
+
+static void work_flush_sentinel_handler(pouch_work_t *work)
+{
+    struct work_flush_sync *sync = CONTAINER_OF(work, struct work_flush_sync, work);
+
+    pouch_sem_give(&sync->sem);
+}
+
+void pouch_work_queue_flush(pouch_work_q_t *queue)
+{
+    struct work_flush_sync sync;
+
+    pouch_work_init(&sync.work, work_flush_sentinel_handler);
+    pouch_sem_init(&sync.sem, 0, 1);
+
+    if (0 == pouch_work_submit_to_queue(queue, &sync.work))
+    {
+        pouch_sem_take(&sync.sem, POUCH_FOREVER);
+    }
+}
+
 /*--------------------------------------------------
  * Delayable Work
  *------------------------------------------------*/

--- a/port/include/pouch/port.h
+++ b/port/include/pouch/port.h
@@ -719,6 +719,21 @@ void pouch_work_queue_start(pouch_work_q_t *queue,
  */
 int pouch_work_submit_to_queue(pouch_work_q_t *queue, pouch_work_t *work);
 
+/**
+ * @brief Flush a work queue
+ *
+ * Blocks the calling thread until every work item pending on the queue at the
+ * time of the call has finished executing. New items submitted while this
+ * function is waiting may or may not have run by the time it returns; the queue
+ * is not guaranteed to be empty on return.
+ *
+ * Must not be called from the work queue's own worker thread, or it would
+ * deadlock.
+ *
+ * @param queue The work queue to flush
+ */
+void pouch_work_queue_flush(pouch_work_q_t *queue);
+
 /*--------------------------------------------------
  * Delayable Work
  *------------------------------------------------*/

--- a/port/zephyr/zephyr_port_layer.c
+++ b/port/zephyr/zephyr_port_layer.c
@@ -269,6 +269,24 @@ int pouch_work_submit_to_queue(pouch_work_q_t *queue, pouch_work_t *work)
     return (0 <= ret) ? 0 : ret;
 }
 
+static void work_flush_sentinel_handler(pouch_work_t *work)
+{
+    ARG_UNUSED(work);
+}
+
+void pouch_work_queue_flush(pouch_work_q_t *queue)
+{
+    pouch_work_t sentinel;
+    struct k_work_sync sync;
+
+    pouch_work_init(&sentinel, work_flush_sentinel_handler);
+
+    if (0 == pouch_work_submit_to_queue(queue, &sentinel))
+    {
+        k_work_flush(&sentinel, &sync);
+    }
+}
+
 /*--------------------------------------------------
  * Delayable Work
  *------------------------------------------------*/

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -241,3 +241,14 @@ void pouch_downlink_finish(void)
     buf_free(encrypted);
     encrypted = NULL;
 }
+
+void pouch_downlink_flush(void)
+{
+    /*
+     * Block until any in-flight decrypt work has completed. The decrypt work
+     * queue is a single FIFO worker and decrypt_blocks() drains its whole buffer
+     * queue per run, so flushing the queue waits for every block pushed so far to
+     * be decrypted.
+     */
+    pouch_work_queue_flush(decrypt.work_queue);
+}

--- a/src/downlink.h
+++ b/src/downlink.h
@@ -10,3 +10,11 @@
 
 /** Initialize the pouch downlink handler */
 int downlink_init(pouch_work_q_t *pouch_work_queue);
+
+/**
+ * Block until all in-flight downlink decryption has completed.
+ *
+ * Must be called before the downlink crypto session is torn down, and never
+ * from the downlink work-queue thread.
+ */
+void pouch_downlink_flush(void);

--- a/src/uplink.c
+++ b/src/uplink.c
@@ -9,6 +9,7 @@
 #include "entry.h"
 #include "stream.h"
 #include "crypto.h"
+#include "downlink.h"
 
 #include <errno.h>
 #include <pouch/uplink.h>
@@ -99,6 +100,12 @@ static void process_blocks(pouch_work_t *work)
 
 static void end_session(void)
 {
+    /*
+     * Wait for any in-flight downlink decryption to finish before destroying
+     * the crypto session: crypto_session_end() destroys the downlink PSA key,
+     * which the async decrypt worker still needs.
+     */
+    pouch_downlink_flush();
     crypto_session_end();
     pouch_atomic_clear_bit(uplink.flags, SESSION_ACTIVE);
     pouch_event_emit(POUCH_EVENT_SESSION_END);


### PR DESCRIPTION
Downlink blocks are decrypted asynchronously on the pouch work queue by
decrypt_blocks(). When a session ends, crypto_session_end() destroys the
downlink PSA key. If decrypt work was still in flight, the worker would use
a destroyed key handle and fail with PSA_ERROR_INVALID_HANDLE (-136).

Drain any in-flight decryption in end_session() before tearing down the
crypto session. end_session() runs on the transport/bearer thread, never on
the pouch work-queue thread, so the drain cannot self-deadlock.

The drain is implemented by flushing the work queue. Add a portable
pouch_work_queue_flush() API. On Zephyr it maps to k_work_queue_drain().
FreeRTOS port submits a sentinel work item to the queue and waits on a
semaphore.