### PR TITLE
boards: add full_name to board metadata

### DIFF
--- a/boards/bsim_2G4_phy/board.yml
+++ b/boards/bsim_2G4_phy/board.yml
@@ -1,5 +1,6 @@
 boards:
 - name: bsim_2G4_phy
+  full_name: BabbleSim 2.4 GHz Physical Layer
   vendor: zephyr
   socs:
   - name: native

--- a/boards/bsim_device/board.yml
+++ b/boards/bsim_device/board.yml
@@ -1,5 +1,6 @@
 boards:
   - name: bsim_device
+    full_name: BabbleSim Arbitrary Device
     vendor: zephyr
     socs:
       - name: native


### PR DESCRIPTION
Zephyr 4.4 tightened the board schema (board-schema.yaml): a board defined
by "name" must now also provide "full_name". Add it to the custom bsim
boards so twister can load them.