### PR TITLE
pytest: adapt to Zephyr 4.4 API

### DIFF
--- a/examples/zephyr/gateway/pytest/conftest.py
+++ b/examples/zephyr/gateway/pytest/conftest.py
@@ -21,6 +21,7 @@ pytest_plugins = ["pytest_pouch.plugin"]
 import pytest  # noqa: E402
 
 from twister_harness.device.device_adapter import DeviceAdapter  # noqa: E402
+from twister_harness.twister_harness_config import TwisterHarnessConfig  # noqa: E402
 
 
 def pytest_addoption(parser):
@@ -92,10 +93,10 @@ async def dut(
 
 
 @pytest.fixture(scope="module")
-def creds_dir(request: pytest.FixtureRequest):
+def creds_dir(twister_harness_config: TwisterHarnessConfig):
     """Override default creds_dir for gateway sysbuild layout."""
     return (
-        Path(request.config.option.build_dir)
+        twister_harness_config.devices[0].build_dir
         / "peripheral_ble_gatt_example_0"
         / "creds"
     )

--- a/examples/zephyr/gateway/pytest/test_sample.py
+++ b/examples/zephyr/gateway/pytest/test_sample.py
@@ -13,15 +13,15 @@ pytestmark = pytest.mark.anyio
 
 
 async def test_setting_project(dut: DeviceAdapter):
-    dut.readlines_until("Bluetooth initialized")
+    dut.readlines_until(regex="Bluetooth initialized")
 
-    dut.readlines_until("Starting downlink")
+    dut.readlines_until(regex="Starting downlink")
 
-    dut.readlines_until("Received LED setting: 0")
+    dut.readlines_until(regex="Received LED setting: 0")
 
 
 async def test_setting_device(device, dut: DeviceAdapter):
     logging.info("Set device-level setting")
     await device.settings.set("LED", True)
 
-    dut.readlines_until("Received LED setting: 1")
+    dut.readlines_until(regex="Received LED setting: 1")

--- a/examples/zephyr/pytest/test_ota.py
+++ b/examples/zephyr/pytest/test_ota.py
@@ -17,7 +17,7 @@ async def test_ota_sha256(dut: DeviceAdapter, ota_firmware):
     expected_sha256 = ota_firmware
 
     logging.info("Waiting for device to boot and load credentials")
-    dut.readlines_until("Credentials loaded", timeout=60.0)
+    dut.readlines_until(regex="Credentials loaded", timeout=60.0)
 
     logging.info("Waiting for OTA download, expected SHA256=%s", expected_sha256)
     lines = dut.readlines_until(

--- a/examples/zephyr/pytest/test_sample.py
+++ b/examples/zephyr/pytest/test_sample.py
@@ -13,12 +13,12 @@ pytestmark = pytest.mark.anyio
 
 
 async def test_setting_project(dut: DeviceAdapter):
-    dut.readlines_until("Credentials loaded", timeout=60.0)
-    dut.readlines_until("Received LED setting: 0", timeout=120.0)
+    dut.readlines_until(regex="Credentials loaded", timeout=60.0)
+    dut.readlines_until(regex="Received LED setting: 0", timeout=120.0)
 
 
 async def test_setting_device(device, dut: DeviceAdapter):
     logging.info("Set device-level setting")
     await device.settings.set("LED", True)
 
-    dut.readlines_until("Received LED setting: 1", timeout=120.0)
+    dut.readlines_until(regex="Received LED setting: 1", timeout=120.0)

--- a/scripts/pytest-pouch/pytest_pouch/plugin.py
+++ b/scripts/pytest-pouch/pytest_pouch/plugin.py
@@ -5,8 +5,8 @@
 #
 
 import logging
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -41,7 +41,11 @@ def creds_dir(request: pytest.FixtureRequest):
 
     Override this fixture in a local conftest.py to change the path.
     """
-    return Path(request.config.option.build_dir) / "creds"
+    try:
+        harness = request.getfixturevalue("twister_harness_config")
+        return harness.devices[0].build_dir / "creds"
+    except (pytest.FixtureLookupError, ImportError):
+        return Path(request.config.option.build_dir) / "creds"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Adapt implementation to be compatible with Zephyr 4.4 twister API.