### PR TITLE
ci: rely on ZEPHYR_SDK_INSTALL_DIR in Docker image

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Coverity build
         run: |
           /opt/toolchains/coverity/bin/cov-configure --comptype gcc \
-            --compiler /opt/toolchains/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
+            --compiler ${ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
           /opt/toolchains/coverity/bin/cov-build --dir cov-int \
             west build -p -b nrf52840dk/nrf52840 pouch/examples/zephyr/ble_gatt \
             -- -DCONFIG_LOG=n

--- a/.github/workflows/test-build-gateway.yml
+++ b/.github/workflows/test-build-gateway.yml
@@ -70,8 +70,6 @@ jobs:
             app: gateway
             sysbuild: true
     container: golioth/golioth-zephyr-base:sdk-${{ matrix.sdk || '1.0.1' }}
-    env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-${{ matrix.sdk || '1.0.1' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -24,8 +24,6 @@ jobs:
             board: native_sim
             no_sysbuild: true
       fail-fast: false
-    env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-1.0.1
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -47,8 +47,6 @@ permissions:
 jobs:
   nsim:
     container: golioth/golioth-zephyr-base:sdk-1.0.1
-    env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-1.0.1
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-twister.yml
+++ b/.github/workflows/test-twister.yml
@@ -17,8 +17,6 @@ jobs:
           - west-zephyr
           - west-ncs
       fail-fast: false
-    env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-1.0.1
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This environment variable is now set inside Docker image at the build stage
from Dockerfile. Drop specifying it in CI.
