### PR TITLE
Add zcbor build dependencies to CMake

### DIFF
--- a/port/esp_idf/CMakeLists.txt
+++ b/port/esp_idf/CMakeLists.txt
@@ -110,8 +110,22 @@ if(_pouch_selected)
     # Transports
     add_subdirectory(${POUCH_PORT}/esp_idf/transport transport)
 
-    # Zcbor library (via submodule)
+    # Check for zcbor python package
     if(NOT CMAKE_BUILD_EARLY_EXPANSION)
         add_subdirectory(${POUCH_PORT}/esp_idf/lib/zcbor zcbor)
+
+        # Check that the zcbor Python package is available
+        idf_build_get_property(_pouch_python PYTHON)
+        execute_process(
+            COMMAND ${_pouch_python} -c "import zcbor"
+            RESULT_VARIABLE _pouch_zcbor_check
+            OUTPUT_QUIET ERROR_QUIET)
+        if(_pouch_zcbor_check)
+            get_filename_component(_pouch_requirements_txt "${POUCH_ROOT}/requirements.txt" ABSOLUTE)
+            message(FATAL_ERROR
+                "\n\nThe 'zcbor' Python package is required by pouch but was not found.\n"
+                "Install it with:\n"
+                "  pip install -r ${_pouch_requirements_txt}\n\n")
+        endif()
     endif()
 endif()

--- a/port/zephyr/CMakeLists.txt
+++ b/port/zephyr/CMakeLists.txt
@@ -43,6 +43,19 @@ if(CONFIG_POUCH)
     set(POUCH_ACTIVE_TARGET ${ZEPHYR_CURRENT_LIBRARY})
     set(POUCH_ACTIVE_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
+    # Check for zcbor python package
+    execute_process(
+        COMMAND ${PYTHON_EXECUTABLE} -c "import zcbor"
+        RESULT_VARIABLE _pouch_zcbor_check
+        OUTPUT_QUIET ERROR_QUIET)
+    if(_pouch_zcbor_check)
+        get_filename_component(_pouch_requirements_txt "${POUCH_ROOT}/requirements.txt" ABSOLUTE)
+        message(FATAL_ERROR
+            "\n\nThe 'zcbor' Python package is required by pouch but was not found.\n"
+            "Install it with:\n"
+            "  pip install -r ${_pouch_requirements_txt}\n\n")
+    endif()
+
     zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/blockbuf.c)
 
     zephyr_library_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)


### PR DESCRIPTION
If the zcbor python package is not installed at build time the cddl generation fails and the build ends in error. The error message is not particularly easy to understand, and further complicated because we also have a dependency on the ZCBOR library/module which is different from the python package.

This PR adds build-time checks to both ESP-IDF and Zephyr, including instructions on how to install the requirement.txt with the correct path already in place. This is clinch for external projects that install pouch as a component/module as it would otherwise be difficult for the user to locate the file.

Zephyr already has support for installing our requirements through the `west pip` command, but ESP-IDF does not. Either way, having this hint in the error message of what otherwise would be a failing build is a quality of life improvement.

## Before

ESP-IDF as an external component:
```
-- Build files have been written to: /home/mike/canonical-compile/pouch_espidf_standalone/build
Executing action: all (aliases: build)
Running ninja in directory /home/mike/canonical-compile/pouch_espidf_standalone/build
Executing "ninja all"...
[1/863] Generating ../header_decode.c, ../header_encode.c
FAILED: [code=127] esp-idf/pouch/header_decode.c esp-idf/pouch/header_encode.c esp-idf/pouch/include/cddl/header_decode.h esp-idf/pouch/include/cddl/header_encode.h esp-idf/pouch/include/cddl/header_types.h /home/mike/canonical-compile/pouch_espidf_standalone/build/esp-idf/pouch/header_decode.c /home/mike/canonical-compile/pouch_espidf_standalone/build/esp-idf/pouch/header_encode.c /home/mike/canonical-compile/pouch_espidf_standalone/build/esp-idf/pouch/include/cddl/header_decode.h /home/mike/canonical-compile/pouch_espidf_standalone/build/esp-idf/pouch/include/cddl/header_encode.h /home/mike/canonical-compile/pouch_espidf_standalone/build/esp-idf/pouch/include/cddl/header_types.h
cd /home/mike/canonical-compile/pouch_espidf_standalone/build/esp-idf/pouch && zcbor code -c /home/mike/canonical-compile/pouch_espidf_standalone/managed_components/pouch/src/header.cddl -t pouch_header -sde --include-prefix cddl/ --oc header.c --oh include/cddl/header.h
/bin/sh: line 1: zcbor: command not found
[5/863] Generating ../../partition_table/partition-table.bin
Partition table binary generated. Contents:
*******************************************************************************
# ESP-IDF Partition Table
# Name, Type, SubType, Offset, Size, Flags
nvs,data,nvs,0x9000,24K,
phy_init,data,phy,0xf000,4K,
factory,app,factory,0x10000,1M,
*******************************************************************************
ninja: build stopped: subcommand failed.
ninja failed with exit code 127, output of the command is in the /home/mike/canonical-compile/pouch_espidf_standalone/build/log/idf_py_stderr_output_2349672 and /home/mike/canonical-compile/pouch_espidf_standalone/build/log/idf_py_stdout_output_2349672
```

## After

Zephyr
```
Kconfig header saved to '/home/mike/canonical-compile/pouch-workspace/pouch/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /home/mike/zephyr-sdk-0.17.2/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd (found version "2.38")
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/mike/zephyr-sdk-0.17.2/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
CMake Error at /home/mike/canonical-compile/pouch-workspace/pouch/port/zephyr/CMakeLists.txt:53 (message):




  The 'zcbor' Python package is required by pouch but was not found.

  Install it with:

    pip install -r /home/mike/canonical-compile/pouch-workspace/pouch/requirements.txt



Call Stack (most recent call first):
  /home/mike/canonical-compile/pouch-workspace/pouch/CMakeLists.txt:18 (include)

```

ESP-IDF (shown as a component of an external project; see the path):
```
-- Adding binary ca_cert: /home/mike/canonical-compile/pouch_espidf_standalone/managed_components/pouch/src/goliothrootx1.der
CMake Error at managed_components/pouch/port/esp_idf/CMakeLists.txt:125 (message):




  The 'zcbor' Python package is required by pouch but was not found.

  Install it with:

    pip install -r /home/mike/canonical-compile/pouch_espidf_standalone/managed_components/pouch/requirements.txt



Call Stack (most recent call first):
  managed_components/pouch/CMakeLists.txt:10 (include)
```

resolves: https://github.com/golioth/firmware-issue-tracker/issues/1023