### PR TITLE
esp-idf: http_client: clear post data before chunk upload

### DIFF
--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -371,6 +371,7 @@ static int send_pouch_uplink(struct sync_context *sync)
     esp_http_client_set_url(sync->client, (char *) sync->url_buf);
     esp_http_client_set_method(sync->client, HTTP_METHOD_POST);
     esp_http_client_set_header(sync->client, "Content-Type", "application/octet-stream");
+    esp_http_client_set_post_field(sync->client, NULL, 0);
 
     err = esp_http_client_open(sync->client, -1);
     if (0 > err)


### PR DESCRIPTION
The post data pointer in the http_client config must be set to NULL before staring a chunked upload.

This step is necessary because we are reusing the configuration from certificate upload to uplink. The post pointer will still be set when uplink runs. This is not an issue with v6.0.1 of ESP-IDF, but a change in v6.0.2 tries to send the post data as part of the chunked upload. While this behavior change could be considered an upstream bug, we should have always been setting the post pointer to NULL for chunked uploads which do not use the build-in post mechanism.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/1024