### PR TITLE
zephyr: gateway: adjust thingy91x partitions

### DIFF
--- a/examples/zephyr/gateway/boards/thingy91x_nrf5340_cpuapp.overlay
+++ b/examples/zephyr/gateway/boards/thingy91x_nrf5340_cpuapp.overlay
@@ -13,6 +13,10 @@
  */
 
 / {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+
 	aliases {
 		modem = &modem;
 	};
@@ -29,6 +33,20 @@
 			cache-size = <64>;
 			lookahead-size = <32>;
 			block-cycles = <512>;
+		};
+	};
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00000000 0x000f8000>;
 		};
 	};
 };


### PR DESCRIPTION
the thingy91x does not use mcuboot so the partition table must be adjusted to place slot0 at 0x0.