### PR TITLE
CI: Add OTA test harness and use it in ESP-IDF http_client example

### DIFF
--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -217,6 +217,9 @@ jobs:
             exit 1
           fi
 
+          # Ensure we can query the short hash
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
           pytest -vv -rs -s                  \
             -c "$SAMPLE_DIR/pytest.ini"      \
             --rootdir "$SAMPLE_DIR"          \
@@ -225,6 +228,9 @@ jobs:
             --port "${!PORT_VAR}"            \
             --app-path "$SAMPLE_DIR"         \
             --build-dir build                \
+            --fw-update-bin "$SAMPLE_DIR/build/${{ matrix.sample.name }}_${{ inputs.idf_target }}_fwupdate.bin" \
+            --fw-update-ver "$(git rev-parse --short HEAD)" \
+            --fw-update-pkg-name "hil_ota_$IDF_TARGET"      \
             --erase-all n                    \
             --api-url "$GOLIOTH_API_URL"     \
             --api-key "$GOLIOTH_API_KEY"     \

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -75,8 +75,16 @@ jobs:
           # Install Pouch dependencies
           pip install -r requirements-ci-esp-idf.txt --require-hashes
 
-          # Enable shorter 10s sync delay for Hil testing
-          export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults"
+          # Prepare App Version
+          cd ${{ matrix.sample.dir }}
+          cat <<EOF > fw_update.defaults
+          CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_${{ inputs.idf_target }}"
+          CONFIG_APP_PROJECT_VER="1.2.3"
+          EOF
+          cd -
+
+          # Shorter 10s sync delay for HIL testing and package name/version
+          export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
 
           idf.py -C "${{ matrix.sample.dir }}" set-target "${{ inputs.idf_target }}"
           idf.py -C "${{ matrix.sample.dir }}" build
@@ -92,6 +100,35 @@ jobs:
           )
 
           tar -cf build-artifacts.tar "${artifact_files[@]}"
+
+      - name: Build update version of firmware
+        shell: bash
+        run: |
+          . "$IDF_PATH/export.sh"
+
+          # Ensure we can query the short hash
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
+          # Prepare App Update Version
+          cd ${{ matrix.sample.dir }}
+          cat <<EOF > fw_update.defaults
+          CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_${{ inputs.idf_target }}"
+          CONFIG_APP_PROJECT_VER="$(git rev-parse --short HEAD)"
+          EOF
+          cd -
+
+          # Shorter 10s sync delay for HIL testing and package name/version
+          export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
+
+          rm -f "${{ matrix.sample.dir }}/sdkconfig"
+          idf.py -C "${{ matrix.sample.dir }}" reconfigure
+          idf.py -C "${{ matrix.sample.dir }}" build
+
+          # Find the app update binary, rename, and include in the artifact upload
+          cd "${{ matrix.sample.dir }}"
+          APP_BIN=$(python3 -c "import json; print(json.load(open('build/flasher_args.json'))['app']['file'])")
+          cp "build/${APP_BIN}" "build/${{ matrix.sample.name }}_${{ inputs.idf_target }}_fwupdate.bin"
+          tar -rf build-artifacts.tar "build/${{ matrix.sample.name }}_${{ inputs.idf_target }}_fwupdate.bin"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/examples/esp_idf/http_client/pytest/conftest.py
+++ b/examples/esp_idf/http_client/pytest/conftest.py
@@ -13,7 +13,11 @@ sys.path.insert(
     0, str(Path(__file__).resolve().parents[4] / "scripts" / "pytest-pouch")
 )
 
-pytest_plugins = ["pytest_pouch.plugin", "pytest_pouch.esp_idf_harness"]
+pytest_plugins = [
+    "pytest_pouch.plugin",
+    "pytest_pouch.esp_idf_harness",
+    "pytest_pouch.ota_harness",
+]
 
 
 @pytest.fixture(scope="module")

--- a/scripts/pytest-pouch/pytest_pouch/esp_idf_sample_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/esp_idf_sample_tests.py
@@ -22,6 +22,8 @@ SYNC_TIMEOUT_S = 180.0
 LED_TIMEOUT_S = 90.0
 REBOOT_TIMEOUT_S = 120.0
 BOOT_STATE_TIMEOUT_S = 90.0
+OTA_DOWNLOAD_TIMEOUT_S = 180.0
+OTA_REBOOT_TIMEOUT_S = 180.0
 STREAM_POLL_ATTEMPTS = 24
 STREAM_POLL_DELAY_S = 5.0
 BOOT_INITIALIZED_TEXT = "Pouch successfully initialized"
@@ -343,3 +345,31 @@ async def test_led_setting_downlink(connected_cloud_session):
     await _dut_expect(dut, expected_pattern, timeout=LED_TIMEOUT_S)
     elapsed = time.monotonic() - write_start
     print(f"Device received LED setting {int(next_led)} after {elapsed:.1f}s")
