### PR TITLE
esp_idf: errors need to close http_client before cleanup

### DIFF
--- a/port/esp_idf/transport/http/client.c
+++ b/port/esp_idf/transport/http/client.c
@@ -517,6 +517,7 @@ clear_and_return:
     if (0 != err)
     {
         ESP_LOGI(TAG, "Freeing http client");
+        esp_http_client_close(sync->client);
         esp_http_client_cleanup(sync->client);
         sync->client = NULL;
     }


### PR DESCRIPTION
when an error occurs, the esp_http_client needs to close the connection before cleaning up the resources. This ensures the TLS shutdown handshake runs to avoid the server resetting the connection when a new client is started.