### PR TITLE
golioth_sdk: ota: reject large component names and versions

### DIFF
--- a/golioth_sdk/ota.c
+++ b/golioth_sdk/ota.c
@@ -221,8 +221,15 @@ static void ota_receive_component_start(golioth_downlink_id_t id, const char *pa
         }
         memcpy(component_download.name, path_remainder, name_len);
         component_download.name[name_len] = '\0';
-        strncpy(component_download.version, delimiter + 1, sizeof(component_download.version));
-        component_download.version[sizeof(component_download.version) - 1] = '\0';
+        size_t version_len = strlen(delimiter + 1);
+        if (version_len >= sizeof(component_download.version))
+        {
+            POUCH_LOG_ERR("Component version too large");
+            component_download.downlink_id = DOWNLINK_ID_INVALID;
+            return;
+        }
+        memcpy(component_download.version, delimiter + 1, version_len);
+        component_download.version[version_len] = '\0';
         component_download.offset = 0;
     }
     else

--- a/golioth_sdk/ota.c
+++ b/golioth_sdk/ota.c
@@ -213,7 +213,13 @@ static void ota_receive_component_start(golioth_downlink_id_t id, const char *pa
     {
         component_download.downlink_id = id;
         size_t name_len = ((intptr_t) delimiter) - ((intptr_t) path_remainder);
-        strncpy(component_download.name, path_remainder, name_len);
+        if (name_len >= sizeof(component_download.name))
+        {
+            POUCH_LOG_ERR("Component name too large");
+            component_download.downlink_id = DOWNLINK_ID_INVALID;
+            return;
+        }
+        memcpy(component_download.name, path_remainder, name_len);
         component_download.name[name_len] = '\0';
         strncpy(component_download.version, delimiter + 1, sizeof(component_download.version));
         component_download.version[sizeof(component_download.version) - 1] = '\0';


### PR DESCRIPTION
Adds a check on component name length to ensure that the strncpy cannot
overflow the component_download.name buffer. We now not only protect
against overflow, but also reject a component name that would be truncated.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

We previously accepted component versions that exceeded the configured
maximum length by truncating them. This could lead to unexpected behavior,
so instead we opt to reject a version that would have previously been
truncated.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>