### PR TITLE
ESP-IDF: HTTP client transport: fix duplicate pouch_uplink_finish() and response callback event handling

### DIFF
--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -234,10 +234,7 @@ esp_err_t pouch_uplink_response_callback(esp_http_client_event_t *evt)
     {
         if (false == pouch_atomic_test_and_set_bit(&sync->flags, DOWNLINK_IN_PROGRESS))
         {
-            pouch_uplink_finish(sync->uplink);
-            ESP_LOGD(TAG, "Uplink complete");
-
-            sync->uplink = NULL;
+            /* This is the first downlink data */
             pouch_downlink_start();
         }
 
@@ -412,10 +409,8 @@ static int send_pouch_uplink(struct sync_context *sync)
     err = 0;
 
 finish_and_return:
-    if (NULL != sync->uplink)
-    {
-        pouch_uplink_finish(sync->uplink);
-    }
+    pouch_uplink_finish(sync->uplink);
+    sync->uplink = NULL;
 
     if (true == pouch_atomic_test_and_clear_bit(&sync->flags, DOWNLINK_IN_PROGRESS))
     {

--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -229,49 +229,46 @@ static int upload_pouch_cert(struct sync_context *sync)
 esp_err_t pouch_uplink_response_callback(esp_http_client_event_t *evt)
 {
     struct sync_context *sync = (struct sync_context *) evt->user_data;
+    int err = 0;
 
-    if (HTTP_EVENT_ON_DATA == evt->event_id)
+    switch (evt->event_id)
     {
-        if (false == pouch_atomic_test_and_set_bit(&sync->flags, DOWNLINK_IN_PROGRESS))
-        {
-            /* This is the first downlink data */
-            pouch_downlink_start();
-        }
+        case HTTP_EVENT_ON_DATA:
+            if (false == pouch_atomic_test_and_set_bit(&sync->flags, DOWNLINK_IN_PROGRESS))
+            {
+                /* This is the first downlink data */
+                pouch_downlink_start();
+            }
 
-        int err = pouch_downlink_push(evt->data, evt->data_len);
-        if (0 != err)
-        {
-            ESP_LOGE(TAG, "Failed to push downlink data: %i", err);
-            return ESP_FAIL;
-        }
+            err = pouch_downlink_push(evt->data, evt->data_len);
+            if (0 != err)
+            {
+                ESP_LOGE(TAG, "Failed to push downlink data: %i", err);
+                return ESP_FAIL;
+            }
 
-        sync->downlink_pos += evt->data_len;
+            sync->downlink_pos += evt->data_len;
 
-        if (!esp_http_client_is_chunked_response(evt->client))
-        {
-            /* Data was not chunked, this is the end of the downlink */
-            ESP_LOGD(TAG, "Downlink complete: %" PRIi64 " bytes", sync->downlink_pos);
-            pouch_downlink_finish();
-            pouch_atomic_clear_bit(&sync->flags, DOWNLINK_IN_PROGRESS);
-            return 0;
-        }
+            /* Feed the watchdog timer between each payload (required for chunked get) */
+            taskYIELD();
+            return err;
 
-        /* Data is chunked, feed the watchdog timer between each payload */
-        taskYIELD();
+        case HTTP_EVENT_DISCONNECTED:
+        case HTTP_EVENT_ERROR:
+            err = ESP_FAIL;
+            /* falls through */
+        case HTTP_EVENT_ON_FINISH:
+
+            if (true == pouch_atomic_test_and_clear_bit(&sync->flags, DOWNLINK_IN_PROGRESS))
+            {
+                ESP_LOGI(TAG, "Received downlink");
+                pouch_downlink_finish();
+            }
+            return err;
+
+        default:
+            return err;
     }
-
-    if (HTTP_EVENT_ON_FINISH == evt->event_id)
-    {
-        if (true == pouch_atomic_test_and_clear_bit(&sync->flags, DOWNLINK_IN_PROGRESS))
-        {
-            /* This is the end of a chunked downlink */
-            ESP_LOGI(TAG, "Received final downlink block");
-            pouch_downlink_finish();
-            pouch_atomic_clear_bit(&sync->flags, DOWNLINK_IN_PROGRESS);
-        }
-    }
-
-    return 0;
 }
 
 static int pouch_http_client_uplink_payload_send(struct sync_context *sync,
@@ -411,11 +408,6 @@ static int send_pouch_uplink(struct sync_context *sync)
 finish_and_return:
     pouch_uplink_finish(sync->uplink);
     sync->uplink = NULL;
-
-    if (true == pouch_atomic_test_and_clear_bit(&sync->flags, DOWNLINK_IN_PROGRESS))
-    {
-        /* TODO: pouch_downlink_finish(); */
-    }
 
     return err;
 }

--- a/src/uplink.c
+++ b/src/uplink.c
@@ -269,6 +269,11 @@ int pouch_uplink_error(struct pouch_uplink *uplink)
 
 void pouch_uplink_finish(struct pouch_uplink *uplink)
 {
+    if (NULL == uplink)
+    {
+        return;
+    }
+
     // Free any remaining blocks, as they won't be valid in the next pouch:
     struct pouch_buf *buf;
     while ((buf = buf_queue_get(&uplink->transport.queue)))


### PR DESCRIPTION
- Remove a duplicate call to pouch_uplink_finish() and add a null check to that function.
- Rework the response callback to use a single path for pouch_downlink_finish() and handle DISCONNECT and ERROR events

When we cleaned up the config related to chunked upload in https://github.com/golioth/pouch/pull/249 it unblocked the proper flow of the esp http client and exposed a double call to pouch_uplink_finish(). Because the first call reset the uplink struct to NULL, the second call crashed when trying to lock the mutex to free buffers.

While working on the above issue, I noted a TODO related to pouch_downlink_finish() and took the opportunity to fix how the GET event callbacks are handled.