### PR TITLE
examples: zephyr: block brokering until gateway ready

### DIFF
--- a/examples/zephyr/gateway/src/main.c
+++ b/examples/zephyr/gateway/src/main.c
@@ -407,10 +407,15 @@ int main(void)
     {
         wait_for_network();
 
-        err = pouch_gateway_cloud_ensure_ready();
-        if (err)
+        while (true)
         {
+            err = pouch_gateway_cloud_ensure_ready();
+            if (!err)
+            {
+                break;
+            }
             LOG_WRN("Initial cloud transport setup failed: %d, will retry", err);
+            k_sleep(K_SECONDS(5));
         }
     }
 

--- a/examples/zephyr/gateway_custom_connect/src/main.c
+++ b/examples/zephyr/gateway_custom_connect/src/main.c
@@ -437,10 +437,15 @@ int main(void)
     {
         wait_for_network();
 
-        err = pouch_gateway_cloud_ensure_ready();
-        if (err)
+        while (true)
         {
+            err = pouch_gateway_cloud_ensure_ready();
+            if (!err)
+            {
+                break;
+            }
             LOG_WRN("Initial cloud transport setup failed: %d, will retry", err);
+            k_sleep(K_SECONDS(5));
         }
     }
 

--- a/port/zephyr/transport/coap/gateway.c
+++ b/port/zephyr/transport/coap/gateway.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(pouch_coap_gateway, CONFIG_POUCH_COAP_CLIENT_LOG_LEVEL);
 
 /*
  * Push the cached server certificate to the gateway core so the
- * gateway can hand it out to BLE peripherals.  Safe to call multiple
+ * gateway can hand it out to BLE peripherals. Safe to call multiple
  * times; the gateway core deduplicates internally via a serial check.
  */
 static void publish_server_cert_to_gateway(void)


### PR DESCRIPTION
Updates gateway transport readiness check to block until the transport is
ready. If we attempt to broker without having fetched a server certificate,
we will fail in perpetuity as the first operation we perform is updating
the server certificate if the SNR does not match.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>