### PR TITLE
downlink: free stored encrypted_block after buf_alloc returns NULL

### DIFF
--- a/src/downlink.c
+++ b/src/downlink.c
@@ -207,6 +207,7 @@ int pouch_downlink_push(const void *buf, size_t buf_len)
                 if (!encrypted)
                 {
                     POUCH_LOG_ERR("Failed to allocate pouch buf");
+                    buf_free(encrypted_block);
                     return -ENOMEM;
                 }
 


### PR DESCRIPTION
avoid memory leak by freeing stored encrypted_block pointer before returning from new buffer allocation failure.