### PR TITLE
CI: update actions and ensure all are pinned to hashes

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Gather summaries
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Gather summaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: summary
           pattern: ci-summary-*

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -45,7 +45,7 @@ jobs:
             --form version="0" \
             --form description="Description" \
             https://scan.coverity.com/builds?project=golioth%2Fpouch
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverity_output
           path: pouch.tgz

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
     container: golioth/golioth-coverity-base:89df175
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: pouch
       - name: Init and update west

--- a/.github/workflows/gateway-release.yml
+++ b/.github/workflows/gateway-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Fetch depth must be greater than the number of commits included in the push in order to
           # compare against commit prior to merge. 15 is chosen as a reasonable default for the
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Fetch depth must be greater than the number of commits included in the push in order to
           # compare against commit prior to merge. 15 is chosen as a reasonable default for the

--- a/.github/workflows/test-build-esp-idf.yml
+++ b/.github/workflows/test-build-esp-idf.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build esp32s3
         uses: espressif/esp-idf-ci-action@e6f5c74232b1ccd4c97ed641f1e48553853f1fd5 # v1.2.0
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 

--- a/.github/workflows/test-build-gateway.yml
+++ b/.github/workflows/test-build-gateway.yml
@@ -101,7 +101,7 @@ jobs:
           echo "ARTIFACT_TARGET=${TARGET//\//-}${SUFFIX}" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.app }}-${{ steps.build.outputs.ARTIFACT_TARGET }}
           path: |

--- a/.github/workflows/test-build-gateway.yml
+++ b/.github/workflows/test-build-gateway.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: pouch
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: pouch
 

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -93,7 +93,7 @@ jobs:
           tar -cf build-artifacts.tar "${artifact_files[@]}"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: esp-idf-${{ matrix.sample.name }}-${{ inputs.idf_target }}-build
           path: ${{ matrix.sample.dir }}/build-artifacts.tar

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -144,7 +144,7 @@ jobs:
           rm -f "$UNITY_REPORT_NAME" "pytest-${{ matrix.sample.name }}-hil.log"
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: esp-idf-${{ matrix.sample.name }}-${{ inputs.idf_target }}-build
           path: esp-idf-${{ matrix.sample.name }}

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -62,7 +62,7 @@ jobs:
     container: espressif/idf@sha256:efc19fae2f52fc6873630c668da26aa834139a063b5fb73a46ebc0dbd217b587
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 

--- a/.github/workflows/test-esp-idf.yml
+++ b/.github/workflows/test-esp-idf.yml
@@ -70,7 +70,7 @@ jobs:
           ./junit_post_process.py ${UNITY_REPORT_NAME}
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: ci-summary-integration-esp-idf-unit-tests

--- a/.github/workflows/test-esp-idf.yml
+++ b/.github/workflows/test-esp-idf.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: pouch
 

--- a/.github/workflows/test-twister.yml
+++ b/.github/workflows/test-twister.yml
@@ -51,7 +51,7 @@ jobs:
              twister-out/integration-${{ matrix.manifest_yml }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: ci-summary-integration-${{ matrix.manifest_yml }}

--- a/.github/workflows/test-twister.yml
+++ b/.github/workflows/test-twister.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: pouch
 


### PR DESCRIPTION
We were getting deprecation warnings for older version of actions/checkout. I resolved them by updating to the latest release and used this as a chance to audit all of our actions, updating to latest and pinning to a hash.