### PR TITLE
bufview: make all byte accesses safe

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -6,6 +6,7 @@
 
 #include "block.h"
 #include <pouch/blockbuf.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pouch/port.h>
@@ -34,23 +35,35 @@
 /** Mask for ID field indicating that this is the last block in the stream */
 #define LAST_DATA_MASK 0x80
 
-void block_decode_hdr(struct pouch_bufview *v,
-                      uint16_t *block_size,
-                      uint8_t *stream_id,
-                      bool *is_stream,
-                      bool *is_first,
-                      bool *is_last)
+int block_decode_hdr(struct pouch_bufview *v,
+                     uint16_t *block_size,
+                     uint8_t *stream_id,
+                     bool *is_stream,
+                     bool *is_first,
+                     bool *is_last)
 {
     __ASSERT_NO_MSG(v->offset == 0);
 
-    *block_size = pouch_bufview_read_be16(v);
+    int err;
+    uint8_t id;
 
-    uint8_t id = pouch_bufview_read_byte(v);
+    err = pouch_bufview_read_be16(v, block_size);
+    if (err)
+    {
+        return err;
+    }
+
+    err = pouch_bufview_read_byte(v, &id);
+    if (err)
+    {
+        return err;
+    }
 
     *stream_id = id & BLOCK_ID_MASK;
     *is_stream = (*stream_id) != BLOCK_ID_ENTRY;
     *is_first = id & FIRST_DATA_MASK;
     *is_last = id & LAST_DATA_MASK;
+    return 0;
 }
 
 static void update_block_header(struct pouch_buf *block, size_t size, uint8_t flags)

--- a/src/block.h
+++ b/src/block.h
@@ -23,12 +23,12 @@
 /** Maximum ciphertext size without the length of the size field */
 #define MAX_BLOCK_SIZE_FIELD_VALUE (MAX_CIPHERTEXT_BLOCK_SIZE - sizeof(uint16_t))
 
-void block_decode_hdr(struct pouch_bufview *v,
-                      uint16_t *block_size,
-                      uint8_t *stream_id,
-                      bool *is_stream,
-                      bool *is_first,
-                      bool *is_last);
+int block_decode_hdr(struct pouch_bufview *v,
+                     uint16_t *block_size,
+                     uint8_t *stream_id,
+                     bool *is_stream,
+                     bool *is_first,
+                     bool *is_last);
 
 struct pouch_buf *block_alloc(pouch_timeout_t timeout);
 

--- a/src/buf.c
+++ b/src/buf.c
@@ -5,6 +5,8 @@
  */
 
 #include "buf.h"
+#include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pouch/port.h>
@@ -168,24 +170,44 @@ const void *pouch_bufview_read(struct pouch_bufview *v, size_t bytes)
     return bufview_read(v, bytes);
 }
 
-uint8_t pouch_bufview_read_byte(struct pouch_bufview *v)
+int pouch_bufview_read_byte(struct pouch_bufview *v, uint8_t *dst)
 {
-    return *bufview_read(v, 1);
+    if (pouch_bufview_available(v) < sizeof(uint8_t))
+    {
+        return -ENODATA;
+    }
+    *dst = *bufview_read(v, sizeof(uint8_t));
+    return 0;
 }
 
-uint16_t pouch_bufview_read_be16(struct pouch_bufview *v)
+int pouch_bufview_read_be16(struct pouch_bufview *v, uint16_t *dst)
 {
-    return pouch_get_be16(bufview_read(v, sizeof(uint16_t)));
+    if (pouch_bufview_available(v) < sizeof(uint16_t))
+    {
+        return -ENODATA;
+    }
+    *dst = pouch_get_be16(bufview_read(v, sizeof(uint16_t)));
+    return 0;
 }
 
