### PR TITLE
zephyr: patch soc to fix frdm_rw612 ethernet init when using sysbuild

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -55,3 +55,12 @@ patches:
     date: 2026-04-23
     apply-command: >-
       bash -c 'if [ $(west config manifest.file) = "west-zephyr.yml" ]; then git am $@; fi' --
+
+  - path: zephyr/zephyr/0008-soc-nxp-rw-re-power-TDDR-PLL-sysbuild.patch
+    sha256sum: 6e4eb961d90962433c1b4c408ccdb83f054eeb7ae54a00a6227029252e938039
+    module: zephyr
+    author: Mike Szczys
+    email: michael.szczys@canonical.com
+    date: 2026-07-21
+    apply-command: >-
+      bash -c 'if [ $(west config manifest.file) = "west-zephyr.yml" ]; then git am $@; fi' --

--- a/zephyr/patches/zephyr/zephyr/0008-soc-nxp-rw-re-power-TDDR-PLL-sysbuild.patch
+++ b/zephyr/patches/zephyr/zephyr/0008-soc-nxp-rw-re-power-TDDR-PLL-sysbuild.patch
@@ -1,0 +1,38 @@
+From 12f5228460b0996c18b7394938319b5b50d0be8f Mon Sep 17 00:00:00 2001
+From: Mike Szczys <michael.szczys@canonical.com>
+Date: Tue, 21 Jul 2026 13:48:43 -0500
+Subject: [PATCH] soc: nxp: rw: re-power TDDR PLL when enabling Ethernet after
+ MCUboot
+
+MCUboot's soc_early_init_hook() calls CLOCK_DeinitTddrRefClk() even when
+not using Ethernet, which clears the TDDR_PDB bit and powers down the
+TDDR PLL. When the application later boots and re-initializes Ethernet,
+the NXP SDK's clock enable functions re-enable the peripheral clock
+outputs but never re-set the PLL power-down-bypass bit.
+
+Add an explicit write of the TDDR_PDB bit to PLL_CTRL before resetting
+the ENET peripherals. This is a no-op on cold boot since the bit is
+already set, but fixes Ethernet after any scenario where
+CLOCK_DeinitTddrRefClk() was called (sysbuild).
+
+Fixes: zephyrproject-rtos/zephyr#108399
+
+Signed-off-by: Mike Szczys <michael.szczys@canonical.com>
+---
+ soc/nxp/rw/soc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/soc/nxp/rw/soc.c b/soc/nxp/rw/soc.c
+index 49700a41761..a88e993e9a1 100644
+--- a/soc/nxp/rw/soc.c
++++ b/soc/nxp/rw/soc.c
+@@ -306,6 +306,7 @@ __weak __ramfunc void clock_init(void)
+ #endif
+
+ #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(enet)) && CONFIG_NET_L2_ETHERNET && CONFIG_ETH_DRIVER
++	SYSCTL2->PLL_CTRL |= SYSCTL2_PLL_CTRL_TDDR_PDB_MASK;
+ 	RESET_PeripheralReset(kENET_IPG_RST_SHIFT_RSTn);
+ 	RESET_PeripheralReset(kENET_IPG_S_RST_SHIFT_RSTn);
+ #else
+--
+2.55.0


### PR DESCRIPTION
ethernet initialization for the frdm_rw612 soc file assumes cold-boot configuration but when using mcuboot (sysboot) the init fails to re-power the clocks that were shut down by the bootloader.