### PR TITLE
examples: ble_gatt: add stdio.h

### DIFF
--- a/examples/zephyr/ble_gatt/src/ble_peripheral.c
+++ b/examples/zephyr/ble_gatt/src/ble_peripheral.c
@@ -9,6 +9,7 @@ LOG_MODULE_REGISTER(example_ble_peripheral);
 
 #include "ble_peripheral.h"
 
+#include <stdio.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 


### PR DESCRIPTION
Implementation uses snprintf(), but there was no explicit stdio.h included.
Fix that.