### PR TITLE
ESP-IDF: HTTP client transport: Use DER for client credentials instead of PEM

### DIFF
--- a/examples/esp_idf/http_client/main/credentials.c
+++ b/examples/esp_idf/http_client/main/credentials.c
@@ -216,7 +216,7 @@ int fill_mtls_credentials(struct mtls_credentials *creds)
     /* Get size including null terminator */
     creds->client_key_pem_len = strlen(device_key_pem) + 1;
 
-    creds->client_key_der = (const char *) cred_get_device_crt_der(&creds->client_key_der_len);
+    creds->client_key_der = (const char *) cred_get_device_key_der(&creds->client_key_der_len);
     if (NULL == creds->client_key_der)
     {
         return -ENOENT;

--- a/examples/esp_idf/http_client/main/credentials.c
+++ b/examples/esp_idf/http_client/main/credentials.c
@@ -108,85 +108,6 @@ int fill_pouch_config(struct pouch_config *config)
     return 0;
 }
 
-/* Buffer and function to convert device key der to pem */
-/* This can be removed after ESP-IDF v6 (includes der support for HTTP client) */
-static char device_crt_pem[768];
-
-static int convert_device_pk_der_to_pem(char *pem_buf, size_t pem_buf_len)
-{
-    psa_crypto_init();
-    mbedtls_pk_context pk;
-    mbedtls_pk_init(&pk);
-
-    struct pouch_cert key_der;
-    key_der.buffer = cred_get_device_key_der(&key_der.size);
-    if (NULL == key_der.buffer)
-    {
-        return -ENOENT;
-    }
-
-    int err = mbedtls_pk_parse_key(&pk, (unsigned char *) key_der.buffer, key_der.size, NULL, 0);
-
-    if (0 != err)
-    {
-        ESP_LOGE(TAG, "Failed to parse device.key.der: %d", err);
-        return err;
-    }
-
-    err = mbedtls_pk_write_key_pem(&pk, (unsigned char *) pem_buf, pem_buf_len);
-    if (0 != err)
-    {
-        ESP_LOGE(TAG, "Failed to convert device.key.der to PEM: %d", err);
-        return err;
-    }
-
-    mbedtls_pk_free(&pk);
-
-    return 0;
-}
-
-/* Buffer and function to convert device crt der to pem */
-/* This can be removed after ESP-IDF v6 (includes der support for HTTP client) */
-static char device_key_pem[310];
-
-static int convert_device_cert_der_to_pem(char *pem_buf, size_t pem_buf_len)
-{
-    psa_crypto_init();
-    mbedtls_x509_crt crt;
-    mbedtls_x509_crt_init(&crt);
-
-    struct pouch_cert crt_der;
-    if (0 != get_device_cert(&crt_der))
-    {
-        ESP_LOGE(TAG, "Failed to load device cert");
-        return -ENOENT;
-    }
-
-    int err = mbedtls_x509_crt_parse_der(&crt, (unsigned char *) crt_der.buffer, crt_der.size);
-    if (0 != err)
-    {
-        ESP_LOGE(TAG, "Failed to parse device.crt.der: %d", err);
-        return err;
-    }
-
-    size_t pem_written = 0;
-    err = mbedtls_pem_write_buffer("-----BEGIN CERTIFICATE-----\n",
-                                   "-----END CERTIFICATE-----\n",
-                                   crt.raw.p,
-                                   crt.raw.len,
-                                   (unsigned char *) pem_buf,
-                                   pem_buf_len,
-                                   &pem_written);
-    if (0 != err)
-    {
-        ESP_LOGE(TAG, "Failed to convert device.crt.der to PEM: %d", err);
-        return err;
-    }
-
-    mbedtls_x509_crt_free(&crt);
-    return 0;
-}
-
 int fill_mtls_credentials(struct mtls_credentials *creds)
 {
     creds->cert_pem = server_ca_cert_pem_start;
@@ -205,32 +126,11 @@ int fill_mtls_credentials(struct mtls_credentials *creds)
         return err;
     }
 
