### PR TITLE
ci: bump Golioth Docker images to latest

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   coverity:
     runs-on: ubuntu-24.04
-    container: golioth/golioth-coverity-base:bda7b71@sha256:fa0cbe0e64a8b3a81a0899e2e57284e661e5ddeef7dac500a22be035c5b21361
+    container: golioth/golioth-coverity-base:sdk-0.17.4
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/test-build-gateway.yml
+++ b/.github/workflows/test-build-gateway.yml
@@ -52,8 +52,7 @@ jobs:
             target: mg100
             app: gateway
             sysbuild: true
-    # yamllint disable-line rule:line-length
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+    container: golioth/golioth-zephyr-base:sdk-0.17.4
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   build-zephyr:
-    # yamllint disable-line rule:line-length
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+    container: golioth/golioth-zephyr-base:sdk-0.17.4
     strategy:
       matrix:
         include:

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -117,8 +117,7 @@ jobs:
       - has_${{ inputs.hil_board }}
 
     container:
-      # yamllint disable-line rule:line-length
-      image: golioth/golioth-hil-base:ed52d4f@sha256:3a1682e2ffd33fad5c01a664e98e21fe5f56abbeebb9a063a38b81dd32b9e546
+      image: golioth/golioth-hil-base:latest
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -46,8 +46,7 @@ permissions:
 
 jobs:
   nsim:
-    # yamllint disable-line rule:line-length
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+    container: golioth/golioth-zephyr-base:sdk-0.17.4
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-twister.yml
+++ b/.github/workflows/test-twister.yml
@@ -10,8 +10,7 @@ permissions:
 
 jobs:
   twister:
-    # yamllint disable-line rule:line-length
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+    container: golioth/golioth-zephyr-base:sdk-0.17.4
     strategy:
       matrix:
         manifest_yml:


### PR DESCRIPTION
Use floating tags for Docker images:
 * coverity/zephyr: sdk-0.17.4 (which is built around Zephyr SDK 0.17.4)
 * hil: latest (it does not contain Zephyr SDK)

This will allow to always use newest versions of Docker images and pull all
the improvements introduced there automatically.