### PR TITLE
esp_idf: source Kconfig for zcbor library

### DIFF
--- a/port/esp_idf/Kconfig
+++ b/port/esp_idf/Kconfig
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+rsource "lib/zcbor/Kconfig"
+
 menu "Pouch"
 
 menuconfig POUCH


### PR DESCRIPTION
when this was moved from a component to a library the Kconfig file stopped being sourced. Resolves issue where ble_gatt builds without ZCBOR_CANONICAL enabled.