### PR TITLE
transport/sar: NULL-region write on a failed open

### DIFF
--- a/src/transport/sar/sender.c
+++ b/src/transport/sar/sender.c
@@ -154,11 +154,7 @@ int pouch_sender_open(struct pouch_sender *sender, struct pouch_bearer *bearer)
         }
     }
 
-    // Publish the sender only once it is fully initialized. Setting bearer/state
-    // before the buffer exists would leave a failed open (malloc or endpoint->start
-    // failure) in a half-initialized state (bearer set, state READY, buf NULL) that
-    // pouch_sender_recv()'s bearer!=NULL check would accept, driving push_fragments()
-    // to dereference &buf[HEADER_LEN] == NULL + HEADER_LEN.
+    // Publish the sender only once it is fully initialized.
     sender->buf = buf;
     sender->bearer = bearer;
     sender->seq = 0;

--- a/src/transport/sar/sender.c
+++ b/src/transport/sar/sender.c
@@ -138,27 +138,32 @@ int pouch_sender_open(struct pouch_sender *sender, struct pouch_bearer *bearer)
         return -EINVAL;
     }
 
-    sender->bearer = bearer;
-    sender->seq = 0;
-    sender->window = 0;
-    sender->state = STATE_READY;
-
-    sender->buf = malloc(bearer->maxlen);
-    if (sender->buf == NULL)
+    uint8_t *buf = malloc(bearer->maxlen);
+    if (buf == NULL)
     {
         return -ENOMEM;
     }
 
     if (sender->endpoint->start != NULL)
     {
-        int err = sender->endpoint->start(sender->bearer);
+        int err = sender->endpoint->start(bearer);
         if (err)
         {
-            free(sender->buf);
-            sender->buf = NULL;
+            free(buf);
             return err;
         }
     }
+
+    // Publish the sender only once it is fully initialized. Setting bearer/state
+    // before the buffer exists would leave a failed open (malloc or endpoint->start
+    // failure) in a half-initialized state (bearer set, state READY, buf NULL) that
+    // pouch_sender_recv()'s bearer!=NULL check would accept, driving push_fragments()
+    // to dereference &buf[HEADER_LEN] == NULL + HEADER_LEN.
+    sender->buf = buf;
+    sender->bearer = bearer;
+    sender->seq = 0;
+    sender->window = 0;
+    sender->state = STATE_READY;
 
     // wait for the receiver to send an ack with a window.
 


### PR DESCRIPTION
## Summary

`pouch_sender_open()` sets `sender->bearer` and `sender->state = STATE_READY`
before it allocates `sender->buf`. On a `malloc` failure (`-ENOMEM`) or an
`endpoint->start` failure, it returns an error but leaves the sender in a
half-initialized, *published* state: `bearer != NULL`, `state == STATE_READY`,
`buf == NULL`. In that state `pouch_sender_recv()`'s `bearer == NULL` guard no
longer fires, so a window-advancing ACK reaches `push_fragments()`, which builds
`pkt.data = &sender->buf[HEADER_LEN]` (= `NULL + 2`) and hands it to
`endpoint->send()` — a real data source writes payload into that near-NULL
pointer, faulting. This PR makes the failure paths restore
`bearer = NULL`/`STATE_CLOSED` so a failed open cannot be driven.

Severity: Medium — NULL-region write (crash/DoS) on the failed-open path;
requires an allocation or `endpoint->start` failure to arm, then a peer-driven
ACK. (The raw finding graded this a *candidate*; the ASan witness below settles
the crash mechanism.)

## The defect

`src/transport/sar/sender.c`, `pouch_sender_open` (`:134`):

```c
    sender->bearer = bearer;          /* :141  published */
    sender->seq = 0;
    sender->window = 0;
    sender->state = STATE_READY;      /* :144  published */

    sender->buf = malloc(bearer->maxlen);   /* :146  allocated AFTER */
    if (sender->buf == NULL)
    {
        return -ENOMEM;               /* :149  leaves bearer!=NULL, state=READY, buf=NULL */
    }

    if (sender->endpoint->start != NULL)
    {
        int err = sender->endpoint->start(sender->bearer);
        if (err)
        {
            free(sender->buf);
            sender->buf = NULL;       /* :158  same half-initialized state, buf=NULL */
            return err;
        }
    }
```

Both error returns leave the sender published (`bearer != NULL`,
`state == STATE_READY`) with `buf == NULL`.

## The reachable use

`pouch_sender_recv` (`:168`) guards only on `bearer == NULL`, which is no longer
true, so it proceeds to process an ACK and — with `state == STATE_READY` — calls
`push_fragments` (`:226`). `push_fragments` (`:73`):

