### PR TITLE
gateway/downlink: bound the CoAP block write into the block pool

### DIFF
--- a/src/gateway/downlink.c
+++ b/src/gateway/downlink.c
@@ -102,8 +102,7 @@ int pouch_gateway_downlink_block_cb(const uint8_t *data, size_t len, bool is_las
             downlink->last_block = block;
         }
 
-        int err =
-            pouch_msgq_put(&downlink->block_queue, &block, pouch_timepoint_timeout(deadline));
+        int err = pouch_msgq_put(&downlink->block_queue, &block, pouch_timepoint_timeout(deadline));
         if (err)
         {
             POUCH_LOG_ERR("Failed to enqueue block: %d", err);

--- a/src/gateway/downlink.c
+++ b/src/gateway/downlink.c
@@ -13,6 +13,7 @@
 #include <pouch/port.h>
 
 #include "../buf.h"
+#include "../block.h"
 
 POUCH_LOG_REGISTER(gw_downlink, CONFIG_POUCH_GATEWAY_LOG_LEVEL);
 
@@ -69,40 +70,60 @@ int pouch_gateway_downlink_block_cb(const uint8_t *data, size_t len, bool is_las
     pouch_timepoint_t deadline =
         pouch_timepoint_get(POUCH_SECONDS(CONFIG_POUCH_GATEWAY_DOWNLINK_BLOCK_TIMEOUT));
 
-    struct pouch_buf *block = blockbuf_alloc(pouch_timepoint_timeout(deadline));
-    if (block == NULL)
-    {
-        POUCH_LOG_ERR("Failed to allocate block");
-        return -ENOMEM;
-    }
-
-    buf_write(block, data, len);
-
-    /* Record the last block's pointer BEFORE submitting so the
-     * consumer sees it as soon as it dequeues this buffer.
+    /* A single received CoAP block payload may be larger than a block-pool
+     * element: CONFIG_POUCH_COAP_BLOCK_SIZE is independent of
+     * CONFIG_POUCH_BLOCK_SIZE (and defaults larger), and a misbehaving or
+     * hostile server can return an oversized datagram. A block-pool element
+     * holds at most MAX_PLAINTEXT_BLOCK_SIZE payload bytes, and buf_write() is
+     * unchecked, so bound every write to the element capacity and split the
+     * payload across as many blocks as needed. The consumer
+     * (pouch_gateway_downlink_get_data) drains queued blocks as a byte stream,
+     * so splitting is transparent; only the final chunk carries is_last.
      */
-    if (is_last)
+    do
     {
-        downlink->last_block = block;
-    }
+        size_t take = MIN(len, (size_t) MAX_PLAINTEXT_BLOCK_SIZE);
+        bool last_chunk = is_last && (take == len);
 
-    int err = pouch_msgq_put(&downlink->block_queue, &block, pouch_timepoint_timeout(deadline));
-    if (err)
-    {
-        POUCH_LOG_ERR("Failed to enqueue block: %d", err);
-        if (is_last)
+        struct pouch_buf *block = blockbuf_alloc(pouch_timepoint_timeout(deadline));
+        if (block == NULL)
         {
-            downlink->last_block = NULL;
+            POUCH_LOG_ERR("Failed to allocate block");
+            return -ENOMEM;
         }
-        blockbuf_free(block);
-        return -ENOMEM;
-    }
 
-    if (NULL == downlink->current_block
-        && pouch_atomic_test_and_clear_bit(downlink->flags, DOWNLINK_FLAG_TRANSPORT_WAITING))
-    {
-        downlink->data_available_cb(downlink->cb_arg);
-    }
+        buf_write(block, data, take);
+
+        /* Record the last block's pointer BEFORE submitting so the
+         * consumer sees it as soon as it dequeues this buffer.
+         */
+        if (last_chunk)
+        {
+            downlink->last_block = block;
+        }
+
+        int err =
+            pouch_msgq_put(&downlink->block_queue, &block, pouch_timepoint_timeout(deadline));
+        if (err)
+        {
+            POUCH_LOG_ERR("Failed to enqueue block: %d", err);
+            if (last_chunk)
+            {
+                downlink->last_block = NULL;
+            }
+            blockbuf_free(block);
+            return -ENOMEM;
+        }
+
+        if (NULL == downlink->current_block
+            && pouch_atomic_test_and_clear_bit(downlink->flags, DOWNLINK_FLAG_TRANSPORT_WAITING))
+        {
+            downlink->data_available_cb(downlink->cb_arg);
+        }
+
+        data += take;
+        len -= take;
+    } while (len);
 
     return 0;
 }


