### PR TITLE
ESP-IDF: make the mtls server certificate common name configurable for the http_client transport

### DIFF
--- a/examples/esp_idf/http_client/main/credentials.c
+++ b/examples/esp_idf/http_client/main/credentials.c
@@ -112,6 +112,7 @@ int fill_mtls_credentials(struct mtls_credentials *creds)
 {
     creds->cert_pem = server_ca_cert_pem_start;
     creds->cert_pem_len = server_ca_cert_pem_end - server_ca_cert_pem_start;
+    creds->cert_cn = NULL; /* Use hostname for server cert common name */
 
     if ((NULL == creds->cert_pem) || (0 == creds->cert_pem_len))
     {

--- a/port/esp_idf/include/pouch/transport/http/client.h
+++ b/port/esp_idf/include/pouch/transport/http/client.h
@@ -8,15 +8,47 @@
 
 #include <stddef.h>
 
+/** mTLS credentials for the ESP-IDF HTTP client transport. */
 struct mtls_credentials
 {
+    /** Server CA certificate in PEM format */
     const char *cert_pem;
+    /** Length of @ref cert_pem in bytes. */
     size_t cert_pem_len;
+
+    /** Device certificate in DER format */
     const char *client_cert_der;
+    /** Length of @ref client_cert_der in bytes. */
     size_t client_cert_der_len;
+
+    /** Device private key in DER format */
     const char *client_key_der;
+    /** Length of @ref client_key_der in bytes. */
     size_t client_key_der_len;
 };
 
+/**
+ * Initialize the HTTP client transport with mTLS credentials.
+ *
+ * Must be called once before http_client_transport_sync().  The pointer is
+ * retained; the struct must remain valid for the transport's lifetime.
+ *
+ * @param mtls_creds Pointer to populated mTLS credentials struct.
+ */
 void http_client_transport_init(struct mtls_credentials *mtls_creds);
+
+/**
+ * Perform a full Pouch synchronization cycle over HTTP.
+ *
+ * Downloads the server certificate, uploads the device certificate, sends
+ * any pending uplink data, and receives downlink data.  Blocks until the
+ * sync completes or fails.
+ *
+ * @retval 0        Success.
+ * @retval -EINVAL  Transport not initialized (call init first).
+ * @retval -EACCES  Sync already in progress.
+ * @retval -ENOENT  HTTP client initialization failed.
+ * @retval -EIO     Server returned a non-2xx status code.
+ * @return          Other negative errno on transport errors.
+ */
 int http_client_transport_sync(void);

--- a/port/esp_idf/include/pouch/transport/http/client.h
+++ b/port/esp_idf/include/pouch/transport/http/client.h
@@ -15,6 +15,12 @@ struct mtls_credentials
     const char *cert_pem;
     /** Length of @ref cert_pem in bytes. */
     size_t cert_pem_len;
+    /** @brief Server certificate common name.
+     *
+     *  When set to NULL, the common name must match hostname.  Strings must be
+     *  null-terminated.
+     */
+    const char *cert_cn;
 
     /** Device certificate in DER format */
     const char *client_cert_der;

--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -450,6 +450,7 @@ esp_http_client_handle_t client_initialize(struct sync_context *sync)
         .event_handler = event_handler_proxy,
         .cert_pem = sync->mtls_creds->cert_pem,
         .cert_len = sync->mtls_creds->cert_pem_len,
+        .common_name = sync->mtls_creds->cert_cn,
         .client_cert_der = sync->mtls_creds->client_cert_der,
         .client_cert_len = sync->mtls_creds->client_cert_der_len,
         .client_key_pem = sync->mtls_creds->client_key_der,


### PR DESCRIPTION
When the common name is NULL, the ESP-IDF http client will use the hostname as the cert common name. Adding esp_http_client_config_t->host makes this value user-configurable.