### PR TITLE
Transport: http_client: check status codes and cert set response

### DIFF
--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -97,12 +97,8 @@ static esp_err_t pouch_server_cert_response_callback(esp_http_client_event_t *ev
         return ESP_OK;
     }
 
-    ESP_LOGD(TAG, "Received http cert response %d", evt->data_len);
-
-    /* FIXME: Handle event where data is not chunked */
-    if (!esp_http_client_is_chunked_response(evt->client))
+    if (HTTP_EVENT_ON_DATA == evt->event_id)
     {
-
         if (sync->server_cert.pos + evt->data_len > sizeof(sync->server_cert.cert_buf))
         {
             ESP_LOGE(TAG, "Server cert too large for buffer");
@@ -111,7 +107,6 @@ static esp_err_t pouch_server_cert_response_callback(esp_http_client_event_t *ev
 
         memcpy(sync->server_cert.cert_buf + sync->server_cert.pos, evt->data, evt->data_len);
         sync->server_cert.pos += evt->data_len;
-        return ESP_OK;
     }
 
     return ESP_OK;

--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -145,6 +145,19 @@ static int fetch_server_cert(struct sync_context *sync)
         return err;
     }
 
+    int status_code = esp_http_client_get_status_code(sync->client);
+    if (!IN_RANGE(status_code, 200, 299))
+    {
+        ESP_LOGE(TAG, "Server cert HTTP request failed: status=%d", status_code);
+        return -EIO;
+    }
+
+    if (sync->server_cert.pos == 0)
+    {
+        ESP_LOGE(TAG, "Server cert response body is empty");
+        return -ENODATA;
+    }
+
     struct pouch_cert cert = {
         .buffer = sync->server_cert.cert_buf,
         .size = sync->server_cert.pos,
@@ -204,6 +217,13 @@ static int upload_pouch_cert(struct sync_context *sync)
         ESP_LOGE(TAG, "Error performing http request %s", esp_err_to_name(err));
         err = -(esp_http_client_get_errno(sync->client));
         return err;
+    }
+
+    int status_code = esp_http_client_get_status_code(sync->client);
+    if (!IN_RANGE(status_code, 200, 299))
+    {
+        ESP_LOGE(TAG, "Device cert upload failed: status=%d", status_code);
+        return -EIO;
     }
 
     pouch_atomic_set_bit(&sync->flags, POUCH_CERT_UPLOADED_BIT);

--- a/port/zephyr/transport/http/client.c
+++ b/port/zephyr/transport/http/client.c
@@ -95,6 +95,12 @@ static int pouch_server_cert_response_callback(struct http_response *rsp,
 
     int err = 0;
 
+    if (!IN_RANGE(rsp->http_status_code, 200, 299))
+    {
+        LOG_ERR("Failed to fetch server cert: %u", rsp->http_status_code);
+        return -EIO;
+    }
+
     if (false == rsp->body_found)
     {
         LOG_ERR("Failed to find HTTP body");
@@ -118,7 +124,14 @@ static int pouch_server_cert_response_callback(struct http_response *rsp,
             .buffer = ctx->cert_buf,
             .size = ctx->pos,
         };
-        pouch_server_certificate_set(&cert);
+
+        err = pouch_server_certificate_set(&cert);
+        if (0 != err)
+        {
+            LOG_ERR("Failed to set server certificate: %d", err);
+            return err;
+        }
+
         atomic_set_bit(&pouch_cert_flags, SERVER_CERT_DOWNLOADED_BIT);
     }
 


### PR DESCRIPTION
Clean up http_client transport response handling by checking the status code for success, validating the return code from pouch_server_certificate_set(), and using the ESP-IDF http client event system to manage chunked responses.