### PR TITLE
sar: receiver: handle all states in pouch_receiver_close

### DIFF
--- a/src/transport/sar/receiver.c
+++ b/src/transport/sar/receiver.c
@@ -227,9 +227,16 @@ void pouch_receiver_close(struct pouch_receiver *recv)
 
     pouch_work_cancel_delayable(&recv->work);
 
-    if (recv->state == STATE_ACTIVE || recv->state == STATE_READY)
+    switch ((enum state) recv->state)
     {
-        // If the transfer didn't finish properly, stop it and report it as failed:
-        end(recv, false);
+        case STATE_ACTIVE:
+        case STATE_READY:
+        case STATE_ENDED:
+            // If the transfer didn't finish properly, stop it and report it as failed:
+            end(recv, false);
+            break;
+        case STATE_IDLE:
+        case STATE_FAILED:
+            break;
     }
 }


### PR DESCRIPTION
use state machine to handle all states in pouch_receiver_close(). This matches the approach we use in pouch_sender_close and resolves an issue where the state machine gets stuck if the receiver is closed when in STATE_ENDED.

## Logs of observed behavior before fix

```
I (00:00:34.325) ble_peripheral: Advertising started
I (00:00:34.612) pouch_gatt: MTU updated: 247
I (00:00:35.029) pouch_gatt: Client connected, conn_handle=1
I (00:00:35.917) ble_peripheral: Encryption established
I (00:00:40.122) temperature_sensor: Range [-10°C ~ 80°C], error < 1°C
I (00:00:43.410) glth_dispatch: Receiving Downlink entry on path /.c
I (00:00:43.412) main: Received LED setting: 200
I (00:00:43.414) glth_dispatch: Finished entry for /.c
I (00:00:43.566) pouch_gatt: Client disconnected, reason=531
I (00:00:43.569) ble_peripheral: Advertising started
pouch>
pouch>
pouch> I (00:01:13.565) ble_peripheral: Advertising started
I (00:01:13.717) pouch_gatt: MTU updated: 247
I (00:01:13.896) pouch_gatt: Client connected, conn_handle=1
I (00:01:14.526) ble_peripheral: Encryption established
I (00:01:19.747) pouch_gatt: Client disconnected, reason=531
I (00:01:19.750) ble_peripheral: Advertising started
I (00:01:49.745) ble_peripheral: Advertising started
I (00:01:49.807) pouch_gatt: MTU updated: 247
I (00:01:49.985) pouch_gatt: Client connected, conn_handle=1
I (00:01:50.616) ble_peripheral: Encryption established
E (00:01:50.617) pouch_gatt: Failed to open characteristic: -16
```