### PR TITLE
CI: pin workflows and contianers to sha and assign write permissions

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -22,18 +26,30 @@ jobs:
     secrets: inherit
   trigger-build-gateway:
     name: Run Gateway Build
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/test-build-gateway.yml
     secrets: inherit
   trigger-twister:
     name: Run Twister
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/test-twister.yml
     secrets: inherit
   trigger-esp-idf:
     name: Run ESP-IDF Unit Test
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/test-esp-idf.yml
     secrets: inherit
   trigger-esp-idf-hil:
     name: Run ESP-IDF HTTP Client HIL
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/test-esp-idf-hil.yml
     with:
       hil_board: esp32s3_devkitc
@@ -43,6 +59,9 @@ jobs:
     secrets: inherit
   trigger-nsim:
     name: Run Native Simulator and BabbleSim Tests
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/test-nsim.yml
     with:
       api_url: "https://api.golioth.io"

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,6 +6,10 @@ on:
     - cron: "00 0 * * 0"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   coverity:
     runs-on: ubuntu-24.04

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   coverity:
     runs-on: ubuntu-24.04
-    container: golioth/golioth-coverity-base:ed52d4f
+    container: golioth/golioth-coverity-base:bda7b71@sha256:fa0cbe0e64a8b3a81a0899e2e57284e661e5ddeef7dac500a22be035c5b21361
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/gateway-release.yml
+++ b/.github/workflows/gateway-release.yml
@@ -6,10 +6,14 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/test-build-gateway.yml
 
   release:

--- a/.github/workflows/gateway-release.yml
+++ b/.github/workflows/gateway-release.yml
@@ -64,7 +64,7 @@ jobs:
           ls release/*.hex
 
       - name: Upload release artifacts
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: |
             release/*.elf

--- a/.github/workflows/test-build-gateway.yml
+++ b/.github/workflows/test-build-gateway.yml
@@ -48,7 +48,8 @@ jobs:
             target: mg100
             app: gateway
             sysbuild: true
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+    # yamllint disable-line rule:line-length
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-build-gateway.yml
+++ b/.github/workflows/test-build-gateway.yml
@@ -4,6 +4,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   build-zephyr:
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+    # yamllint disable-line rule:line-length
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     strategy:
       matrix:
         include:

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -54,6 +54,7 @@ jobs:
   build:
     permissions:
       contents: read
+      actions: write
     runs-on: ubuntu-24.04
     needs: prepare-matrix
     strategy:
@@ -101,6 +102,7 @@ jobs:
   hil-test:
     permissions:
       contents: read
+      actions: write
 
     needs:
       - prepare-matrix

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -115,7 +115,8 @@ jobs:
       - has_${{ inputs.hil_board }}
 
     container:
-      image: golioth/golioth-hil-base:ed52d4f
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-hil-base:ed52d4f@sha256:3a1682e2ffd33fad5c01a664e98e21fe5f56abbeebb9a063a38b81dd32b9e546
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/test-esp-idf.yml
+++ b/.github/workflows/test-esp-idf.yml
@@ -8,6 +8,7 @@ jobs:
   unit-tests:
     permissions:
       contents: read
+      actions: write
     runs-on: ubuntu-24.04
     # ESP-IDF v6.0.1
     container: espressif/idf@sha256:efc19fae2f52fc6873630c668da26aa834139a063b5fb73a46ebc0dbd217b587

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -42,7 +42,8 @@ on:
 
 jobs:
   nsim:
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+    # yamllint disable-line rule:line-length
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -40,6 +40,10 @@ on:
         default: "coaps://coap.golioth.io"
         type: string
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   nsim:
     # yamllint disable-line rule:line-length

--- a/.github/workflows/test-twister.yml
+++ b/.github/workflows/test-twister.yml
@@ -4,6 +4,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   twister:
     # yamllint disable-line rule:line-length

--- a/.github/workflows/test-twister.yml
+++ b/.github/workflows/test-twister.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   twister:
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+    # yamllint disable-line rule:line-length
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     strategy:
       matrix:
         manifest_yml:


### PR DESCRIPTION
- Upgrade all actions to latest release and pin by sha
- Update golioth-coverity-base to latest (it was broken before) and pin to digest sha
- Add write permissions to workflows that require them