### PR TITLE
ci: add scheduled project cleanup workflow

### DIFF
--- a/.github/workflows/ci-clean-project.yml
+++ b/.github/workflows/ci-clean-project.yml
@@ -1,0 +1,36 @@
+name: "CI: Clean Project"
+
+on:
+  schedule:
+    # Run workflow at the start of every day (11 PM UTC)
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  clean_project:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup python
+        uses: actions/setup-python@a26affd4eb6113bc5b0d0c2d57f0f2b8e3fb7d1f # v5.3.0
+        with:
+          python-version: '3.11'
+
+      - name: Install Golioth Python Tools
+        run: |
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.8.1
+
+      - name: Remove old assets from Prod
+        run: |
+          python3 scripts/ci/clean_ci_project "${{ secrets.PROD_CI_PROJECT_API_KEY }}" \
+                  --api-url "https://api.golioth.io"                                   \
+                  --days-old 1
+
+      - name: Remove old asset from Dev
+        run: |
+          python3 scripts/ci/clean_ci_project "${{ secrets.DEV_CI_PROJECT_API_KEY }}"  \
+                  --api-url "https://api.golioth.dev"                                  \
+                  --days-old 1

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -217,6 +217,9 @@ jobs:
             exit 1
           fi
 
+          # Ensure we can query the short hash
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
           pytest -vv -rs -s                  \
             -c "$SAMPLE_DIR/pytest.ini"      \
             --rootdir "$SAMPLE_DIR"          \
@@ -225,6 +228,9 @@ jobs:
             --port "${!PORT_VAR}"            \
             --app-path "$SAMPLE_DIR"         \
             --build-dir build                \
+            --fw-update-bin "$SAMPLE_DIR/build/${{ matrix.sample.name }}_${{ inputs.idf_target }}_fwupdate.bin" \
+            --fw-update-ver "$(git rev-parse --short HEAD)" \
+            --fw-update-pkg-name "hil_ota_$IDF_TARGET"      \
             --erase-all n                    \
             --api-url "$GOLIOTH_API_URL"     \
             --api-key "$GOLIOTH_API_KEY"     \

--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -75,8 +75,16 @@ jobs:
           # Install Pouch dependencies
           pip install -r requirements-ci-esp-idf.txt --require-hashes
 
-          # Enable shorter 10s sync delay for Hil testing
-          export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults"
+          # Prepare App Version
+          cd ${{ matrix.sample.dir }}
+          cat <<EOF > fw_update.defaults
+          CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_${{ inputs.idf_target }}"
+          CONFIG_APP_PROJECT_VER="1.2.3"
+          EOF
+          cd -
+
+          # Shorter 10s sync delay for HIL testing and package name/version
+          export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
 
           idf.py -C "${{ matrix.sample.dir }}" set-target "${{ inputs.idf_target }}"
           idf.py -C "${{ matrix.sample.dir }}" build
@@ -92,6 +100,35 @@ jobs:
           )
 
           tar -cf build-artifacts.tar "${artifact_files[@]}"
+
+      - name: Build update version of firmware
+        shell: bash
+        run: |
+          . "$IDF_PATH/export.sh"
+
+          # Ensure we can query the short hash
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
+          # Prepare App Update Version
+          cd ${{ matrix.sample.dir }}
+          cat <<EOF > fw_update.defaults
+          CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_${{ inputs.idf_target }}"
+          CONFIG_APP_PROJECT_VER="$(git rev-parse --short HEAD)"
+          EOF
+          cd -
+
+          # Shorter 10s sync delay for HIL testing and package name/version
+          export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
+
+          rm -f "${{ matrix.sample.dir }}/sdkconfig"
+          idf.py -C "${{ matrix.sample.dir }}" reconfigure
+          idf.py -C "${{ matrix.sample.dir }}" build
+
+          # Find the app update binary, rename, and include in the artifact upload
+          cd "${{ matrix.sample.dir }}"
+          APP_BIN=$(python3 -c "import json; print(json.load(open('build/flasher_args.json'))['app']['file'])")
+          cp "build/${APP_BIN}" "build/${{ matrix.sample.name }}_${{ inputs.idf_target }}_fwupdate.bin"
+          tar -rf build-artifacts.tar "build/${{ matrix.sample.name }}_${{ inputs.idf_target }}_fwupdate.bin"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/examples/esp_idf/http_client/pytest/conftest.py
+++ b/examples/esp_idf/http_client/pytest/conftest.py
@@ -13,7 +13,11 @@ sys.path.insert(
     0, str(Path(__file__).resolve().parents[4] / "scripts" / "pytest-pouch")
 )
 
