### PR TITLE
crypto: saead: check for active session before attempting decrypt

### DIFF
--- a/src/saead/downlink.c
+++ b/src/saead/downlink.c
@@ -153,6 +153,12 @@ struct pouch_buf *saead_downlink_block_buf_alloc(void)
 
 int saead_downlink_block_decrypt(const struct pouch_buf *block, struct pouch_buf *decrypted)
 {
+    if (!pouch_atomic_test_bit(&downlink.flags, SESSION_ACTIVE))
+    {
+        POUCH_LOG_ERR("Not in a session");
+        return -ENOTCONN;
+    }
+
     int err = session_decrypt_block(&downlink, block, decrypted);
     if (0 != err)
     {


### PR DESCRIPTION
Adds a check to verify that the session is active before attempting to decrypt a block. In practice the decryption should fail regardless because the PSA functionas will operate on a null key, but we should avoid attempting if we know the session is not active.