### PR TITLE
transport: sar: receiver: stop ack retry loop on fatal bearer errors

### DIFF
--- a/src/transport/sar/receiver.c
+++ b/src/transport/sar/receiver.c
@@ -56,6 +56,11 @@ static void send_ack(pouch_work_delayable_t *dwork)
     {
         // try again later:
         POUCH_LOG_ERR("TX failed (%d)", err);
+        if (err == -ENOTCONN || err == -ECONNRESET)
+        {
+            end(p, false);
+            return;
+        }
         schedule_ack(p);
         return;
     }
@@ -113,6 +118,11 @@ int pouch_receiver_open(struct pouch_receiver *recv, struct pouch_bearer *bearer
 int pouch_receiver_recv(struct pouch_receiver *recv, const uint8_t *buf, size_t len)
 {
     struct pouch_sar_tx_pkt pkt;
+
+    if (recv->state == STATE_IDLE || recv->state == STATE_FAILED)
+    {
+        return -ENOTCONN;
+    }
 
     int err = pouch_sar_tx_pkt_decode(buf, len, &pkt);
     if (err)


### PR DESCRIPTION
call end() on fatal bearer errors instead of retrying, so the receiver transitions to STATE_FAILED and the work loop terminates. Also guard pouch_receiver_recv() against STATE_IDLE/STATE_FAILED to prevent stale calls from restarting the retry loop.

This is the correct fix for the issues seen in this draft PR:
closes #210