-pytest_plugins = ["pytest_pouch.plugin", "pytest_pouch.esp_idf_harness"]
+pytest_plugins = [
+    "pytest_pouch.plugin",
+    "pytest_pouch.esp_idf_harness",
+    "pytest_pouch.ota_harness",
+]
 
 
 @pytest.fixture(scope="module")

--- a/scripts/ci/clean_ci_project
+++ b/scripts/ci/clean_ci_project
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+
+__author__ = "Golioth, Inc."
+__copyright__ = "Copyright (c) 2024 Golioth, Inc."
+__license__ = "Apache-2.0"
+
+import argparse
+import asyncio
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable
+
+from golioth import (
+    Certificate,
+    Client,
+    Cohort,
+    Device,
+    Project,
+    Release,
+    Tag,
+)
+
+RemFunc = Callable[[Any], Awaitable[Any]]
+
+EXPIRY_AGE = timedelta(days=1)
+
+
+class OrphanCleaner:
+    def __init__(
+        self,
+        api_url,
+        api_key,
+        default_delta: timedelta | None = None,
+        verbose: bool = False,
+    ):
+        self.client = Client(api_url, api_key)
+        self.project = None
+
+        self.artifacts = None
+        self.certificates = None
+        self.cohorts = None
+        self.devices = None
+        self.tags = None
+
+        self.default_delta = default_delta or EXPIRY_AGE
+        self.verbose = verbose
+
+    async def fetch_all_project_info(self):
+        self.project = (await self.client.get_projects())[0]
+        if self.project is None:
+            if self.verbose:
+                print("No project found")
+            return
+
+        self.devices = await self.project.get_devices()
+        self.artifacts = await self.project.artifacts.get_all()
+        self.certificates = await self.project.certificates.get_all()
+        self.cohorts = await self.project.cohorts.get_all()
+        self.releases = await self.project.releases.get_all()
+        self.tags = await self.project.tags.get_all()
+
+    def get_age(self, ts: str) -> timedelta | None:
+        try:
+            created_dt = datetime.fromisoformat(ts)
+        except Exception:
+            if self.verbose:
+                print(f"Error processing timestamp: {ts}")
+            return None
+
+        return datetime.now(timezone.utc) - created_dt
+
+    async def remove_expired_ids(
+        self,
+        member: Certificate | Cohort | Device | Release | Tag,
+        remove: RemFunc,
+        delta: timedelta | None = None,
+    ) -> str | None:
+        age = self.get_age(member.info["createdAt"])
+        if age and age > (delta or self.default_delta):
+            print("Removing:", member.id, "Age:", age)
+            try:
+                await remove(member.id)
+                return member.id
+            except Exception:
+                print(f"Unable to remove: {member.id}")
+                return None
+
+    async def cull_artifacts(
+        self, project: Project | None, delta: timedelta | None = None
+    ) -> int:
+        if not (project and self.artifacts):
+            if self.verbose:
+                print("No artifacts found.")
+            return -1
+
+        removal_count = 0
+        print("Processing Artifacts:")
+        for a in self.artifacts:
+            if not a.package.startswith("hil_ota_"):
+                continue
+            id = await self.remove_expired_ids(a, project.artifacts.delete, delta)
+            if id:
+                removal_count += 1
+        print("Complete.\n")
+        return removal_count
+
+    async def cull_certificates(
+        self, project: Project | None, delta: timedelta | None = None
+    ) -> int:
+        if not (project and self.certificates):
+            return -1
+
+        removal_count = 0
+        print("Processing Certificates:")
+        for c in self.certificates:
+            id = await self.remove_expired_ids(c, project.certificates.delete, delta)
+            if id:
+                removal_count += 1
+        print("Complete.\n")
+        return removal_count
+
+    async def cull_cohorts(
+        self, project: Project | None, delta: timedelta | None = None
+    ) -> int:
+        if not (project and self.cohorts):
+            if self.verbose:
+                print("No cohorts found.")
+            return -1
+
+        removal_count = 0
+        print("Processing Cohorts:")
+        for c in self.cohorts:
+            id = await self.remove_expired_ids(c, project.cohorts.delete, delta)
+            if id:
+                removal_count += 1
+        print("Complete.\n")
+        return removal_count
+
+    async def cull_devices(
+        self, project: Project | None, delta: timedelta | None = None
+    ) -> int:
+        if not (project and self.devices):
+            if self.verbose:
+                print("No devices found.")
+            return -1
+
+        removal_count = 0
+        print("Processing Devices:")
+        for d in self.devices:
+            id = await self.remove_expired_ids(d, project.delete_device_by_id, delta)
+            if id:
+                removal_count += 1
+        print("Complete.\n")
+        return removal_count
+
+    async def cull_releases(
+        self, project: Project | None, delta: timedelta | None = None
+    ) -> int:
+        if not (project and self.releases):
+            if self.verbose:
+                print("No releases found.")
+            return -1
+
+        removal_count = 0
+        print("Processing Releases:")
+        for r in self.releases:
+            id = await self.remove_expired_ids(r, project.releases.delete, delta)
+            if id:
+                removal_count += 1
+        print("Complete.\n")
+        return removal_count
+
+    async def cull_tags(
+        self, project: Project | None, delta: timedelta | None = None
+    ) -> int:
+        if not (project and self.tags):
+            if self.verbose:
+                print("No tags found.")
+            return -1
+
+        removal_count = 0
+        print("Processing Tags:")
+        for t in self.tags:
+            id = await self.remove_expired_ids(t, project.tags.delete, delta)
+            if id:
+                removal_count += 1
+        print("Complete.\n")
+        return removal_count
+
+
+async def main(api_url: str, api_key: str, days_old: int, verbose: bool) -> int:
+    oc = OrphanCleaner(api_url, api_key, timedelta(days=days_old), verbose)
+    await oc.fetch_all_project_info()
+    if not oc.project:
+        print("Unable to initialize project.")
+        return -1
+
+    print("\nStarting removal process.")
+    print(f"  Org: {oc.project.organization}")
+    print(f"  Proj: {oc.project.id}")
+    print("")
+
+    device_count = 0
+    if oc.devices:
+        device_count = await oc.cull_devices(oc.project, timedelta(days=days_old))
+
+    artifact_count = 0
+    if oc.artifacts:
+        artifact_count = await oc.cull_artifacts(oc.project, timedelta(days=days_old))
+
+    release_count = 0
+    if oc.releases:
+        release_count = await oc.cull_releases(oc.project, timedelta(days=days_old))
+
+    cohorts_count = 0
+    if oc.cohorts:
+        cohorts_count = await oc.cull_cohorts(oc.project, timedelta(days=days_old))
+
+    tag_count = 0
+    if oc.tags:
+        tag_count = await oc.cull_tags(oc.project, timedelta(days=days_old))
+
+    certificate_count = 0
+    if oc.certificates:
+        certificate_count = await oc.cull_certificates(
+            oc.project, timedelta(days=days_old)
+        )
+
+    print(f"Devices removed: {device_count}")
+    print(f"Artifacts removed: {artifact_count}")
+    print(f"Releases removed: {release_count}")
+    print(f"Cohorts removed: {cohorts_count}")
+    print(f"Tags removed: {tag_count}")
+    print(f"Certificates removed: {certificate_count}")
+
+    print("\nFinished removal process.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Remove older assets from Golioth project."
+    )
+    parser.add_argument(
+        "api_key",
+        type=str,
+        help="Golioth project API key",
+    )
+    parser.add_argument(
+        "--api-url",
+        type=str,
+        default="https://api.golioth.io",
+        help="URL to use for the Golioth REST API",
+    )
+    parser.add_argument(
+        "--days-old",
+        type=float,
+        default=7,
+        help="Assets older than this number of days will be removed",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="increase output verbosity",
+        action="store_true",
+    )
+
+    args = parser.parse_args()
+
+    exit_code = asyncio.run(
+        main(args.api_url, args.api_key, args.days_old, args.verbose)
+    )
+    sys.exit(exit_code)