-uint32_t pouch_bufview_read_be32(struct pouch_bufview *v)
+int pouch_bufview_read_be32(struct pouch_bufview *v, uint32_t *dst)
 {
-    return pouch_get_be32(bufview_read(v, sizeof(uint32_t)));
+    if (pouch_bufview_available(v) < sizeof(uint32_t))
+    {
+        return -ENODATA;
+    }
+    *dst = pouch_get_be32(bufview_read(v, sizeof(uint32_t)));
+    return 0;
 }
 
-uint64_t pouch_bufview_read_be64(struct pouch_bufview *v)
+int pouch_bufview_read_be64(struct pouch_bufview *v, uint64_t *dst)
 {
-    return pouch_get_be64(bufview_read(v, sizeof(uint64_t)));
+    if (pouch_bufview_available(v) < sizeof(uint64_t))
+    {
+        return -ENODATA;
+    }
+    *dst = pouch_get_be64(bufview_read(v, sizeof(uint64_t)));
+    return 0;
 }
 
 size_t pouch_bufview_available(const struct pouch_bufview *v)

--- a/src/buf.h
+++ b/src/buf.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <pouch/port.h>
+#include <stdint.h>
 
 /** Initial state of the buffer */
 #define POUCH_BUF_STATE_INITIAL ((pouch_buf_state_t) 0)
@@ -110,16 +111,16 @@ size_t pouch_bufview_memcpy(struct pouch_bufview *v, void *dst, size_t bytes);
 const void *pouch_bufview_read(struct pouch_bufview *v, size_t bytes);
 
 /** Read a byte from the buffer view */
-uint8_t pouch_bufview_read_byte(struct pouch_bufview *v);
+int pouch_bufview_read_byte(struct pouch_bufview *v, uint8_t *dst);
 
 /** Read a big endian uint16_t from the buffer view */
-uint16_t pouch_bufview_read_be16(struct pouch_bufview *v);
+int pouch_bufview_read_be16(struct pouch_bufview *v, uint16_t *dst);
 
 /** Read a big endian uint32_t from the buffer view */
-uint32_t pouch_bufview_read_be32(struct pouch_bufview *v);
+int pouch_bufview_read_be32(struct pouch_bufview *v, uint32_t *dst);
 
 /** Read a big endian uint64_t from the buffer view */
-uint64_t pouch_bufview_read_be64(struct pouch_bufview *v);
+int pouch_bufview_read_be64(struct pouch_bufview *v, uint64_t *dst);
 
 /** Get the number of bytes available for reading */
 size_t pouch_bufview_available(const struct pouch_bufview *v);

--- a/src/downlink.c
+++ b/src/downlink.c
@@ -55,11 +55,12 @@ static void decrypt_blocks(pouch_work_t *work)
 
     while ((encrypted_block = buf_queue_get(&decrypt.queue)) != NULL)
     {
+        int err;
         // Reset the target buffer
         buf_restore(decrypted_block, POUCH_BUF_STATE_INITIAL);
 
         /* Decrypt this block */
-        int err = crypto_decrypt_block(encrypted_block, decrypted_block);
+        err = crypto_decrypt_block(encrypted_block, decrypted_block);
 
         /* Encrypted block was consumed; free buffer no matter the outcome */
         /* buffers were allocated then enqueued in pouch_downlink_push() */
@@ -73,7 +74,13 @@ static void decrypt_blocks(pouch_work_t *work)
             break;
         }
 
-        pouch_downlink_block_push(decrypted_block);
+        err = pouch_downlink_block_push(decrypted_block);
+        if (err)
+        {
+            POUCH_LOG_ERR("Failed to push block: %d", err);
+            // TODO: Abort the downlink
+            break;
+        }
 
         pouch_yield();  // let other threads run
     }
