### PR TITLE
esp_idf: fix temperature conditional in http_client example

### DIFF
--- a/examples/esp_idf/http_client/main/temperature.c
+++ b/examples/esp_idf/http_client/main/temperature.c
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if SOC_TEMPERATURE_SENSOR_SUPPORTED
+#include "sdkconfig.h"
+
+#if CONFIG_SOC_TEMP_SENSOR_SUPPORTED
 
 #include <driver/temperature_sensor.h>
 


### PR DESCRIPTION
include sdkconfig so that kconfig symbols are available and fix the symbol that indicates soc-level temperature sensor support.