### PR TITLE
ESP-IDF: use static queue for blockbuf

### DIFF
--- a/port/esp_idf/blockbuf.c
+++ b/port/esp_idf/blockbuf.c
@@ -4,12 +4,46 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <pouch/blockbuf.h>
+#include <pouch/port.h>
 #include "../../src/block.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+
+#define BLOCKBUF_ALIGN 4
+#define BLOCKBUF_BLOCK_SIZE \
+    ROUND_UP((POUCH_BUF_OVERHEAD + MAX_PLAINTEXT_BLOCK_SIZE), BLOCKBUF_ALIGN)
+
+static struct pouch_buf *_blockbuf_pool[CONFIG_POUCH_BLOCK_COUNT];
+static uint8_t _blockbuf_storage[CONFIG_POUCH_BLOCK_COUNT][BLOCKBUF_BLOCK_SIZE]
+    __attribute__((aligned(BLOCKBUF_ALIGN)));
+
+static StaticQueue_t _blockbuf_queue_buf;
+static QueueHandle_t _blockbuf_queue_handle;
+
+static void blockbuf_init(void)
+{
+    _blockbuf_queue_handle = xQueueCreateStatic(CONFIG_POUCH_BLOCK_COUNT,
+                                                sizeof(struct pouch_buf *),
+                                                (uint8_t *) _blockbuf_pool,
+                                                &_blockbuf_queue_buf);
+    configASSERT(_blockbuf_queue_handle != NULL);
+
+    for (int i = 0; i < CONFIG_POUCH_BLOCK_COUNT; i++)
+    {
+        struct pouch_buf *buf = (struct pouch_buf *) _blockbuf_storage[i];
+        BaseType_t err = xQueueSend(_blockbuf_queue_handle, &buf, 0);
+        configASSERT(err == pdPASS);
+    }
+}
+POUCH_APPLICATION_STARTUP_HOOK(blockbuf_init);
 
 struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout)
 {
-    struct pouch_buf *buf = malloc(POUCH_BUF_OVERHEAD + MAX_PLAINTEXT_BLOCK_SIZE);
-    if (buf == NULL)
+    struct pouch_buf *buf = NULL;
+
+    if (pdTRUE
+        != xQueueReceive(_blockbuf_queue_handle, &buf, pouch_timeout_to_freertos_ticks(timeout)))
     {
         return NULL;
     }
@@ -20,5 +54,12 @@ struct pouch_buf *blockbuf_alloc(pouch_timeout_t timeout)
 
 void blockbuf_free(struct pouch_buf *buf)
 {
-    free(buf);
+    if (buf == NULL)
+    {
+        return;
+    }
+
+    BaseType_t err = xQueueSend(_blockbuf_queue_handle, &buf, 0);
+    /* This can only return errQUEUE_FULL which should never happen */
+    configASSERT(pdPASS == err);
 }

--- a/port/freertos/freertos_port_layer.c
+++ b/port/freertos/freertos_port_layer.c
@@ -159,14 +159,14 @@ void pouch_put_be16(uint16_t val, uint8_t dst[2])
  * Time
  *------------------------------------------------*/
 
-static int32_t get_ticks(pouch_timeout_t timeout)
+int32_t pouch_timeout_to_freertos_ticks(int32_t pouch_timeout)
 {
-    if (timeout > 0)
+    if (pouch_timeout > 0)
     {
-        return pdMS_TO_TICKS(timeout);
+        return pdMS_TO_TICKS(pouch_timeout);
     }
 
-    if (0 == timeout)
+    if (0 == pouch_timeout)
     {
         return 0;
     }
@@ -267,14 +267,14 @@ void pouch_msgq_init(pouch_msgq_t *msgq,
 
 int pouch_msgq_put(pouch_msgq_t *msgq, const void *data, pouch_timeout_t timeout)
 {
-    bool result = xQueueSend(msgq->xQueue, data, get_ticks(timeout));
+    bool result = xQueueSend(msgq->xQueue, data, pouch_timeout_to_freertos_ticks(timeout));
 
     return (pdPASS == result) ? 0 : -EAGAIN;
 }
 
 int pouch_msgq_get(pouch_msgq_t *msgq, void *buf, pouch_timeout_t timeout)
 {
-    bool result = xQueueReceive(msgq->xQueue, buf, get_ticks(timeout));
+    bool result = xQueueReceive(msgq->xQueue, buf, pouch_timeout_to_freertos_ticks(timeout));
 
     return (pdPASS == result) ? 0 : -ENOMSG;
 }
@@ -303,7 +303,7 @@ void pouch_mutex_init(pouch_mutex_t *mutex)
 
 bool pouch_mutex_lock(pouch_mutex_t *mutex, pouch_timeout_t timeout)
 {
-    return xSemaphoreTake(*mutex, get_ticks(timeout));
+    return xSemaphoreTake(*mutex, pouch_timeout_to_freertos_ticks(timeout));
 }
 
 bool pouch_mutex_unlock(pouch_mutex_t *mutex)

--- a/port/freertos/freertos_port_layer.h
+++ b/port/freertos/freertos_port_layer.h
@@ -86,6 +86,12 @@ typedef struct freertos_sem pouch_sem_internal_t;
     }                                                               \
     POUCH_APPLICATION_STARTUP_HOOK(static_semaphore_init_##name)
 
+/*------------------------------------------------
+ * Time
+ *------------------------------------------------*/
+
+int32_t pouch_timeout_to_freertos_ticks(int32_t pouch_timeout);
+
 /*--------------------------------------------------
  * Work Queue
  *------------------------------------------------*/

--- a/port/include/pouch/port.h
+++ b/port/include/pouch/port.h
@@ -20,6 +20,11 @@
 #define __ASSERT_NO_MSG(condition) configASSERT(condition)
 #endif
 
+#ifndef ROUND_UP
+#define ROUND_UP(x, align) \
+    (((unsigned long) (x) + ((unsigned long) align - 1)) & ~((unsigned long) align - 1))
+#endif
+
 #ifndef DIV_ROUND_UP
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
 #endif


### PR DESCRIPTION
Move from using dynamic allocation in blockbuf.c to using static allocation based on FreeRTOS queues. This maps well to the memory slabs used in the Zephyr implementation.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/960