--- a/scripts/pytest-pouch/pytest_pouch/esp_idf_sample_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/esp_idf_sample_tests.py
@@ -22,6 +22,8 @@ SYNC_TIMEOUT_S = 180.0
 LED_TIMEOUT_S = 90.0
 REBOOT_TIMEOUT_S = 120.0
 BOOT_STATE_TIMEOUT_S = 90.0
+OTA_DOWNLOAD_TIMEOUT_S = 180.0
+OTA_REBOOT_TIMEOUT_S = 180.0
 STREAM_POLL_ATTEMPTS = 24
 STREAM_POLL_DELAY_S = 5.0
 BOOT_INITIALIZED_TEXT = "Pouch successfully initialized"
@@ -343,3 +345,31 @@ async def test_led_setting_downlink(connected_cloud_session):
     await _dut_expect(dut, expected_pattern, timeout=LED_TIMEOUT_S)
     elapsed = time.monotonic() - write_start
     print(f"Device received LED setting {int(next_led)} after {elapsed:.1f}s")
+
+
+async def test_ota_firmware_update(
+    connected_cloud_session,
+    ota_update,
+    fw_update_ver,
+):
+    dut = connected_cloud_session.dut
+
+    await _dut_expect(
+        dut, r".*Beginning package download", timeout=OTA_DOWNLOAD_TIMEOUT_S
+    )
+    await _dut_expect(
+        dut,
+        r".*Rebooting into new image in \d+ seconds",
+        timeout=OTA_REBOOT_TIMEOUT_S,
+    )
+    await _dut_expect(
+        dut,
+        rf".*App version:\s+{re.escape(fw_update_ver)}",
+        timeout=OTA_REBOOT_TIMEOUT_S,
+    )
+    await _dut_expect(
+        dut,
+        rf".*{re.escape(BOOT_INITIALIZED_TEXT)}",
+        timeout=OTA_REBOOT_TIMEOUT_S,
+    )
+    await _dut_expect(dut, r".*Sync successful", timeout=OTA_REBOOT_TIMEOUT_S)

