### PR TITLE
examples: zephyr: gateway_custom_connect: scan: initialise tf.addr

### DIFF
--- a/examples/zephyr/gateway_custom_connect/src/scan.c
+++ b/examples/zephyr/gateway_custom_connect/src/scan.c
@@ -96,6 +96,7 @@ static void device_found(const bt_addr_le_t *addr,
 {
     char addr_str[BT_ADDR_LE_STR_LEN];
     struct tf_data tf = {
+        .addr = addr,
         .is_tf = false,
     };
     int err;


### PR DESCRIPTION
bond_filter() compares each bond's address against tf->addr, but the
addr field of the local tf_data struct in device_found() was never
populated. With CONFIG_POUCH_GATEWAY_GATT_SCAN_FILTER_BONDED=y the
memcmp() in bond_filter() reads from a NULL/garbage pointer.

Set tf.addr to the address passed in by the BT scan callback.