### PR TITLE
gateway: fix stack use-after-return in pouch_gateway_workq_run_sync

### DIFF
--- a/src/gateway/uplink.c
+++ b/src/gateway/uplink.c
@@ -254,7 +254,6 @@ struct workq_sync_ctx
     pouch_work_t work;
     void (*fn)(void *arg);
     void *arg;
-    pouch_sem_t done;
 };
 
 static void workq_sync_handler(pouch_work_t *work)
@@ -262,23 +261,18 @@ static void workq_sync_handler(pouch_work_t *work)
     struct workq_sync_ctx *ctx = CONTAINER_OF(work, struct workq_sync_ctx, work);
 
     ctx->fn(ctx->arg);
-    pouch_sem_give(&ctx->done);
 }
 
 void pouch_gateway_workq_run_sync(void (*fn)(void *arg), void *arg)
 {
-    /* Lives on the caller's stack; stays valid because we block on the semaphore below until the
-     * handler has run to completion.
-     */
     struct workq_sync_ctx ctx = {
         .fn = fn,
         .arg = arg,
     };
 
-    pouch_sem_init(&ctx.done, 0, 1);
     pouch_work_init(&ctx.work, workq_sync_handler);
     pouch_work_submit_to_queue(&gateway_work_q, &ctx.work);
-    pouch_sem_take(&ctx.done, POUCH_FOREVER);
+    pouch_work_queue_flush(&gateway_work_q);
 }
 
 struct pouch_gateway_uplink *pouch_gateway_uplink_open(


### PR DESCRIPTION
pouch_gateway_workq_run_sync() (added in 87136d7 "gateway: offload device
cert cloud upload to the gateway work queue") signalled completion with a
semaphore given from inside the work handler.

The caller runs on the transport receive thread, which can have a higher
priority than the gateway work queue. k_sem_give() from the handler then
preempts the work queue and lets the caller return from
pouch_gateway_workq_run_sync() and tear down its stack frame - including
the stack-allocated k_work item - before the work queue has finished its
own post-handler bookkeeping on that item. The work queue then operates on
freed stack memory and crashes (observed as a SIGSEGV on nrf52_bsim right
after "Peripheral device certificate uploaded").

Wait for completion with pouch_work_queue_flush() instead. It only returns
once the work queue has finished with the submitted item, so the context
can safely go out of scope and nothing is signalled from within the handler.