### PR TITLE
Zero out length on error

### DIFF
--- a/src/gateway/cert.c
+++ b/src/gateway/cert.c
@@ -151,6 +151,7 @@ int pouch_gateway_server_cert_get_data(struct pouch_gateway_server_cert_context 
 
     if (context->offset >= len)
     {
+        *dst_len = 0;
         return -ENODATA;
     }
 

--- a/src/gateway/downlink.c
+++ b/src/gateway/downlink.c
@@ -173,6 +173,7 @@ int pouch_gateway_downlink_get_data(struct pouch_gateway_downlink_context *downl
 
     if (pouch_gateway_downlink_is_complete(downlink))
     {
+        *dst_len = 0;
         return -ENODATA;
     }
 

--- a/src/transport/endpoints/device/uplink.c
+++ b/src/transport/endpoints/device/uplink.c
@@ -26,6 +26,7 @@ static enum pouch_result send(struct pouch_bearer *bearer, void *dst, size_t *ds
 {
     if (uplink == NULL)
     {
+        *dst_len = 0;
         return POUCH_ERROR;
     }
 

--- a/src/uplink.c
+++ b/src/uplink.c
@@ -224,13 +224,13 @@ int pouch_wait_for_queue(struct pouch_uplink *uplink, pouch_timeout_t timeout)
 
 enum pouch_result pouch_uplink_fill(struct pouch_uplink *uplink, uint8_t *dst, size_t *len)
 {
+    size_t maxlen = *len;
+    *len = 0;
+
     if (!session_is_active())
     {
         return POUCH_ERROR;
     }
-
-    size_t maxlen = *len;
-    *len = 0;
 
     while (*len < maxlen)
     {


### PR DESCRIPTION
A few endpoints on both the device and broker fail to set the data length to zero on error.