### PR TITLE
ci: bump Docker images

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   coverity:
     runs-on: ubuntu-24.04
-    container: golioth/golioth-coverity-base:89df175
+    container: golioth/golioth-coverity-base:ed52d4f
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -31,7 +31,7 @@ jobs:
       - name: Coverity build
         run: |
           /opt/toolchains/coverity/bin/cov-configure --comptype gcc \
-            --compiler /opt/toolchains/zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
+            --compiler /opt/toolchains/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
           /opt/toolchains/coverity/bin/cov-build --dir cov-int \
             west build -p -b nrf52840dk/nrf52840 pouch/examples/zephyr/ble_gatt \
             -- -DCONFIG_LOG=n

--- a/.github/workflows/test-build-gateway.yml
+++ b/.github/workflows/test-build-gateway.yml
@@ -48,9 +48,9 @@ jobs:
             target: mg100
             app: gateway
             sysbuild: true
-    container: golioth/golioth-zephyr-base:0.17.0-SDK-v0
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    container: golioth/golioth-zephyr-base:0.17.0-SDK-v0
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
     strategy:
       matrix:
         include:
@@ -25,7 +25,7 @@ jobs:
             no_sysbuild: true
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -115,7 +115,7 @@ jobs:
       - has_${{ inputs.hil_board }}
 
     container:
-      image: golioth/golioth-hil-base:bda7b71
+      image: golioth/golioth-hil-base:ed52d4f
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -42,9 +42,9 @@ on:
 
 jobs:
   nsim:
-    container: golioth/golioth-zephyr-base:0.17.0-SDK-v0
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-twister.yml
+++ b/.github/workflows/test-twister.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   twister:
-    container: golioth/golioth-zephyr-base:0.17.0-SDK-v0
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
     strategy:
       matrix:
         manifest_yml:
@@ -14,7 +14,7 @@ jobs:
           - west-ncs
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Bump to the latest published Docker images.

* golioth-zephyr-base:    0.17.0-SDK-v0 -> 0.17.4-SDK-v0
* golioth-hil-base:       bda7b71       -> ed52d4f
* golioth-coverity-base:  89df175       -> ed52d4f

Also bump the ZEPHYR_SDK_INSTALL_DIR env var and the hardcoded SDK toolchain path in the coverity workflow to match the new SDK version.