### PR TITLE
zephyr: remove duplicate Kconfig rsource

### DIFF
--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -133,8 +133,5 @@ endif
 # Gateway
 rsource "../../src/gateway/Kconfig"
 
-# Libraries
+# SDK
 rsource "../../Kconfig"
-
-# Golioth SDK
-rsource "../../golioth_sdk/Kconfig"


### PR DESCRIPTION
The root Kconfig file was updated to rsource golioth_sdk/Kconfig. Remove explicit rsource of the SDK Kconfig file in port/zephyr/Kconfig and update comment to indicate the root file is used to import SDK.