### PR TITLE
port: imply MBEDTLS_ECP_NIST_OPTIM

### DIFF
--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -10,6 +10,7 @@ menuconfig POUCH
   select MBEDTLS_PSA_CRYPTO_C
   select PSA_CRYPTO
   select PSA_WANT_ALG_SHA_256
+  imply MBEDTLS_ECP_NIST_OPTIM
   help
     Pouch is a protocol for communicating with Golioth from devices not
     directly connected to the internet.


### PR DESCRIPTION
MBEDTLS_ECP_NIST_OPTIM enables the specialised pseudo-Mersenne 'modulo p'
reduction routines for the NIST prime curves (P-256/P-384/ P-521). Without
it, every field multiplication on a NIST curve falls back to the generic
modular reduction, which upstream Mbed TLS documents as "4 to 8 times
slower on the corresponding curve".

On frdm_rw612 (Cortex-M33 @ 260 MHz) the mTLS handshake to gw.golioth.io
with NIST_OPTIM disabled takes ~6.0 s wall-clock and overshoots the
server-side handshake window (empirically ~5 s). The same handshake with
the option enabled completes in ~1.4 s and succeeds.

On Zephyr 4.3 (Mbed TLS 3.6.x) the NIST_OPTIM=n default happened to be
tolerable in practice on this target: the full mTLS handshake to
gw.golioth.io completed in ~4.6 s wall-clock (~4.35 s of that inside the
first ssl_handshake() call) and just squeaked in under the server-side
window.

The Zephyr 4.4 bump in the previous commit lands Mbed TLS 4.0 /
tf-psa-crypto, and on the same target the same NIST_OPTIM=n configuration
measures ~6.0 s of wall-clock (~5.87 s spent inside ssl_handshake() between
receiving ServerHello and attempting to send ClientKeyExchange, i.e. ~1.5 s
slower than 4.3). After that the server sent RSTs at
MBEDTLS_SSL_CLIENT_KEY_EXCHANGE with MBEDTLS_ERR_NET_CONN_RESET (-0x004E).
Most of the delta is the constant-time hardening when NIST_OPTIM is off.

Enabling NIST_OPTIM sidesteps that generic path via ecp_mod_p{256,384,521}
and restores handshake times equivalent to 4.3-plus-NIST_OPTIM (~1.3s).

Upstream Mbed TLS / TF-PSA-Crypto define this option unconditionally in
their default configuration headers (see
tf-psa-crypto/configs/ext/crypto_config_profile_medium.h). Zephyr's current
default of n is a Kconfig-conversion oversight rather than a policy
decision. When the previously-unconditional #define was turned into a
Kconfig `bool` symbol it was given no default, so the symbol silently
defaults to n. Zephyr upstream has already restored the default:

  https://github.com/zephyrproject-rtos/zephyr/pull/111632
  "modules: mbedtls: enable MBEDTLS_ECP_NIST_OPTIM by default"

The same oversight already caused two other Zephyr subsystems to hit
handshake-timeout regressions, both fixed by selecting the option locally:

  https://github.com/zephyrproject-rtos/zephyr/issues/106803
  "OpenThread DTLS session establishment is slower than before"
  (labelled Regression, milestone v4.4.0)

  https://github.com/zephyrproject-rtos/zephyr/pull/106811
  "modules: openthread: Enable NIST optimisations if ECC is used"

Apply this at the top-level POUCH menuconfig so every Pouch app picks it up
without having to know about the footgun.