-    /* NOTE: DER support in ESP-IDF HTTP Client wasn't added until v6 */
-    /* Device DER files need to be converted to PEM */
-    err = convert_device_pk_der_to_pem(device_key_pem, sizeof(device_key_pem));
-    if (0 != err)
-    {
-        return err;
-    }
-    creds->client_key_pem = device_key_pem;
-    /* Get size including null terminator */
-    creds->client_key_pem_len = strlen(device_key_pem) + 1;
-
     creds->client_key_der = (const char *) cred_get_device_key_der(&creds->client_key_der_len);
     if (NULL == creds->client_key_der)
     {
         return -ENOENT;
     }
-
-    err = convert_device_cert_der_to_pem(device_crt_pem, sizeof(device_crt_pem));
-    if (0 != err)
-    {
-        ESP_LOGE(TAG, "Failed to load device key");
-        return err;
-    }
-    creds->client_cert_pem = device_crt_pem;
-    /* Get size including null terminator */
-    creds->client_cert_pem_len = strlen(device_crt_pem) + 1;
 
     creds->client_cert_der = (const char *) cred_get_device_crt_der(&creds->client_cert_der_len);
     if (NULL == creds->client_cert_der)

--- a/port/esp_idf/include/pouch/transport/http/client.h
+++ b/port/esp_idf/include/pouch/transport/http/client.h
@@ -12,12 +12,8 @@ struct mtls_credentials
 {
     const char *cert_pem;
     size_t cert_pem_len;
-    const char *client_cert_pem;
-    size_t client_cert_pem_len;
     const char *client_cert_der;
     size_t client_cert_der_len;
-    const char *client_key_pem;
-    size_t client_key_pem_len;
     const char *client_key_der;
     size_t client_key_der_len;
 };

--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -7,6 +7,7 @@
 #include <esp_log.h>
 #define TAG "http_client"
 
+#include <assert.h>
 #include <errno.h>
 #include <esp_http_client.h>
 #include <esp_tls.h>
@@ -442,6 +443,17 @@ esp_err_t event_handler_proxy(esp_http_client_event_t *evt)
 
 esp_http_client_handle_t client_initialize(struct sync_context *sync)
 {
+    /* .client_key_pem is a very bad name for the esp_http_client_config_t. As long as a non-zero
+     * length is passed to .client_key_len, a pointer to a DER formatted key may be passed to
+     * .client_key_pem.
+     * https://github.com/espressif/esp-idf/blob/v6.0.1/components/esp_http_client/esp_http_client.c#L956-L962
+     *
+     * The same is true for .client_cert_pem, but a union adds the .client_key_der member:
+     * https://github.com/espressif/esp-idf/blob/v6.0.1/components/esp_http_client/include/esp_http_client.h#L196
+     */
+    assert(sync->mtls_creds->client_cert_der_len > 0);
+    assert(sync->mtls_creds->client_key_der_len > 0);
+
     esp_http_client_config_t config = {
         .path = HTTP_PATH_POUCH,
         .host = CONFIG_POUCH_HTTP_GW_URI,
@@ -450,10 +462,10 @@ esp_http_client_handle_t client_initialize(struct sync_context *sync)
         .event_handler = event_handler_proxy,
         .cert_pem = sync->mtls_creds->cert_pem,
         .cert_len = sync->mtls_creds->cert_pem_len,
-        .client_cert_pem = sync->mtls_creds->client_cert_pem,
-        .client_cert_len = sync->mtls_creds->client_cert_pem_len,
-        .client_key_pem = sync->mtls_creds->client_key_pem,
-        .client_key_len = sync->mtls_creds->client_key_pem_len,
+        .client_cert_der = sync->mtls_creds->client_cert_der,
+        .client_cert_len = sync->mtls_creds->client_cert_der_len,
+        .client_key_pem = sync->mtls_creds->client_key_der,
+        .client_key_len = sync->mtls_creds->client_key_der_len,
         .timeout_ms = HTTP_TIMEOUT_MS,
         .user_data = sync,
     };


### PR DESCRIPTION
The original implementation used PEM formatting for the client certificate and key with an eye toward ESP-IDF v6 which added support for DER format. This PR makes that change, simplifying the credentials handling.

When working on this I discovered that DER format handling is not new, it is just (still) not documented and the configuration struct members are poorly worded.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/972