### PR TITLE
bufview: safe-access follow-up fixes

### DIFF
--- a/src/buf.h
+++ b/src/buf.h
@@ -110,16 +110,36 @@ size_t pouch_bufview_memcpy(struct pouch_bufview *v, void *dst, size_t bytes);
 /** Read available data, if the requested amount is available. */
 const void *pouch_bufview_read(struct pouch_bufview *v, size_t bytes);
 
-/** Read a byte from the buffer view */
+/**
+ * Read a byte from the buffer view.
+ *
+ * @return 0 on success, or -ENODATA if fewer bytes remain than requested. On
+ *         failure @p dst is left unmodified.
+ */
 int pouch_bufview_read_byte(struct pouch_bufview *v, uint8_t *dst);
 
-/** Read a big endian uint16_t from the buffer view */
+/**
+ * Read a big endian uint16_t from the buffer view.
+ *
+ * @return 0 on success, or -ENODATA if fewer bytes remain than requested. On
+ *         failure @p dst is left unmodified.
+ */
 int pouch_bufview_read_be16(struct pouch_bufview *v, uint16_t *dst);
 
-/** Read a big endian uint32_t from the buffer view */
+/**
+ * Read a big endian uint32_t from the buffer view.
+ *
+ * @return 0 on success, or -ENODATA if fewer bytes remain than requested. On
+ *         failure @p dst is left unmodified.
+ */
 int pouch_bufview_read_be32(struct pouch_bufview *v, uint32_t *dst);
 
-/** Read a big endian uint64_t from the buffer view */
+/**
+ * Read a big endian uint64_t from the buffer view.
+ *
+ * @return 0 on success, or -ENODATA if fewer bytes remain than requested. On
+ *         failure @p dst is left unmodified.
+ */
 int pouch_bufview_read_be64(struct pouch_bufview *v, uint64_t *dst);
 
 /** Get the number of bytes available for reading */

--- a/src/entry.c
+++ b/src/entry.c
@@ -139,7 +139,7 @@ static int pouch_downlink_entries_push(struct pouch_bufview *v)
         downlink_data(0, data, data_len, true);
     }
 
-    return err;
+    return 0;
 }
 
 static int pouch_downlink_stream_push(struct pouch_bufview *v,
@@ -192,7 +192,7 @@ static int pouch_downlink_stream_push(struct pouch_bufview *v,
     data = pouch_bufview_read(v, data_len);
 
     downlink_data(stream_id, data, data_len, is_last);
-    return err;
+    return 0;
 }
 
 int pouch_downlink_block_push(struct pouch_buf *pouch_buf)

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -225,7 +225,7 @@ struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_bu
 
     if (plaintext_len != pouch_bufview_available(&plaintext))
     {
-        POUCH_LOG_ERR("Invalid plaintext length: %zu", plaintext_len);
+        POUCH_LOG_ERR("Invalid plaintext length: %u", (unsigned int) plaintext_len);
         buf_free(encrypted);
         return NULL;
     }
@@ -293,7 +293,7 @@ int session_decrypt_block(struct session *session,
 
     if (ciphertext_len <= AUTH_TAG_LEN || ciphertext_len != pouch_bufview_available(&ciphertext))
     {
-        POUCH_LOG_ERR("Invalid ciphertext length: %zu", ciphertext_len);
+        POUCH_LOG_ERR("Invalid ciphertext length: %u", (unsigned int) ciphertext_len);
         return -EINVAL;
     }
 


### PR DESCRIPTION
Follow-up fixes found after "bufview: make all byte accesses safe" PR.