### PR TITLE
cert: silently returns success without installing the trust anchor

### DIFF
--- a/src/cert.c
+++ b/src/cert.c
@@ -246,6 +246,7 @@ int cert_server_set(const struct pouch_cert *certbuf)
     {
         POUCH_LOG_ERR("Unexpected server certificate serial number size: %zu",
                       cert_chain.serial.len);
+        err = -EINVAL;
         goto exit;
     }
 


### PR DESCRIPTION
## Summary

`cert_server_set()` (`src/cert.c`) rejects a server certificate whose X.509
serial number is longer than the serial buffer — but it takes the reject branch
**without setting `err`**, so the function returns `0` (success) while skipping
`extract_pubkey()` and the serial/pubkey store. The caller believes the server
trust anchor was installed when it was not. This PR sets an error code on that
branch so the failure propagates.

## The problem

`src/cert.c`, `cert_server_set()`:

```c
int err;
...
err = parse_x509_cert(certbuf, &cert_chain);          /* err = 0 on success */
if (err) { ...; goto exit; }

if (IS_ENABLED(CONFIG_POUCH_VALIDATE_SERVER_CERT)) {
    err = authenticate_server_cert(&cert_chain);      /* err = 0 on success */
    if (err) { goto exit; }
}

if (cert_chain.serial.len > sizeof(server_cert.serial.data)) {
    POUCH_LOG_ERR("Unexpected server certificate serial number size: %zu",
                  cert_chain.serial.len);
    goto exit;                                        /* <-- err is still 0 here */
}

err = extract_pubkey(&cert_chain, &server_cert.pubkey);   /* SKIPPED */
if (err) { goto exit; }

memcpy(server_cert.serial.data, cert_chain.serial.p, cert_chain.serial.len);  /* SKIPPED */
server_cert.serial.len = cert_chain.serial.len;                               /* SKIPPED */

exit:
    mbedtls_x509_crt_free(&cert_chain);
    return err;                                       /* returns 0 = SUCCESS */
```

On the over-long-serial path, `err` still carries the `0` from the successful
parse/authenticate above. The `goto exit` therefore returns **`0` (success)**
even though `server_cert.pubkey` and `server_cert.serial` were never updated.

Note this is *not* a memory-safety bug: the `serial.len > sizeof(...)` guard
correctly prevents the serial `memcpy` from overflowing (that is why the check
exists). The defect is purely in the control flow — a rejected certificate is
reported as accepted.

## Impact

- **Silent partial success.** A server certificate with a serial number longer
  than `sizeof(server_cert.serial.data)` (20 bytes) is silently "accepted": the
  caller of `cert_server_set` / `pouch_server_certificate_set` gets `0` and has
  no signal that the trust anchor was not installed.
- **Trust-state confusion.** Because `server_cert.pubkey` is left untouched, a
  **stale** pubkey from a previously installed certificate remains in place while
  the caller believes it just installed a new one.
- **Fails safe on the crypto path, but masks the rejection.** Defense-in-depth
  holds — the session-key derivation gate requires `pubkey->len != 0` before
  ECDH+HKDF, so a *never-populated* store fails closed rather than deriving keys
  against attacker input. The concern is the masked rejection and the stale-anchor
  case, not key compromise.

Severity: **logic bug / robustness** (silent failure of an install operation),
not a remotely exploitable memory-safety issue.

## The fix

Set an error code on the reject branch so the failure propagates, matching the
function's existing `err`-return contract:

```diff
--- a/src/cert.c
+++ b/src/cert.c
@@ int cert_server_set(const struct pouch_cert *certbuf)
     if (cert_chain.serial.len > sizeof(server_cert.serial.data))
     {
         POUCH_LOG_ERR("Unexpected server certificate serial number size: %zu",
                       cert_chain.serial.len);
+        err = -EINVAL;
         goto exit;
     }
```

`<errno.h>` (for `EINVAL`) is already in the translation unit. With this change,
an over-long serial returns a non-zero error and the caller can react instead of
silently continuing with an un-installed (or stale) trust anchor.

## Related

The sibling gateway path (`src/gateway/cert.c::server_crt_update`) has the *inverse*
problem on the same serial field: it **omits** the length guard entirely and
overflows a fixed 20-byte buffer (reported separately as a memory-safety
violation). The two should be reconciled so both the device and gateway serial
handlers apply the same bounds check *and* propagate a rejection.

## How this was found

Surfaced by a deductive proof coupled with Squeeze Loop strategy: while proving
`cert_server_set` memory-safe, the over-long-serial branch was found to reach
`exit` with `err == 0`, so the postcondition "on success, `server_cert.pubkey`
is populated" does not hold on that path — the guard rejects the cert for memory
safety but the return value reports success. The memcpy itself is proven safe
under the guard; the finding is the missing `err` assignment, not an alarm.

## Testing

- Suggested regression: call `cert_server_set` with a certificate whose X.509
  serialNumber is longer than `sizeof(server_cert.serial.data)` (21+ bytes) and
  assert (a) the return value is non-zero and (b) `server_cert.pubkey.len` is
  unchanged (in particular, still `0` from a fresh state). On the current code the
  return value is `0`; with the fix it is `-EINVAL`.
