### PR TITLE
gateway/cert: bound X.509 serial length in server_crt_update

### DIFF
--- a/src/gateway/cert.c
+++ b/src/gateway/cert.c
@@ -124,6 +124,15 @@ static int server_crt_update(size_t len)
 
     POUCH_LOG_HEXDUMP(cert_chain.serial.p, cert_chain.serial.len, "cert_chain.serial");
 
+    if (cert_chain.serial.len > sizeof(server_crt_serial))
+    {
+        POUCH_LOG_ERR("Server certificate serial number too long: %zu > %zu",
+                      cert_chain.serial.len,
+                      sizeof(server_crt_serial));
+        mbedtls_x509_crt_free(&cert_chain);
+        return -EINVAL;
+    }
+
     memcpy(server_crt_serial, cert_chain.serial.p, cert_chain.serial.len);
     pouch_atomic_set(&server_crt_serial_len, cert_chain.serial.len);
 


### PR DESCRIPTION
## Summary

`server_crt_update()` (`src/gateway/cert.c`) copies the parsed X.509
serialNumber into a fixed 20-byte static buffer with no length check.
The serial length is attacker-controlled (it comes from the server certificate),
and mbedtls does not enforce RFC 5280's 20-octet limit, so a certificate with a
serialNumber longer than 20 bytes causes an out-of-bounds write past
`server_crt_serial` into adjacent statics. This PR adds the bounds check that the
sibling device path (`src/cert.c`) already has.

## The Issue

`src/gateway/cert.c`:

```c
static uint8_t server_crt_serial[CERT_SERIAL_MAXLEN];   /* CERT_SERIAL_MAXLEN == 20 */
static pouch_atomic_t server_crt_serial_len;            /* adjacent statics */
static pouch_atomic_t server_crt_len;
static pouch_atomic_t server_crt_id;
...
static int server_crt_update(size_t len)
{
    mbedtls_x509_crt cert_chain;
    mbedtls_x509_crt_init(&cert_chain);

    int ret = mbedtls_x509_crt_parse(&cert_chain, server_crt_buf, len);
    if (ret < 0) { ...; return -EIO; }

    /* NO check that cert_chain.serial.len <= sizeof(server_crt_serial) */
    memcpy(server_crt_serial, cert_chain.serial.p, cert_chain.serial.len);   /* line 127: OOB write */
    pouch_atomic_set(&server_crt_serial_len, cert_chain.serial.len);
    ...
}
```

- `server_crt_serial` is a fixed `uint8_t[CERT_SERIAL_MAXLEN]` with
  `CERT_SERIAL_MAXLEN == 20` (`include/pouch/gateway/cert.h:19`).
- `cert_chain.serial.len` is the length of the certificate's serialNumber
  INTEGER, taken straight from the parsed X.509. mbedtls does not enforce the
  RFC 5280 §4.1.2.2 "SHOULD be ≤ 20 octets" recommendation — a certificate with
  a longer serialNumber parses successfully with `serial.len > 20`.
- There is no bounds check between `mbedtls_x509_crt_parse` (line 116) and the
  `memcpy` (line 127), so the copy writes past the 20-byte buffer into the
  adjacent BSS (`server_crt_serial_len`, `server_crt_len`, `server_crt_id`).

## Trigger and reachability

Reached via `pouch_gateway_server_cert_set(cert, len)` ->
`server_crt_update(len)` — i.e. any code path that installs a server certificate
on the gateway. An attacker who can supply that certificate (a malicious or MITM
server certificate with a serialNumber INTEGER longer than 20 bytes) triggers
the overwrite.

- When `CONFIG_POUCH_VALIDATE_SERVER_CERT` is unset, the certificate is not
  even chain-verified before the copy.
- Even when it is set, mbedtls chain verification does not reject an over-long
  serialNumber, so the overflow is still reachable.