@@ -185,7 +192,13 @@ int pouch_downlink_push(const void *buf, size_t buf_len)
 
         if (pouch_bufview_available(&v) > sizeof(uint16_t))
         {
-            uint16_t block_size = pouch_bufview_read_be16(&v);
+            uint16_t block_size;
+            int err = pouch_bufview_read_be16(&v, &block_size);
+            if (err)
+            {
+                POUCH_LOG_ERR("Failed to read block size: %d", err);
+                return err;
+            }
 
             if (block_size > MAX_BLOCK_SIZE_FIELD_VALUE)
             {
@@ -224,7 +237,7 @@ int pouch_downlink_push(const void *buf, size_t buf_len)
                 }
 
                 /* buffers pushed to queue are freed in decrypt_blocks(). */
-                int err = block_downlink_push(encrypted_block);
+                err = block_downlink_push(encrypted_block);
                 if (0 > err)
                 {
                     POUCH_LOG_ERR("Failed to enqueue block: %d", err);

--- a/src/entry.c
+++ b/src/entry.c
@@ -83,8 +83,9 @@ static void downlink_data(unsigned int stream_id, const void *data, size_t len, 
     }
 }
 
-static void pouch_downlink_entries_push(struct pouch_bufview *v)
+static int pouch_downlink_entries_push(struct pouch_bufview *v)
 {
+    int err = 0;
     const uint8_t *path;
     uint8_t path_len;
     const uint8_t *data;
@@ -94,9 +95,23 @@ static void pouch_downlink_entries_push(struct pouch_bufview *v)
 
     while (pouch_bufview_available(v))
     {
-        data_len = pouch_bufview_read_be16(v);
-        content_type = pouch_bufview_read_be16(v);
-        path_len = pouch_bufview_read_byte(v);
+        err = pouch_bufview_read_be16(v, &data_len);
+        if (err)
+        {
+            return err;
+        }
+
+        err = pouch_bufview_read_be16(v, &content_type);
+        if (err)
+        {
+            return err;
+        }
+
+        err = pouch_bufview_read_byte(v, &path_len);
+        if (err)
+        {
+            return err;
+        }
 
         POUCH_LOG_DBG("data_len %u", (unsigned int) data_len);
         POUCH_LOG_DBG("content_type %s (%u)",
@@ -105,7 +120,16 @@ static void pouch_downlink_entries_push(struct pouch_bufview *v)
         POUCH_LOG_DBG("path_len %u", (unsigned int) path_len);
 
         path = pouch_bufview_read(v, path_len);
+        if (NULL == path)
+        {
+            return -ENODATA;
+        }
+
         data = pouch_bufview_read(v, data_len);
+        if (NULL == data)
+        {
+            return -ENODATA;
+        }
 
         /* Copy path to add NULL terminator */
         memcpy(path_null_term, path, path_len);
@@ -114,13 +138,16 @@ static void pouch_downlink_entries_push(struct pouch_bufview *v)
         downlink_start(0, (char *) path_null_term, content_type);
         downlink_data(0, data, data_len, true);
     }
+
+    return err;
 }
 
-static void pouch_downlink_stream_push(struct pouch_bufview *v,
-                                       unsigned int stream_id,
-                                       bool is_first,
-                                       bool is_last)
+static int pouch_downlink_stream_push(struct pouch_bufview *v,
+                                      unsigned int stream_id,
+                                      bool is_first,
+                                      bool is_last)
 {
+    int err = 0;
     const uint8_t *data;
     uint16_t data_len;
 
@@ -131,8 +158,17 @@ static void pouch_downlink_stream_push(struct pouch_bufview *v,
         uint16_t content_type;
         uint8_t path_null_term[256];
 
-        content_type = pouch_bufview_read_be16(v);
-        path_len = pouch_bufview_read_byte(v);
+        err = pouch_bufview_read_be16(v, &content_type);
+        if (err)
+        {
+            return err;
+        }
+
+        err = pouch_bufview_read_byte(v, &path_len);
+        if (err)
+        {
+            return err;
+        }
 
         POUCH_LOG_DBG("content_type %s (%d)",
                       entry_content_format_str(content_type),
@@ -140,6 +176,10 @@ static void pouch_downlink_stream_push(struct pouch_bufview *v,
         POUCH_LOG_DBG("path_len %u", path_len);
 
         path = pouch_bufview_read(v, path_len);
+        if (NULL == path)
+        {
+            return -ENODATA;
+        }
 
         /* Copy path to add NULL terminator */
         memcpy(path_null_term, path, path_len);
@@ -152,30 +192,37 @@ static void pouch_downlink_stream_push(struct pouch_bufview *v,
     data = pouch_bufview_read(v, data_len);
 
     downlink_data(stream_id, data, data_len, is_last);
+    return err;
 }
 
-void pouch_downlink_block_push(struct pouch_buf *pouch_buf)
+int pouch_downlink_block_push(struct pouch_buf *pouch_buf)
 {
     struct pouch_bufview v;
     pouch_bufview_init(&v, pouch_buf);
 
+    int err;
     uint16_t block_size;
     uint8_t stream_id;
     bool is_stream;
     bool is_first;
     bool is_last;
-    block_decode_hdr(&v, &block_size, &stream_id, &is_stream, &is_first, &is_last);
+    err = block_decode_hdr(&v, &block_size, &stream_id, &is_stream, &is_first, &is_last);
+    if (err)
+    {
+        return err;
+    }
 
     POUCH_LOG_HEXDUMP(pouch_bufview_read(&v, 0), pouch_bufview_available(&v), "block bufview");
 
     if (is_stream)
     {
-        pouch_downlink_stream_push(&v, stream_id, is_first, is_last);
+        err = pouch_downlink_stream_push(&v, stream_id, is_first, is_last);
     }
     else
     {
-        pouch_downlink_entries_push(&v);
+        err = pouch_downlink_entries_push(&v);
     }
+    return err;
 }
 
 static int write_entry(struct pouch_buf *block, const struct pouch_entry *entry)

--- a/src/entry.h
+++ b/src/entry.h
@@ -8,5 +8,5 @@
 
 #include "buf.h"
 
-void pouch_downlink_block_push(struct pouch_buf *pouch_buf);
+int pouch_downlink_block_push(struct pouch_buf *pouch_buf);
 int entry_block_close(pouch_timeout_t timeout);

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -214,7 +214,15 @@ struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_bu
     struct pouch_bufview plaintext;
     pouch_bufview_init(&plaintext, block);
 
-    size_t plaintext_len = pouch_bufview_read_be16(&plaintext);
+    uint16_t plaintext_len;
+    int err = pouch_bufview_read_be16(&plaintext, &plaintext_len);
+    if (err)
+    {
+        POUCH_LOG_ERR("Failed to read plaintext length: %d", err);
+        buf_free(encrypted);
+        return NULL;
+    }
+
     if (plaintext_len != pouch_bufview_available(&plaintext))
     {
         POUCH_LOG_ERR("Invalid plaintext length: %zu", plaintext_len);
@@ -275,7 +283,14 @@ int session_decrypt_block(struct session *session,
     struct pouch_bufview ciphertext;
     pouch_bufview_init(&ciphertext, block);
 
-    size_t ciphertext_len = pouch_bufview_read_be16(&ciphertext);
+    uint16_t ciphertext_len;
+    int err = pouch_bufview_read_be16(&ciphertext, &ciphertext_len);
+    if (err)
+    {
+        POUCH_LOG_ERR("Failed to read ciphertext length: %d", err);
+        return err;
+    }
+
     if (ciphertext_len <= AUTH_TAG_LEN || ciphertext_len != pouch_bufview_available(&ciphertext))
     {
         POUCH_LOG_ERR("Invalid ciphertext length: %zu", ciphertext_len);


### PR DESCRIPTION
Updates the bufview API to ensure that all byte accesses in a bufview are safe by checking the remaining available bytes in the buffer. While callers could perform this check themselves in a more efficient manner when multiple reads are performed, we opt to enforce safety at the API boundary given that offset accounting is managed internally by the bufview and there are unlikely to ever be legitimate use cases where a caller would want to read past the end of the buffer.