### PR DESCRIPTION
## Summary

`pouch_gateway_downlink_block_cb()` (`src/gateway/downlink.c`) writes an entire
received CoAP block payload into a pool element with no length check. The pool
element is dimensioned for `MAX_PLAINTEXT_BLOCK_SIZE` (515 bytes at defaults), but
the payload length is the CoAP block size — 1024 bytes in the shipped default
Kconfig. The first downlink block of every gateway session therefore writes 509
bytes past the pool element. The length is remote-controlled (it is the CoAP
datagram payload length), so this is a remote-triggerable pool/heap buffer
overflow.

Estmated Severity: High — reachable out-of-bounds write, remote-length-controlled,
present in the default configuration.

## The defect

`src/gateway/downlink.c`:

```c
int pouch_gateway_downlink_block_cb(const uint8_t *data, size_t len, bool is_last, void *arg)
{
    ...
    struct pouch_buf *block = blockbuf_alloc(pouch_timepoint_timeout(deadline));   /* :72 */
    if (block == NULL) { ...; return -ENOMEM; }

    buf_write(block, data, len);                                                   /* :79  <-- unbounded */
```

`buf_write` cannot bounds-check — `struct pouch_buf` carries no capacity field,
only a running `bytes` count (`src/buf.c`):

```c
struct pouch_buf { pouch_slist_node_t node; size_t bytes; uint8_t buf[]; };

void buf_write(struct pouch_buf *buf, const uint8_t *data, size_t len)
{ memcpy(buf_claim(buf, len), data, len); }

uint8_t *buf_claim(struct pouch_buf *buf, size_t bytes)
{ uint8_t *data = &buf->buf[buf->bytes]; buf->bytes += bytes; return data; }   /* no capacity */
```

The bound is a caller obligation, and on this path no caller enforces it.

`blockbuf_alloc()` returns an element of a statically dimensioned pool sized for
`MAX_PLAINTEXT_BLOCK_SIZE` (`port/zephyr/blockbuf.c`):

```c
K_MEM_SLAB_DEFINE(blockbuf, WB_UP(POUCH_BUF_OVERHEAD + MAX_PLAINTEXT_BLOCK_SIZE),
                  CONFIG_POUCH_BLOCK_COUNT, 4);
```

with `MAX_PLAINTEXT_BLOCK_SIZE = BLOCK_HEADER_SIZE(3) + (1 << LOG2(CONFIG_POUCH_BLOCK_SIZE))`
(`src/block.h`) = 515 at the default `CONFIG_POUCH_BLOCK_SIZE = 512`.

## Where `len` comes from

`len` is the payload length of the received CoAP datagram, forwarded from the CoAP
client's receive path down to the gateway downlink callback:

```
zsock_recv(coap_sock, coap_recv_buf, sizeof(coap_recv_buf))     port/zephyr/transport/coap/client.c:123
  coap_packet_parse(...) -> coap_packet_get_payload(resp, &resp_len)
    resp_cb(resp_data, resp_len, ...) ... -> cloud_downlink_cb
      pouch_gateway_downlink_block_cb(data, len /* = resp_len */, ...)  src/gateway/downlink.c:60
        buf_write(block, data, len)                                     src/gateway/downlink.c:79
```

`resp_len` is compared against nothing on this chain. Its only ceiling is the CoAP
receive buffer, `COAP_BUF_SIZE = COAP_HEADER_OVERHEAD(48) + CONFIG_POUCH_COAP_BLOCK_SIZE`
(`client.c:37-38`). Crucially, there is no `BUILD_ASSERT` or Kconfig dependency
relating `CONFIG_POUCH_COAP_BLOCK_SIZE` to `CONFIG_POUCH_BLOCK_SIZE` — the two
size knobs that must agree are independent.

## Two independent reachable overflows

### D1 — overflow in the shipped default configuration (no adversary)

