### PR TITLE
gateway: offload device cert cloud upload to the gateway work queue

### DIFF
--- a/src/gateway/Kconfig
+++ b/src/gateway/Kconfig
@@ -51,9 +51,14 @@ config POUCH_GATEWAY_CLOUD
 
 config POUCH_GATEWAY_WORKQ_STACK_SIZE
     int "Gateway work queue stack size"
-    default 3072
+    default 8192
     help
       Stack size for the internal gateway work queue.
+
+      This queue runs the blocking cloud (CoAP/DTLS) operations for the
+      gateway, including the peripheral device-certificate upload and the
+      pouch uplink forward. It must be large enough to hold a full mbedtls
+      DTLS handshake when the connection needs to be (re)established.
 
 config POUCH_GATEWAY_WORKQ_PRIORITY
     int "Gateway work queue priority"

--- a/src/gateway/uplink.c
+++ b/src/gateway/uplink.c
@@ -249,6 +249,38 @@ void pouch_gateway_submit_close_work(pouch_work_t *work)
     pouch_work_submit_to_queue(&gateway_work_q, work);
 }
 
+struct workq_sync_ctx
+{
+    pouch_work_t work;
+    void (*fn)(void *arg);
+    void *arg;
+    pouch_sem_t done;
+};
+
+static void workq_sync_handler(pouch_work_t *work)
+{
+    struct workq_sync_ctx *ctx = CONTAINER_OF(work, struct workq_sync_ctx, work);
+
+    ctx->fn(ctx->arg);
+    pouch_sem_give(&ctx->done);
+}
+
+void pouch_gateway_workq_run_sync(void (*fn)(void *arg), void *arg)
+{
+    /* Lives on the caller's stack; stays valid because we block on the semaphore below until the
+     * handler has run to completion.
+     */
+    struct workq_sync_ctx ctx = {
+        .fn = fn,
+        .arg = arg,
+    };
+
+    pouch_sem_init(&ctx.done, 0, 1);
+    pouch_work_init(&ctx.work, workq_sync_handler);
+    pouch_work_submit_to_queue(&gateway_work_q, &ctx.work);
+    pouch_sem_take(&ctx.done, POUCH_FOREVER);
+}
+
 struct pouch_gateway_uplink *pouch_gateway_uplink_open(
     struct pouch_gateway_downlink_context *downlink,
     pouch_gateway_uplink_end_cb end_cb,

--- a/src/gateway/uplink.h
+++ b/src/gateway/uplink.h
@@ -17,3 +17,17 @@
  * @param work The work item to submit.
  */
 void pouch_gateway_submit_close_work(pouch_work_t *work);
+
+/**
+ * Run a function synchronously on the internal gateway work queue.
+ *
+ * Submits @p fn to the gateway work queue and blocks the calling thread until it has finished
+ * executing. This moves the stack usage of blocking cloud operations (e.g. a DTLS handshake) off
+ * the caller's thread while keeping the caller's control flow synchronous.
+ *
+ * Must not be called from the gateway work queue's own worker thread, or it would deadlock.
+ *
+ * @param fn  Function to execute on the work queue.
+ * @param arg Argument passed to @p fn.
+ */
+void pouch_gateway_workq_run_sync(void (*fn)(void *arg), void *arg);

--- a/src/transport/endpoints/broker/device_cert.c
+++ b/src/transport/endpoints/broker/device_cert.c
@@ -11,6 +11,7 @@
 #include <pouch/gateway/cert.h>
 #include <pouch/port.h>
 #include "gateway/types.h"
+#include "gateway/uplink.h"
 #include "transport/bearer.h"
 #include "endpoints.h"
 
@@ -33,6 +34,19 @@ static int recv(struct pouch_bearer *bearer, const void *buf, size_t len)
     return pouch_gateway_device_cert_push(node->device_cert_ctx, buf, len);
 }
 
+struct device_cert_finish_ctx
+{
+    struct pouch_gateway_device_cert_context *ctx;
+    int result;
+};
+
+static void device_cert_finish_on_workq(void *arg)
+{
+    struct device_cert_finish_ctx *finish = arg;
+
+    finish->result = pouch_gateway_device_cert_finish(finish->ctx);
+}
+
 static void end(struct pouch_bearer *bearer, bool success)
 {
     struct pouch_gateway_node_info *node = bearer->ctx;
@@ -44,9 +58,19 @@ static void end(struct pouch_bearer *bearer, bool success)
         return;
     }
 
-    int err = pouch_gateway_device_cert_finish(node->device_cert_ctx);
+    /*
+     * pouch_gateway_device_cert_finish() performs a blocking CoAP/DTLS cloud upload (including a
+     * potential DTLS handshake via mbedtls), which is far too stack-hungry to run on the transport
+     * receive thread (e.g. the BT RX workqueue). Run it on the gateway work queue instead, blocking
+     * here until it completes so the provisioning sequence semantics are preserved.
+     */
+    struct device_cert_finish_ctx finish = {
+        .ctx = node->device_cert_ctx,
+    };
     node->device_cert_ctx = NULL;
-    if (err)
+
+    pouch_gateway_workq_run_sync(device_cert_finish_on_workq, &finish);
+    if (finish.result)
     {
         pouch_bearer_close(bearer, false);
         return;


### PR DESCRIPTION
The device_cert broker endpoint's end callback ran
pouch_gateway_device_cert_finish() inline on the transport receive
thread (the BT RX workqueue on the BLE transport). That finish performs
the full CoAP/DTLS cloud upload of the peripheral certificate, including
a potential mbedtls DTLS handshake, which needs ~7.6 KB of stack. When
the cloud connection was cold at that point, the handshake overflowed
the BT RX workqueue stack and crashed the gateway:

    ZEPHYR FATAL ERROR 2: Stack overflow on CPU 0
    Current thread: BT RX WQ

Commit c46200e already moved the equivalent uplink close work off the
receive thread to the gateway work queue for the same reason, but the
device_cert endpoint was missed.

Offload the device cert finish to the gateway work queue via a new
pouch_gateway_workq_run_sync() helper. It runs synchronously (blocks the
caller until the work completes), so the provisioning sequence semantics
are unchanged, while the deep DTLS/CoAP stack now lives on gw_workq
instead of the receive thread.

Because the cold DTLS handshake can now land on gw_workq, raise
CONFIG_POUCH_GATEWAY_WORKQ_STACK_SIZE from 3072 to 8192 (measured peak
7648 bytes on nrf9160dk/nrf52840).

Verified on nrf9160dk/nrf52840 with a forced cold handshake. Without the
change the BT RX workqueue overflows and resets. With it the BT RX
workqueue peaks at 1064 bytes, gw_workq absorbs the handshake at
7648/8192, and peripheral provisioning succeeds.