### PR TITLE
west: bump NCS to v3.4-branch tip

### DIFF
--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: v3.4.0
+      revision: f30459884d7f4c3769e5b61409d101d4baedc91e  # v3.4-branch
       url: http://github.com/nrfconnect/sdk-nrf
       import:
         name-allowlist:


### PR DESCRIPTION
Bump NCS from v3.4.0 to f30459884d7f, the current tip of NCS v3.4-branch. This pulls in a sdk-zephyr revision bump to b836543f5393, which contains the upstream fix "Bluetooth: Host: Fix use-after-free in bt_att_sent on disconnect" (dfdea9bad8d9).

Without this fix, when a peer disconnects mid-transfer, the bt_att and bt_att_chan are freed by att_chan_detach()/att_reset() and bt_att_released() while a deferred unenhanced-ATT "sent" callback is still queued on the system workqueue. When that work runs, att_on_sent_cb() -> bt_att_sent() dereferences the freed context and bus-faults inside sys_slist_get(&att->reqs).

This reproduced reliably on nrf9160dk/nrf52840 running examples/zephyr/gateway: every peripheral disconnect (immediately after "Aborting downlink") produced a BUS FAULT in sysworkq. Bumping to the v3.4-branch tip fixes it.