+
+
+async def test_ota_firmware_update(
+    connected_cloud_session,
+    ota_update,
+    fw_update_ver,
+):
+    dut = connected_cloud_session.dut
+
+    await _dut_expect(
+        dut, r".*Beginning package download", timeout=OTA_DOWNLOAD_TIMEOUT_S
+    )
+    await _dut_expect(
+        dut,
+        r".*Rebooting into new image in \d+ seconds",
+        timeout=OTA_REBOOT_TIMEOUT_S,
+    )
+    await _dut_expect(
+        dut,
+        rf".*App version:\s+{re.escape(fw_update_ver)}",
+        timeout=OTA_REBOOT_TIMEOUT_S,
+    )
+    await _dut_expect(
+        dut,
+        rf".*{re.escape(BOOT_INITIALIZED_TEXT)}",
+        timeout=OTA_REBOOT_TIMEOUT_S,
+    )
+    await _dut_expect(dut, r".*Sync successful", timeout=OTA_REBOOT_TIMEOUT_S)

--- a/scripts/pytest-pouch/pytest_pouch/ota_harness.py
+++ b/scripts/pytest-pouch/pytest_pouch/ota_harness.py
@@ -1,0 +1,140 @@
+#
+# Copyright (c) 2026 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import logging
+import secrets
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--fw-update-bin",
+        type=str,
+        help="Path to the firmware update binary for OTA tests",
+    )
+    parser.addoption(
+        "--fw-update-ver",
+        type=str,
+        help="Version string of the firmware update binary for OTA tests",
+    )
+    parser.addoption(
+        "--fw-update-pkg-name",
+        type=str,
+        help="OTA package name for the firmware update artifact (required for OTA tests)",
+    )
+
+
+@pytest.fixture(scope="module")
+def test_id() -> str:
+    return secrets.token_hex(8)
+
+
+@pytest.fixture(scope="module")
+def artifacts_to_cleanup() -> list:
+    return []
+
+
+@pytest.fixture(scope="module")
+def fw_update_bin(request: pytest.FixtureRequest) -> Path:
+    bin_path = request.config.getoption("--fw-update-bin")
+    if not bin_path:
+        pytest.skip("--fw-update-bin not provided")
+    return Path(bin_path)
+
+
+@pytest.fixture(scope="module")
+def fw_update_ver(request: pytest.FixtureRequest) -> str:
+    version = request.config.getoption("--fw-update-ver")
+    if not version:
+        pytest.skip("--fw-update-ver not provided")
+    return version
+
+
+@pytest.fixture(scope="module")
+def pouch_ota_package(request: pytest.FixtureRequest) -> str:
+    package = request.config.getoption("--fw-update-pkg-name")
+    if not package:
+        pytest.skip("--fw-update-pkg-name not provided")
+    return package
+
+
+@pytest.fixture(scope="module")
+async def ota_cohort(project, device, test_id, artifacts_to_cleanup):
+    cohort_name = f"{device.name.lower().replace('-', '_')}_{test_id}"
+    logging.info("Creating cohort '%s' for device '%s'", cohort_name, device.name)
+    cohort = await project.cohorts.create(cohort_name)
+    await device.update_cohort(cohort.id)
+
+    yield cohort
+
+    try:
+        await device.remove_cohort()
+    except Exception:
+        pass
+
+    try:
+        await project.cohorts.delete(cohort.id)
+    except Exception:
+        logging.warning("Cohort %s could not be deleted", cohort_name)
+
+    for artifact_id in artifacts_to_cleanup:
+        try:
+            await project.artifacts.delete(artifact_id)
+        except Exception:
+            logging.warning("Artifact %s could not be deleted", artifact_id)
+
+
+@pytest.fixture(scope="module")
+async def ota_update(
+    project,
+    device,
+    ota_cohort,
+    pouch_ota_package,
+    fw_update_bin,
+    fw_update_ver,
+    test_id,
+    artifacts_to_cleanup,
+) -> str:
+    existing_artifacts = await project.artifacts.get_all()
+    matching = [
+        a
+        for a in existing_artifacts
+        if a.package == pouch_ota_package and a.version == fw_update_ver
+    ]
+
+    if matching:
+        artifact = matching[0]
+        logging.info(
+            "Found existing artifact (id=%s) for package=%s, version=%s — skipping upload",
+            artifact.id,
+            pouch_ota_package,
+            fw_update_ver,
+        )
+    else:
+        logging.info(
+            "Uploading OTA artifact: %s, version=%s, package=%s",
+            fw_update_bin,
+            fw_update_ver,
+            pouch_ota_package,
+        )
+        artifact = await project.artifacts.upload(
+            path=fw_update_bin,
+            version=fw_update_ver,
+            package=pouch_ota_package,
+        )
+        artifacts_to_cleanup.append(artifact.id)
+
+    logging.info("Creating deployment on cohort '%s'", ota_cohort.name)
+    await ota_cohort.deployments.create(
+        f"ota-test-{device.name}-{test_id}",
+        [artifact.id],
+    )
+
+    yield fw_update_ver


### PR DESCRIPTION
- Add a platform-agnostic harness for working with OTA packages, cohorts, and release.
- Add an OTA test to the ESP-IDF http_client pytest
- Add the OTA-specific pytest flags to the HIL workflow

resolves: https://github.com/golioth/firmware-issue-tracker/issues/1047