### PR TITLE
esp_idf: add components required by transports to REQUIRES section

### DIFF
--- a/examples/esp_idf/ble_gatt/main/CMakeLists.txt
+++ b/examples/esp_idf/ble_gatt/main/CMakeLists.txt
@@ -14,7 +14,6 @@ idf_component_register(SRCS
 
                        PRIV_REQUIRES
                          app_update
-                         bt
                          console
                          mbedtls
                          nvs_flash

--- a/port/esp_idf/CMakeLists.txt
+++ b/port/esp_idf/CMakeLists.txt
@@ -78,6 +78,18 @@ if("${CONFIG_GOLIOTH}" STREQUAL "y")
 endif()
 
 #########################
+# Components required by the transports
+#########################
+
+# http_client transport
+list(APPEND POUCH_TRANSPORT_REQUIRES esp_http_client esp-tls)
+
+# ble_gatt transport (not available for Linux unit testing)
+if(NOT IDF_TARGET STREQUAL "linux")
+    list(APPEND POUCH_TRANSPORT_REQUIRES bt)
+endif()
+
+#########################
 # ESP-IDF Component
 #########################
 
@@ -97,6 +109,7 @@ idf_component_register(SRCS
 
                        REQUIRES
                         mbedtls
+                        ${POUCH_TRANSPORT_REQUIRES}
 
                        KCONFIG
                         ${POUCH_PORT}/esp_idf/Kconfig

--- a/port/esp_idf/transport/gatt/CMakeLists.txt
+++ b/port/esp_idf/transport/gatt/CMakeLists.txt
@@ -13,7 +13,3 @@ target_include_directories(${POUCH_ACTIVE_TARGET} PRIVATE
     # Access to shared headers like: #include "transport/sar/receiver.h"
     ${POUCH_ROOT}/src
 )
-
-target_link_libraries(${POUCH_ACTIVE_TARGET} PUBLIC
-    idf::bt
-)

--- a/port/esp_idf/transport/http/CMakeLists.txt
+++ b/port/esp_idf/transport/http/CMakeLists.txt
@@ -13,8 +13,3 @@ target_include_directories(${POUCH_ACTIVE_TARGET} PRIVATE
     # Access to shared headers like: #include "transport/sar/receiver.h"
     ${POUCH_ROOT}/src
 )
-
-target_link_libraries(${POUCH_ACTIVE_TARGET} PUBLIC
-    idf::esp_http_client
-    idf::esp-tls
-)


### PR DESCRIPTION
This removes the need for applications that are using Pouch to have the components required by the transports in the application-level REQUIRES list. Adding all necessary required components does not increase the flash size unless the associated transports are actually enabled in the build.

I tested building the ble example with and without esp_http_client/esp-tls and the http example without bt required and the resulting binaries measure the same size.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/1022