--- a/scripts/pytest-pouch/pytest_pouch/ota_harness.py
+++ b/scripts/pytest-pouch/pytest_pouch/ota_harness.py
@@ -1,0 +1,140 @@
+#
+# Copyright (c) 2026 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import logging
+import secrets
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--fw-update-bin",
+        type=str,
+        help="Path to the firmware update binary for OTA tests",
+    )
+    parser.addoption(
+        "--fw-update-ver",
+        type=str,
+        help="Version string of the firmware update binary for OTA tests",
+    )
+    parser.addoption(
+        "--fw-update-pkg-name",
+        type=str,
+        help="OTA package name for the firmware update artifact (required for OTA tests)",
+    )
+
+
+@pytest.fixture(scope="module")
+def test_id() -> str:
+    return secrets.token_hex(8)
+
+
+@pytest.fixture(scope="module")
+def artifacts_to_cleanup() -> list:
+    return []
+
+
+@pytest.fixture(scope="module")
+def fw_update_bin(request: pytest.FixtureRequest) -> Path:
+    bin_path = request.config.getoption("--fw-update-bin")
+    if not bin_path:
+        pytest.skip("--fw-update-bin not provided")
+    return Path(bin_path)
+
+
+@pytest.fixture(scope="module")
+def fw_update_ver(request: pytest.FixtureRequest) -> str:
+    version = request.config.getoption("--fw-update-ver")
+    if not version:
+        pytest.skip("--fw-update-ver not provided")
+    return version
+
+
+@pytest.fixture(scope="module")
+def pouch_ota_package(request: pytest.FixtureRequest) -> str:
+    package = request.config.getoption("--fw-update-pkg-name")
+    if not package:
+        pytest.skip("--fw-update-pkg-name not provided")
+    return package
+
+
+@pytest.fixture(scope="module")
+async def ota_cohort(project, device, test_id, artifacts_to_cleanup):
+    cohort_name = f"{device.name.lower().replace('-', '_')}_{test_id}"
+    logging.info("Creating cohort '%s' for device '%s'", cohort_name, device.name)
+    cohort = await project.cohorts.create(cohort_name)
+    await device.update_cohort(cohort.id)
+
+    yield cohort
+
+    try:
+        await device.remove_cohort()
+    except Exception:
+        pass
+
+    try:
+        await project.cohorts.delete(cohort.id)
+    except Exception:
+        logging.warning("Cohort %s could not be deleted", cohort_name)
+
+    for artifact_id in artifacts_to_cleanup:
+        try:
+            await project.artifacts.delete(artifact_id)
+        except Exception:
+            logging.warning("Artifact %s could not be deleted", artifact_id)
+
+
+@pytest.fixture(scope="module")
+async def ota_update(
+    project,
+    device,
+    ota_cohort,
+    pouch_ota_package,
+    fw_update_bin,
+    fw_update_ver,
+    test_id,
+    artifacts_to_cleanup,
+) -> str:
+    existing_artifacts = await project.artifacts.get_all()
+    matching = [
+        a
+        for a in existing_artifacts
+        if a.package == pouch_ota_package and a.version == fw_update_ver
+    ]
+
+    if matching:
+        artifact = matching[0]
+        logging.info(
+            "Found existing artifact (id=%s) for package=%s, version=%s — skipping upload",
+            artifact.id,
+            pouch_ota_package,
+            fw_update_ver,
+        )
+    else:
+        logging.info(
+            "Uploading OTA artifact: %s, version=%s, package=%s",
+            fw_update_bin,
+            fw_update_ver,
+            pouch_ota_package,
+        )
+        artifact = await project.artifacts.upload(
+            path=fw_update_bin,
+            version=fw_update_ver,
+            package=pouch_ota_package,
+        )
+        artifacts_to_cleanup.append(artifact.id)
+
+    logging.info("Creating deployment on cohort '%s'", ota_cohort.name)
+    await ota_cohort.deployments.create(
+        f"ota-test-{device.name}-{test_id}",
+        [artifact.id],
+    )
+
+    yield fw_update_ver


### PR DESCRIPTION
Add clean_ci_project script that removes old devices, artifacts, cohorts, releases, tags, and certificates older than 1 day. Artifact cleanup is scoped to packages starting with 'hil_ota_' to avoid removing manually-uploaded or non-HIL artifacts.

Scheduled daily at 11 PM UTC against PROD project.

This is functionally the same cleanup script as the Golioth Firmware SDK with artifact cleanup added and style/formatting fixed. Because the two are redundant, I propose we run the clean up in this repository and deprecate the cleanup workflow in the Firmware SDK.

PR to remove cleaning workflow from Firmware SDK repo: https://github.com/golioth/golioth-firmware-sdk/pull/918
