### PR TITLE
examples: gateway_custom_connect: mirror SDK is_bonded default

### DIFF
--- a/examples/zephyr/gateway_custom_connect/src/scan.c
+++ b/examples/zephyr/gateway_custom_connect/src/scan.c
@@ -98,6 +98,8 @@ static void device_found(const bt_addr_le_t *addr,
     struct tf_data tf = {
         .addr = addr,
         .is_tf = false,
+        /* When filtering bonded devices is disabled, treat all devices as bonded */
+        .is_bonded = IS_ENABLED(CONFIG_POUCH_GATEWAY_GATT_SCAN_FILTER_BONDED) ? false : true,
     };
     int err;
 


### PR DESCRIPTION
When CONFIG_POUCH_GATEWAY_GATT_SCAN_FILTER_BONDED was disabled, the
custom scanner left tf.is_bonded false. After the first accepted
connection attempt, the sample disabled bonding. Later advertisements
were then rejected by the "not bonded and bonding disabled" gate, so
the peripheral could not reconnect. Workflows such as OTA then timed
out.

Initialize tf.is_bonded to true when bonded-device filtering is
disabled, matching the library scanner. Filtering-enabled builds
continue to determine the actual bonding state with bt_foreach_bond().