### PR TITLE
esp_idf: http client: use hardcoded temperature when sensor not present

### DIFF
--- a/examples/esp_idf/http_client/main/temperature.c
+++ b/examples/esp_idf/http_client/main/temperature.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#if SOC_TEMPERATURE_SENSOR_SUPPORTED
+
 #include <driver/temperature_sensor.h>
 
 static bool initialized = false;
@@ -26,3 +28,12 @@ float read_temperature(void)
 
     return tsens_out;
 }
+
+#else
+
+float read_temperature(void)
+{
+    return 22.0;
+}
+
+#endif


### PR DESCRIPTION
this allows versions of ESP32 that don't have a temperature sensor to build and run the http_client example.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/1029