### PR TITLE
saead/session: nonce reuse under one session key

### DIFF
--- a/src/saead/downlink.c
+++ b/src/saead/downlink.c
@@ -153,12 +153,6 @@ struct pouch_buf *saead_downlink_block_buf_alloc(void)
 
 int saead_downlink_block_decrypt(const struct pouch_buf *block, struct pouch_buf *decrypted)
 {
-    if (!pouch_atomic_test_bit(&downlink.flags, SESSION_ACTIVE))
-    {
-        POUCH_LOG_ERR("Not in a session");
-        return -ENOTCONN;
-    }
-
     int err = session_decrypt_block(&downlink, block, decrypted);
     if (0 != err)
     {

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -199,6 +199,12 @@ static void nonce_generate(const struct session *session,
 
 struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_buf *block)
 {
+    if (session->pouch.block_index == UINT16_MAX)
+    {
+        POUCH_LOG_ERR("Block index space exhausted; session must rotate");
+        return NULL;
+    }
+
     struct pouch_buf *encrypted = buf_alloc(MAX_CIPHERTEXT_BLOCK_SIZE);
     if (encrypted == NULL)
     {
@@ -277,6 +283,12 @@ int session_decrypt_block(struct session *session,
                           const struct pouch_buf *block,
                           struct pouch_buf *decrypted)
 {
+    if (session->pouch.block_index == UINT16_MAX)
+    {
+        POUCH_LOG_ERR("Block index space exhausted; session must rotate");
+        return -ERANGE;
+    }
+
     uint8_t nonce[NONCE_LEN];
     nonce_generate(session, POUCH_ROLE_SERVER, nonce);
 

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -184,6 +184,8 @@ int session_pouch_start(struct session *session, pouch_id_t pouch_id)
     session->pouch.id = pouch_id;
     session->pouch.block_index = 0;
 
+    pouch_atomic_set_bit(&session->flags, SESSION_POUCH_OPEN);
+
     return 0;
 }
 
@@ -197,11 +199,27 @@ static void nonce_generate(const struct session *session,
     memset(&nonce[5], 0, NONCE_LEN - 5);
 }
 
+static bool pouch_is_open(const struct session *session)
+{
+    if (!pouch_atomic_test_bit(&session->flags, SESSION_ACTIVE))
+    {
+        POUCH_LOG_ERR("Not in a session");
+        return false;
+    }
+
+    if (!pouch_atomic_test_bit(&session->flags, SESSION_POUCH_OPEN))
+    {
+        POUCH_LOG_ERR("Pouch has been closed");
+        return false;
+    }
+
+    return true;
+}
+
 struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_buf *block)
 {
-    if (session->pouch.block_index == UINT16_MAX)
+    if (!pouch_is_open(session))
     {
-        POUCH_LOG_ERR("Block index space exhausted; session must rotate");
         return NULL;
     }
 
@@ -267,6 +285,13 @@ struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_bu
         return NULL;
     }
 
+    if (session->pouch.block_index == UINT16_MAX)
+    {
+        // This pouch is now full, and we shouldn't accept any more blocks for it.
+        pouch_atomic_clear_bit(&session->flags, SESSION_POUCH_OPEN);
+        return encrypted;
+    }
+
     // prepare for the next block:
     memcpy(&session->pouch.ad, &ciphertext[plaintext_len], AUTH_TAG_LEN);
     session->pouch.block_index++;
@@ -283,10 +308,9 @@ int session_decrypt_block(struct session *session,
                           const struct pouch_buf *block,
                           struct pouch_buf *decrypted)
 {
-    if (session->pouch.block_index == UINT16_MAX)
+    if (!pouch_is_open(session))
     {
-        POUCH_LOG_ERR("Block index space exhausted; session must rotate");
-        return -ERANGE;
+        return -ENOLINK;
     }
 
     uint8_t nonce[NONCE_LEN];
@@ -337,6 +361,13 @@ int session_decrypt_block(struct session *session,
     {
         POUCH_LOG_ERR("Unexpected length");
         return -EINVAL;
+    }
+
+    if (session->pouch.block_index == UINT16_MAX)
+    {
+        // This pouch is now full, and we can't add any more blocks to it.
+        pouch_atomic_clear_bit(&session->flags, SESSION_POUCH_OPEN);
+        return 0;
     }
 
     // prepare for the next block:

--- a/src/saead/session.h
+++ b/src/saead/session.h
@@ -49,6 +49,7 @@ enum session_flags
     SESSION_VALID,
     SESSION_ACTIVE,
     SESSION_HAS_POUCH,
+    SESSION_POUCH_OPEN,
 };
 
 struct session

--- a/src/saead/session.h
+++ b/src/saead/session.h
@@ -60,7 +60,7 @@ struct session
     struct
     {
         pouch_id_t id;
-        uint32_t block_index;
+        uint16_t block_index;
         uint8_t ad[AD_LEN];
     } pouch;
 };

--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -104,13 +104,6 @@ int saead_uplink_header_get(struct saead_info *info)
 
 struct pouch_buf *saead_uplink_encrypt_block(struct pouch_buf *block)
 {
-    if (!pouch_atomic_test_bit(&uplink.flags, SESSION_ACTIVE))
-    {
-        POUCH_LOG_WRN("Not in a session");
-        block_free(block);
-        return NULL;
-    }
-
     struct pouch_buf *encrypted = session_encrypt_block(&uplink, block);
 
     block_free(block);


### PR DESCRIPTION
## Summary

The per-block AEAD nonce embeds `session->pouch.block_index` - a `uint32_t`
counter - through `pouch_put_be16`, which takes a 16-bit argument. The index is
therefore truncated to its low 16 bits in the nonce. Within a single session (one
key, one `pouch.id`), two blocks whose indices differ by a multiple of 2^16 build the
same nonce. `block_index` is unbounded, so a session of >= 2^16 blocks reuses a
`(key, nonce)` pair - an AEAD failure: a two-time pad across the
colliding blocks (confidentiality break) and, under AES-GCM, recovery of the
authentication subkey `H` -> universal forgery. This PR bounds `block_index` to the
lossless range of the nonce field so the nonce is injective by construction within a
session.

Severity: High - cryptographic (nonce reuse) on the shipped default
configuration; intra-session, reachable without any adversary.

## The defect

`src/saead/session.c`, `nonce_generate` (`:190-198`):

```c
static void nonce_generate(const struct session *session, enum pouch_role sender,
                           uint8_t nonce[NONCE_LEN])
{
    pouch_put_be16(session->pouch.id, &nonce[0]);          /* pouch_id_t == uint16_t : lossless */
    pouch_put_be16(session->pouch.block_index, &nonce[2]); /* uint32_t -> uint16_t : TRUNCATED */
    nonce[4] = sender;
    memset(&nonce[5], 0, NONCE_LEN - 5);
}
```

`session->pouch.block_index` is `uint32_t` (`src/saead/session.h:63`), and
`pouch_put_be16(uint16_t val, uint8_t dst[2])` (`port/.../..._port_layer.c`) stores only
`val`'s low 16 bits. So `nonce` varies only in `block_index mod 2^16`:

- One session = one key = one `pouch.id`. `pouch.id` is fixed for the session
  and `block_index` resets to 0 at `session_pouch_start` (`session.c:185`) and is
  incremented `+1` after every sealed block (`session.c:266` encrypt, `:332` decrypt).
- Nothing bounds `block_index` anywhere in the tree - no rotation, no expiry, no
  counter check. So `nonce(k) == nonce(k + 65536)` under the same key.

The AEAD keystream of both AES-GCM and ChaCha20-Poly1305 is a function of
`(key, nonce)` only; the chained associated data (`session->pouch.ad`) enters the
tag, not the keystream, so it cannot mitigate a nonce collision.

## Reachability

`CONFIG_POUCH_BLOCK_SIZE` declares no Kconfig `range`; the legal ceiling from the
16-bit block-size field is `L ≤ 15`. Blocks needed to reach 2^16:

| `CONFIG_POUCH_BLOCK_SIZE` | app bytes to 2^16 blocks (stream path) | zero-payload path |
|---|---|---|
| 8 | 524 288 | 0 |
| 512 (default) | 32 MiB | 0 |
| 4096 | 256 MiB | 0 |
| 32768 (max legal) | 2 GiB | 0 |

The zero-payload path is config-independent: `pouch_uplink_entry_write`
(`src/entry.c`) seals and enqueues the current block whenever `write_entry` fails,
with no "is it non-empty" test (contrast `entry_block_close`, which *does* test
`block_size_get > 0`). An entry that can never fit (`5 + pathlen + len > 2^L`) makes
every call seal an essentially empty block, so 65 537 such calls -> 65 536 sealed
blocks -> 0 application payload, ~1.19 MiB on the wire, at any block size, as long
as an uplink stream is held open. Devices that never open an uplink stream are
bounded by the blockbuf pool (`range 2 10000` < 65 536) and do not wrap - the defect
is "any device that holds an uplink stream open wraps, at zero payload cost".

## Confirmation

This is a cryptographic-logic defect, not a memory-safety bug - AddressSanitizer
is not the detector. The confirmation is a witness (`W7b-witness.c`) that
transcribes `nonce_generate` and `pouch_put_be16` verbatim and prints the two
nonces, compiled under `-fsanitize=address` to show the collision produces no
memory error (which is why sanitizer/fuzz tests do not surface it):

```
cc -g -fsanitize=address W7b-witness.c -o w7b && ./w7b        # shipped nonce_generate
[W7-b witness | shipped src/saead/session.c]
  nonce(block_index=0)      00 01 00 00 00 00 00 00 00 00 00 00
  nonce(block_index=1)      00 01 00 01 00 00 00 00 00 00 00 00
  nonce(block_index=65536)  00 01 00 00 00 00 00 00 00 00 00 00
  W7B-NONCEREUSE-CONFIRMED: nonce(0) == nonce(65536) under the SAME key (two-time pad; AES-GCM H-recovery -> forgery)
```

`nonce(0)` and `nonce(65536)` are byte-identical; `nonce(0)` vs `nonce(1)` differ
(non-vacuity). ASan reports nothing. Rebuilt with `-DFIX` (the guard below),
`block_index = 65536` is refused before sealing, so the colliding nonce is never
generated (`W7B-NO-REUSE`).

## The fix

Refuse to seal once `block_index` would exceed the lossless range of the 16-bit
nonce field, so every sealed block in a session has `block_index ≤ 0xFFFF` and the
nonce is injective in the full `(pouch.id, block_index, sender)` by construction.

```c
/* src/saead/session.c, with the other #defines */
/* Largest block index whose 16-bit big-endian nonce field is lossless. A session
 * must rotate before exceeding it, so the AEAD nonce stays injective in block_index.
 * block_index is a uint32 counter but pouch_put_be16 embeds only its low 16 bits. */
#define BLOCK_INDEX_MAX UINT16_MAX   /* 2^16 blocks per session, indices [0..0xFFFF] */
```

```diff
 struct pouch_buf *session_encrypt_block(struct session *session, struct pouch_buf *block)
 {
+    if (session->pouch.block_index > BLOCK_INDEX_MAX)
+    {
+        POUCH_LOG_ERR("Block index space exhausted; session must rotate");
+        return NULL;
+    }
     struct pouch_buf *encrypted = buf_alloc(MAX_CIPHERTEXT_BLOCK_SIZE);
```

```diff
 int session_decrypt_block(struct session *session, const struct pouch_buf *block,
                           struct pouch_buf *decrypted)
 {
+    if (session->pouch.block_index > BLOCK_INDEX_MAX)
+    {
+        POUCH_LOG_ERR("Block index space exhausted; session must rotate");
+        return -ERANGE;
+    }
     uint8_t nonce[NONCE_LEN];
```

`block_index` increments only after a successful seal, so index `0xFFFF` is sealed,
`block_index` becomes `0x10000`, and the next call refuses - exactly 2^16 sealable
blocks per session.

Honesty note - the guard needs a rotation trigger to be complete. The guard is
*fail-closed* (no nonce reuse) but is not sufficient on its own: the current caller
does not rotate to a fresh session on a seal failure. `crypto_encrypt_block()`
returning NULL lands in `process_blocks`, which merely does `continue;`
(`src/uplink.c`) after the block is freed - no rotation. With only the guard,
`block_index` sticks at `0x10000` and every subsequent block in that session is
silently dropped (a fail-closed DoS - vastly better than nonce reuse, but still a
liveness bug). A complete fix must pair the guard with a real session-rotation
trigger on exhaustion.

Alternatives (from the finding): (d) widen the nonce `block_index` field to ≥ 32
bits (removes the truncation at the source, no rotation ceiling - but a wire-format
change requiring peer version negotiation); (b) a key/AD-committing AEAD; (c) a
nonce-misuse-resistant AEAD (AES-GCM-SIV) as defense-in-depth. The bound is the
smallest, no-wire-change fix and is recommended now, with (d) recorded as the
eventual protocol-rev fix.

## How this was found

Deductive proof of `src/saead/session.c` against a Lean model of Pouch.
The nonce byte construction proves
```
`nonce[0..1]=be16(pouch.id)`, `nonce[2..3]=be16(block_index)`, `nonce[4]=sender`
```
but anti-splicing over the *unbounded* index could not be discharged - it rested on
a truncation-reachable assumption plus the AEAD's AD-commitment. The fork prototype
with the guard proves the strengthened, no-`uint16`-cast nonce post-condition
(injective in the full `uint32` index) and a no-wrap `block_index++`; deleting the
guard reddens the `block_index ≤ BLOCK_INDEX_MAX` precondition - the guard is
load-bearing. The guard makes the nonce injective *in-session* by construction; the
AEAD injectivity itself remains a trusted crypto-primitive assumption (this fix
removes the wrap/truncation leg, not the primitive leg).
