### PR TITLE
ci: use latest actions versions in ci-clean-project

### DIFF
--- a/.github/workflows/ci-clean-project.yml
+++ b/.github/workflows/ci-clean-project.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup python
-        uses: actions/setup-python@a26affd4eb6113bc5b0d0c2d57f0f2b8e3fb7d1f # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
Fixes an error in the python-setup hash and updates both actions to latest. Tested on the branch and now working:

<img width="631" height="732" alt="image" src="https://github.com/user-attachments/assets/a4fbd5ff-6a93-4fb7-9326-77b5bdab2e3b" />
