### PR TITLE
gateway samples: update provisioning instructions

### DIFF
--- a/examples/zephyr/gateway/README.md
+++ b/examples/zephyr/gateway/README.md
@@ -6,12 +6,14 @@ management.
 
 During scanning Bluetooth peripherals need to follow specific criteria
 in order to initiate connection to them:
+
 - advertise Pouch Service UUID (0xFC49 or
   89a316ae-89b7-4ef6-b1d3-5c9a6e27d272 for backward compatibility) with
   compatible version and "sync request" flag set
 
 Bluetooth connection is maintained just for the time Pouch
 synchronizatio takes place:
+
 - scan
 - connect
 - Pouch sync
@@ -28,11 +30,25 @@ $ west flash
 
 ## Provisioning
 
-```sh
-uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-uart:~$ settings set golioth/psk <my-psk>
-uart:-$ kernel reboot
+The example is set up with
+[MCUmgr](https://docs.zephyrproject.org/latest/services/device_mgmt/mcumgr.html)
+support for transferring credentials into the device's built-in file system over
+a serial connection.
+
+### Provisioning with MCUmgr:
+
+[The MCUmgr CLI](https://github.com/apache/mynewt-mcumgr) is available as a
+command line tool built as a Go package. Follow the installation instructions in
+the MCUmgr repository, then transfer your certificate and private key to the
+device using the following commands:
+
+```bash
+mcumgr --conntype serial --connstring $SERIAL_PORT fs upload $CERT_FILE /lfs1/credentials/crt.der
+mcumgr --conntype serial --connstring $SERIAL_PORT fs upload $KEY_FILE /lfs1/credentials/key.der
 ```
+
+where `$SERIAL_PORT` is the serial port for the device, like `/dev/ttyACM0` on
+Linux, or `COM1` on Windows.
 
 ## WiFi Gateway Using the NXP frdm_rw612
 
@@ -133,22 +149,24 @@ CLI tool.
 
 1. Program the nRF9151 Serial Modem Firmware
 
-    a. Position the SWD selection switch (`SW2`) to `nRF91`
+   a. Position the SWD selection switch (`SW2`) to `nRF91`
 
-    b. Issue the following command:
-    ```
-    nrfutil device program --firmware thingy91x_nrf9151.hex --x-family nrf91
-    ```
+   b. Issue the following command:
+
+   ```
+   nrfutil device program --firmware thingy91x_nrf9151.hex --x-family nrf91
+   ```
 
 2. Program the nRF5340 Gateway Firmware
 
-    a. Power cycle the device and position the SWD selection switch (`SW2`) to
-    `nRF53`
+   a. Power cycle the device and position the SWD selection switch (`SW2`) to
+   `nRF53`
 
-    b. Issue the following command:
-    ```
-    nrfutil device program --firmware thingy91x_nrf5340.hex --x-family nrf53 --core application
-    ```
+   b. Issue the following command:
+
+   ```
+   nrfutil device program --firmware thingy91x_nrf5340.hex --x-family nrf53 --core application
+   ```
 
 </details>
 
@@ -158,21 +176,23 @@ CLI tool.
 
 1. Program the nRF9160 Serial Modem Firmware
 
-    a. Position the SWD selection switch (`SW10`) to `nRF91`
+   a. Position the SWD selection switch (`SW10`) to `nRF91`
 
-    b. Issue the following command:
-    ```
-    nrfutil device program --firmware nrf9160dk_nrf9160.hex --x-family nrf91
-    ```
+   b. Issue the following command:
+
+   ```
+   nrfutil device program --firmware nrf9160dk_nrf9160.hex --x-family nrf91
+   ```
 
 2. Program the nRF52840 Gateway Firmware
 
-    a. Power cycle the device and position the SWD selection switch (`SW10`) to
-    `nRF52`
+   a. Power cycle the device and position the SWD selection switch (`SW10`) to
+   `nRF52`
 
-    b. Issue the following command:
-    ```
-    nrfutil device program --firmware nrf9160dk_nrf52840.hex --x-family nrf52
-    ```
+   b. Issue the following command:
+
+   ```
+   nrfutil device program --firmware nrf9160dk_nrf52840.hex --x-family nrf52
+   ```
 
 </details>

--- a/examples/zephyr/gateway_custom_connect/README.md
+++ b/examples/zephyr/gateway_custom_connect/README.md
@@ -6,6 +6,7 @@ scanning, device selection and connection management.
 
 During scanning Bluetooth peripherals need to follow specific criteria
 in order to initiate connection to them:
+
 - advertise Pouch Service UUID (0xFC49) with compatible version and
   "sync request" flag set
 - use "Golioth" as advertised name
@@ -13,6 +14,7 @@ in order to initiate connection to them:
 
 Bluetooth connection is maintained for two Pouch synchonization events,
 with a delay of 5 seconds between them:
+
 - scan
 - connect
 - Pouch sync
@@ -31,8 +33,108 @@ $ west flash
 
 ## Provisioning
 
+The example is set up with
+[MCUmgr](https://docs.zephyrproject.org/latest/services/device_mgmt/mcumgr.html)
+support for transferring credentials into the device's built-in file system over
+a serial connection.
+
+### Provisioning with MCUmgr:
+
+[The MCUmgr CLI](https://github.com/apache/mynewt-mcumgr) is available as a
+command line tool built as a Go package. Follow the installation instructions in
+the MCUmgr repository, then transfer your certificate and private key to the
+device using the following commands:
+
+```bash
+mcumgr --conntype serial --connstring $SERIAL_PORT fs upload $CERT_FILE /lfs1/credentials/crt.der
+mcumgr --conntype serial --connstring $SERIAL_PORT fs upload $KEY_FILE /lfs1/credentials/key.der
+```
+
+where `$SERIAL_PORT` is the serial port for the device, like `/dev/ttyACM0` on
+Linux, or `COM1` on Windows.
+
+## WiFi Gateway Using the NXP frdm_rw612
+
+By default the frdm_rw612 will build with Ethernet support, but may
+instead be built with WiFi support:
+
 ```sh
-uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-uart:~$ settings set golioth/psk <my-psk>
-uart:-$ kernel reboot
+$ west build -p -b frdm_rw612 gateway -- -DEXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+$ west flash
+```
+
+Use the shell to provision WiFi credentials:
+
+```sh
+uart:~$ wifi cred add -s <your-wifi-ssid> -p <your-wifi-password> -k 1
+uart:~$ wifi cred auto_connect
+```
+
+## Gateway on Nordic nRF91 platforms
+
+On Nordic platforms that combine an nRF91 cellular modem with a
+separate Bluetooth-capable chip (nRF52840 or nRF5340), the gateway
+firmware is split across two chips:
+
+- **Serial modem firmware** runs on the nRF91 chip and provides LTE
+  connectivity to the gateway over UART. See
+  [`examples/zephyr/ncs-serial-modem`](../ncs-serial-modem) for the
+  serial modem application.
+- **Gateway firmware** runs on the Bluetooth-capable chip (nRF52840 on
+  nRF9160 DK, nRF5340 on Thingy:91 X). It runs the Bluetooth Host
+  stack and communicates with the nRF91 serial modem over UART for
+  Internet access.
+
+Both firmwares must be flashed for the platform to work.
+
+### Thingy:91 X
+
+Serial modem firmware runs on the nRF9151 chip. Switch to the serial
+modem manifest, build and flash by changing the `SWD` switch (`SW2`)
+to `nRF91`, then:
+
+```
+west config manifest.file examples/zephyr/ncs-serial-modem/west.yml
+west update
+west patch apply
+west build -p -b thingy91x/nrf9151/ns pouch/examples/zephyr/ncs-serial-modem/
+west flash
+```
+
+Gateway firmware runs on the nRF5340 chip. Switch back to the NCS
+manifest, build and flash by changing the `SWD` switch (`SW2`) to
+`nRF53`, then:
+
+```
+west config manifest.file west-ncs.yml
+west update
+west patch apply
+west build -p -b thingy91x/nrf5340/cpuapp --sysbuild pouch/examples/zephyr/gateway/
+west flash
+```
+
+### nRF9160 DK
+
+Serial modem firmware runs on the nRF9160 chip. Switch to the serial
+modem manifest, build and flash by changing the `SWD` switch (`SW10`)
+to `nRF91`, then:
+
+```
+west config manifest.file examples/zephyr/ncs-serial-modem/west.yml
+west update
+west patch apply
+west build -p -b nrf9160dk/nrf9160/ns pouch/examples/zephyr/ncs-serial-modem/
+west flash
+```
+
+Gateway firmware runs on the nRF52840 chip. Switch back to the NCS
+manifest, build and flash by changing the `SWD` switch (`SW10`) to
+`nRF52`, then:
+
+```
+west config manifest.file west-ncs.yml
+west update
+west patch apply
+west build -p -b nrf9160dk/nrf52840 --sysbuild pouch/examples/zephyr/gateway/
+west flash
 ```


### PR DESCRIPTION
The gateway samples have moved away from PSK authentication, to use the same certificate authentication mechanism as the Pouch devices. This patch replaces the provisioning section with the one from the Pouch device samples, and adds the same platform-specific instructions in the custom connect logic gateway sample as in the regular gateway sample.