### PR TITLE
examples: gateway: drop duplicate settings options for frdm_rw612

### DIFF
--- a/examples/zephyr/gateway/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/gateway/boards/frdm_rw612_wifi.conf
@@ -5,11 +5,6 @@
 CONFIG_WIFI=y
 CONFIG_WIFI_NXP=y
 
-# Store credentials in settings, on filesystem
-CONFIG_SETTINGS=y
-CONFIG_SETTINGS_FILE=y
-CONFIG_SETTINGS_FILE_PATH="/lfs1/settings"
-
 # Ensure that filesystem initializes before settings
 CONFIG_FILE_SYSTEM_INIT_PRIORITY=89
 

--- a/examples/zephyr/gateway_custom_connect/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/gateway_custom_connect/boards/frdm_rw612_wifi.conf
@@ -5,11 +5,6 @@
 CONFIG_WIFI=y
 CONFIG_WIFI_NXP=y
 
-# Store credentials in settings, on filesystem
-CONFIG_SETTINGS=y
-CONFIG_SETTINGS_FILE=y
-CONFIG_SETTINGS_FILE_PATH="/lfs1/settings"
-
 # Ensure that filesystem initializes before settings
 CONFIG_FILE_SYSTEM_INIT_PRIORITY=89
 


### PR DESCRIPTION
Those are already set in prj.conf for all platforms, so drop that from WiFi
specific overlay.