The overwritten adjacent statics (`server_crt_serial_len`, `server_crt_len`,
`server_crt_id`) subsequently drive serial/length/id bookkeeping used by the
gateway's server-cert read-out path, so the corruption is not inert.

## The divergence 

The device-side sibling `src/cert.c::cert_server_set` copies the *same* serial
field and has exactly this guard:

```c
/* src/cert.c */
if (cert_chain.serial.len > sizeof(server_cert.serial.data)) {
    POUCH_LOG_ERR("Unexpected server certificate serial number size: %zu",
                  cert_chain.serial.len);
    goto exit;
}
memcpy(server_cert.serial.data, cert_chain.serial.p, cert_chain.serial.len);
```

`src/gateway/cert.c::server_crt_update` omits it. The fix brings the gateway path
in line with the device path.

## The fix

Reject an over-long serial before the copy, freeing the parsed chain first
(matching the function's existing error-return convention):

```diff
--- a/src/gateway/cert.c
+++ b/src/gateway/cert.c
@@ static int server_crt_update(size_t len)
     POUCH_LOG_HEXDUMP(cert_chain.serial.p, cert_chain.serial.len, "cert_chain.serial");

+    if (cert_chain.serial.len > sizeof(server_crt_serial))
+    {
+        POUCH_LOG_ERR("Server certificate serial number too long: %zu > %zu",
+                      cert_chain.serial.len, sizeof(server_crt_serial));
+        mbedtls_x509_crt_free(&cert_chain);
+        return -EINVAL;
+    }
+
     memcpy(server_crt_serial, cert_chain.serial.p, cert_chain.serial.len);
     pouch_atomic_set(&server_crt_serial_len, cert_chain.serial.len);
```

`sizeof(server_crt_serial)` (== `CERT_SERIAL_MAXLEN`, 20) is the exact capacity,
so the guard is robust to the constant changing. `<errno.h>` is already in the
translation unit.

## Reproducer (AddressSanitizer)

A test was performed using `pouch-v-1-asan-test.c` is a self-contained reproducer. 
It models a parsed serial of attacker-controlled length (pointer + length, as mbedtls
yields) and passes a 40-byte serialNumber:

```
cc -g -fsanitize=address pouch-v-1-asan-test.c -o v1 && ./v1
```

ASan reports the out-of-bounds write immediately after the 20-byte
`server_crt_serial`, in `server_crt_update`:

```
serial.len = 40, server_crt_serial capacity = 20
==…==ERROR: AddressSanitizer: global-buffer-overflow … WRITE of size 40 …
    #0 … in memcpy
    #1 … in server_crt_update  pouch-v-1-asan-test.c:24
… is located 0 bytes after global variable 'server_crt_serial' … of size 20
… is located 44 bytes before global variable 'server_crt_serial_len' …
SUMMARY: AddressSanitizer: global-buffer-overflow … in server_crt_update
```

With the guard applied (`serial.len > sizeof(server_crt_serial)` -> return before
the copy), the same 40-byte serial is rejected and ASan runs clean.

## How this was found

Surfaced by a deductive proof coupled with Squeeze Loop strategy: on the
unguarded path WP cannot discharge the
`memcpy` `requires valid_dest` obligation — `serial.len <= 20` is unprovable
because it is false for reachable inputs. A twin carrying the
`if (n > sizeof(dst)) return;` guard proves the same obligation (re-confirmed
under `-wp-model bytes`: unguarded `valid_dest` UNPROVED, guarded `valid_dest`
Valid). The contrast with the guarded `src/cert.c` sibling pinpointed the missing
check.

## Testing

- The ASan reproducer above faults (global-buffer-overflow) on the current logic
  and passes clean with the guard — suitable as a sanitizer-CI regression.
- Suggested integration regression: install a server certificate whose
  serialNumber is 21+ bytes via `pouch_gateway_server_cert_set` and assert
  `server_crt_update` returns an error and does not modify `server_crt_serial_len`
  (on current code it overflows the serial buffer).