```c
        struct pouch_sar_tx_pkt pkt = {
            .data = &sender->buf[POUCH_SAR_TX_PKT_HEADER_LEN],   /* NULL + 2 when buf == NULL */
            .len  = sender->bearer->maxlen - POUCH_SAR_TX_PKT_HEADER_LEN,
        };
        enum pouch_result res = sender->endpoint->send(sender->bearer, (void *) pkt.data, &pkt.len);  /* :87 */
        ...
        int err = pouch_sar_tx_pkt_encode(&pkt, sender->buf, &len);   /* :107 */
```

`endpoint->send(bearer, dst, dst_len)` is a data source that writes payload into
`dst` (e.g. `device/uplink.c::send` -> `pouch_uplink_fill(uplink, dst, dst_len)`).
Here `dst = pkt.data = NULL + 2`, so a live uplink with data performs a write to a
near-NULL address -> SEGV.

The existing NULL-defense is in the wrong place. `pouch_sar_tx_pkt_encode`
*does* defensively return on `dst == NULL` (`packet.c:89`), and a Frama-C sweep
relied on that to bound this site. But `endpoint->send` (`:87`) runs before the
encode (`:107`), so the write through the near-NULL `pkt.data` faults first — the
defensive check never runs on this path.

## Confirmation (AddressSanitizer)

The raw finding recorded this as a candidate with no witness. `W8-witness.c`
transcribes the failed-open state, `pouch_sender_recv`'s reachable ACK path, and
`push_fragments`, with an `endpoint->send` that writes payload into `dst` (modeling
`pouch_uplink_fill`), and a discriminating companion (successful open):

```
cc -g -fsanitize=address W8-witness.c -o w8

./w8 failopen
[failopen] sender_open rc=-12 : bearer=SET state=READY buf=NULL
  driving a window-advancing ACK (peer writes data characteristic)...
==…==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000002
==…==The signal is caused by a WRITE memory access.
    #1 … in ep_send          W8-witness.c:25
    #2 … in push_fragments   W8-witness.c:57

./w8 ok
[ok] sender_open rc=0 : bearer=SET state=READY buf=alloc
  driving a window-advancing ACK ...
  survived (no fault); buf=alloc
```

The write faults at address `0x2` (= `NULL + POUCH_SAR_TX_PKT_HEADER_LEN`), inside
`endpoint->send`, reached via `push_fragments`; the successfully-opened sender does
not fault. This confirms the crash mechanism and that it is discriminated exactly by
the failed-open `buf == NULL` state.

Reachability, stated honestly. Three legs must combine: (1) the failed-open state
— *confirmed reachable* against the real code (either `malloc` returns NULL under
memory pressure, or `endpoint->start` returns an error; both leave the published
half-state); (2) an ACK that advances the window into `push_fragments` — the ordinary
receive path; (3) a data-producing endpoint so `send` writes into the buffer. The
witness confirms legs (2)+(3) produce the crash given leg (1). What this witness does
not independently re-verify is the end-to-end network path through the Zephyr GATT
transport — the raw finding argues the peripheral maps the open error onto the *CCC*
attribute only, so the peer can still write the *data* characteristic and reach
`recv`; that GATT-layer claim is plausible but not re-checked here. The fix below is
correct regardless of the exact reachability probability, because a failed open must
not leave a published, half-initialized sender.

## The fix

Do not publish `bearer`/`STATE_READY` until the buffer exists, and restore a closed
state on every failure path:

```c
int pouch_sender_open(struct pouch_sender *sender, struct pouch_bearer *bearer)
{
    if (bearer->maxlen <= POUCH_SAR_TX_PKT_HEADER_LEN)
    {
        return -EINVAL;
    }

    uint8_t *buf = malloc(bearer->maxlen);
    if (buf == NULL)
    {
        return -ENOMEM;                     /* nothing published yet */
    }

    if (sender->endpoint->start != NULL)
    {
        int err = sender->endpoint->start(bearer);
        if (err)
        {
            free(buf);
            return err;                     /* still nothing published */
        }
    }

    sender->buf    = buf;                    /* publish only once fully initialized */
    sender->bearer = bearer;
    sender->seq    = 0;
    sender->window = 0;
    sender->state  = STATE_READY;
    return 0;
}
```

(Equivalently, keep the current ordering but on each failure path set
`sender->bearer = NULL; sender->state = STATE_CLOSED;` before returning.) Either way
`pouch_sender_recv`'s `bearer == NULL` guard fires after a failed open, and
`push_fragments` is never entered with `buf == NULL`. A defence-in-depth
`buf == NULL` check in `push_fragments`/`pouch_sender_recv` is also cheap and would
harden the invariant.

## How this was found

Deductive proof of SAR call-site sweep: `pouch_sar_tx_pkt_encode` against a Lean
model of Pouch. `pouch_sar_tx_pkt_encode`'s entry precondition are
broken by the failed-open state, and the proof only held because the reachable NULL
input was excluded as a defensive branch — a cap that is doing real work here. The
witness then confirmed the state is not merely contract-illegal but produces an
actual near-NULL write, upstream of the defensive check.