Defaults: `CONFIG_POUCH_COAP_BLOCK_SIZE = 1024` (`.../coap/Kconfig:30`, range 64..1024)
and `CONFIG_POUCH_BLOCK_SIZE = 512` (`src/Kconfig:7`). The gateway itself requests
1024-byte Block2 chunks (`coap_append_block2_option` with `pouch_coap_block_size()`),
and an RFC 7959-conformant server returns 1024 payload bytes per block.

| | value |
|---|---|
| pool payload capacity `MAX_PLAINTEXT_BLOCK_SIZE` | 515 |
| first Block2 chunk `len` | 1024 |
| bytes written past the pool element | 509 |

On Zephyr the overrun lands in the next `k_mem_slab` element; a free slab
element stores the free-list `next` pointer in its first word, so this is an
allocator-pointer overwrite with server-controlled content.

### D2 — hostile overflow even when D1 is configured away

`resp_len` is never validated against the negotiated block size, and the payload of
a response carrying no Block2 option is forwarded as a single block. A malicious
or compromised server (or anyone holding a cert the gateway's `sec_tag` accepts)
returns one oversized datagram: `resp_len` is bounded only by
`COAP_BUF_SIZE = 48 + CONFIG_POUCH_COAP_BLOCK_SIZE`, i.e. up to ~48 bytes past
capacity even when the two block sizes are "matched", because of the 48-byte header
slack. No pairing of the two Kconfig knobs makes D2 unreachable.

## Reproduction (AddressSanitizer)

`W5a-asan-test.c` reuses the shipped semantics verbatim — `struct pouch_buf`
(no capacity), `buf_claim`/`buf_write`, the slab geometry
`WB_UP(POUCH_BUF_OVERHEAD + MAX_PLAINTEXT_BLOCK_SIZE)`, and
`pouch_gateway_downlink_block_cb`'s unbounded `buf_write` — built at the default
Kconfig (block 512 → capacity 515, CoAP block 1024):

```
cc -g -fsanitize=address W5a-asan-test.c -o w5a && ./w5a
```

ASan faults on the write, past the pool element, in `buf_write ← downlink_block_cb`:

```
coap payload len = 1024, pool payload capacity MAX_PLAINTEXT_BLOCK_SIZE = 515, overflow = 509
==…==ERROR: AddressSanitizer: heap-buffer-overflow … WRITE of size 1024 …
    #1 … in buf_write                          W5a-asan-test.c:27
    #2 … in pouch_gateway_downlink_block_cb    W5a-asan-test.c:40
… is located 0 bytes after 532-byte region      <-- the pool element, WB_UP(16 + 515)
    #1 … in blockbuf_alloc                     W5a-asan-test.c:31
SUMMARY: AddressSanitizer: heap-buffer-overflow … in buf_write
```

(532 is the 64-bit host element size, `WB_UP(16 + 515)`; on 32-bit targets it is
`WB_UP(8 + 515) = 524`. It overflows either way.) With the chunk-and-bound fix
below applied, the same 1024-byte payload is split into ≤ 515-byte writes and ASan
runs clean.

## Why the existing tests miss it

`tests/pouch/gateway/src/stub_blockbuf.c` replaces the slab with an 8× oversized
`malloc`:

```c
#define STUB_BLOCKBUF_SIZE 4096
struct pouch_buf *blockbuf_alloc(pouch_timeout_t t) { return buf_alloc(STUB_BLOCKBUF_SIZE); }
```

Every gateway downlink test runs against a 4096-byte buffer (vs the real 515-byte
capacity) and writes only a few bytes, so the test double masks the exact geometry
that makes production unsafe.

## The contrast that settles intent

The device (non-gateway) consumer of the same CoAP callback signature bounds
correctly (`src/downlink.c`):

```c
if (buf_size_get(encrypted) >= MAX_CIPHERTEXT_BLOCK_SIZE) { return -ENOMEM; }
size_t buf_written = MIN(buf_len, MAX_CIPHERTEXT_BLOCK_SIZE - buf_size_get(encrypted));
buf_write(encrypted, buf_p, buf_written);       /* inside a while (buf_len) loop */
```

and the gateway uplink path bounds too (`src/gateway/uplink.c`,
`space = GW_BLOCK_MAX_BYTES - buf_size_get(...)`, `MIN(len, space)`). The gateway
downlink ingress is the one place the `MIN`-and-loop idiom is missing. It is
also a size-class mismatch: the buffer holds downlink ciphertext (bound
`MAX_CIPHERTEXT_BLOCK_SIZE`), yet the pool is dimensioned for plaintext.

## Suggested fix

Mirror the device path — chunk and bound — and add the missing build-time relation:

```c
/* src/gateway/downlink.c — replace the single unbounded buf_write */
while (len) {
    struct pouch_buf *block = blockbuf_alloc(pouch_timepoint_timeout(deadline));
    if (block == NULL) { POUCH_LOG_ERR("Failed to allocate block"); return -ENOMEM; }

    size_t take = MIN(len, (size_t) MAX_PLAINTEXT_BLOCK_SIZE);
    buf_write(block, data, take);
    data += take;
    len  -= take;
    /* existing is_last / pouch_msgq_put / free-on-error handling,
     * with is_last set only on the final chunk */
}
```

plus, independently, either

- `BUILD_ASSERT(CONFIG_POUCH_COAP_BLOCK_SIZE <= MAX_PLAINTEXT_BLOCK_SIZE, ...)`, or
  — better, as it also fixes the plaintext-pool-for-ciphertext mismatch — draw the
  gateway downlink block from a `MAX_CIPHERTEXT_BLOCK_SIZE`-dimensioned pool and
  reject `resp_len` above that at the CoAP layer, where the negotiated block size is
  known.

Longer term, a `capacity` field on `struct pouch_buf` (or a bounds assert inside
`buf_claim`) would turn a whole class of these into fail-stops instead of silent
pool overruns.

## How this was found

This was found by creating a model of Pouch using a theorem prover, then proving using
Weakest Preconditions the expected properties on the source code. WP could not
discharge the `buf_write` `valid_dest` obligation on this path -
`len <= MAX_PLAINTEXT_BLOCK_SIZE` is unprovable because it is false for reachable
inputs and the contrast with the bounded device/uplink siblings pinpointed the missing
guard. The finding was then confirmed independently under AddressSanitizer (above),
at the default Kconfig, with a faithful transcription of the shipped
`buf`/`block`/slab geometry.

## Notes

What the change does in`src/gateway/downlink.c`:

- Adds `#include "../block.h"` (for `MAX_PLAINTEXT_BLOCK_SIZE`, not currently in
  scope in this file).
- Wraps the alloc/write/enqueue in a `do { … } while (len)` loop that bounds each
  write to `MIN(len, MAX_PLAINTEXT_BLOCK_SIZE)` and splits an oversized payload
  across as many pool blocks as needed — mirroring the device-side sibling's idiom.

Design points verified rather than assumed:

- Splitting is safe: the consumer `pouch_gateway_downlink_get_data` drains
  queued blocks as a continuous byte stream (concatenates, block boundaries carry
  no meaning) — so re-chunking is transparent to it.
- `is_last` only on the final chunk: `last_chunk = is_last && (take == len)`, so
  `last_block` points at the last queued block — preserving end-of-stream detection.
  The error path clears `last_block` only for that chunk.
- `do/while` (not `while`): preserves the original `len == 0` behavior — an
  `is_last` call with no payload still enqueues exactly one empty block as the
  end-marker (a `while (len)` would have dropped it).
- No `BUILD_ASSERT` added: deliberately did not add the alternative
  `BUILD_ASSERT(CONFIG_POUCH_COAP_BLOCK_SIZE <= MAX_PLAINTEXT_BLOCK_SIZE)` — it would
  fail the default build (1024 > 515). The chunk loop is the general fix that makes
  any size safe.

## Verification

- Behavioral harness under ASan: 1024-byte payload → two blocks (515 + 509),
  reassembles to the exact original bytes in order, `is_last` set on the final chunk
  only, `len == 0` end-marker preserved — all ASan-clean.

## Caveat

The patch bounds writes to the pool's actual `MAX_PLAINTEXT_BLOCK_SIZE`
capacity, which fixes the memory safety. The deeper plaintext-pool-holds-ciphertext
size-class mismatch (§6 above) is a separate design decision (re-dimension the pool
to `MAX_CIPHERTEXT_BLOCK_SIZE`) that is left out of this minimal safety patch; it can
be prepared as a follow-up if desired.
