### PR TITLE
zephyr: CONFIG_BT_MAX_CONN to 8 for nrf9160dk gateway_custom_connect

### DIFF
--- a/examples/zephyr/gateway_custom_connect/boards/nrf9160dk_nrf52840.conf
+++ b/examples/zephyr/gateway_custom_connect/boards/nrf9160dk_nrf52840.conf
@@ -1,3 +1,6 @@
+# Reduce max connected BT devices help with RAM usage
+CONFIG_BT_MAX_CONN=8
+
 # PPP
 CONFIG_NET_L2_PPP=y
 CONFIG_NET_L2_PPP_OPTION_DNS_USE=y


### PR DESCRIPTION
reduce max number of bluetooth connections to conserve RAM.

This change should have been made as part of golioth/pouch#279 but was accidentally left out.