### PR TITLE
fix(serial): guard optional endpoint->end and re-arm a stalled channel

### DIFF
--- a/include/pouch/transport/serial/broker.h
+++ b/include/pouch/transport/serial/broker.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <pouch/port.h>
+
+/**
+ * @file broker.h
+ * @brief Pouch Serial transport (broker side)
+ *
+ * The broker is the master of the serial exchange. It initiates all transfers,
+ * drives the provisioning and data exchange sequence, and owns a
+ * @ref pouch_serial_broker instance allocated by the transport adapter.
+ *
+ * Typical usage:
+ *
+ *   1. Embed @ref pouch_serial_broker inside your adapter context struct.
+ *   2. Fill in a @ref pouch_serial_broker_adapter with your ready/end callbacks
+ *      and the adapter's maximum frame size.
+ *   3. Call @ref pouch_serial_broker_init once at startup.
+ *   4. Call @ref pouch_serial_broker_start to begin an exchange with a device.
+ *   5. Feed received frames to @ref pouch_serial_broker_recv.
+ *   6. Call @ref pouch_serial_broker_notify when the device signals that it
+ *      has data available (e.g. via an interrupt line).
+ */
+
+struct pouch_serial_broker;
+struct pouch_gateway_node_info;
+
+/**
+ * Transport adapter interface for the serial broker.
+ *
+ * The adapter is responsible for all physical bus concerns (framing, length
+ * delimitation, error detection). It presents complete frames to the broker
+ * protocol layer and retrieves complete frames from it via
+ * @ref pouch_serial_broker_frame_get.
+ */
+struct pouch_serial_broker_adapter
+{
+    /**
+     * Signal to the adapter that the broker has a frame ready to send.
+     *
+     * Called whenever @ref pouch_serial_broker_frame_get would return a non-zero
+     * length. The adapter should call @ref pouch_serial_broker_frame_get at its
+     * next opportunity.
+     *
+     * @param broker Broker instance.
+     */
+    void (*ready)(const struct pouch_serial_broker *broker);
+
+    /**
+     * Called when the exchange sequence completes or fails.
+     *
+     * @param broker  Broker instance.
+     * @param success true if the full exchange completed successfully.
+     */
+    void (*end)(const struct pouch_serial_broker *broker, bool success);
+};
+
+/**
+ * Create a broker instance.
+ * The broker must be started with @ref pouch_serial_broker_start before it can
+ * process frames.
+ *
+ * @param adapter Serial adapter to use for this broker.
+ * @return Pointer to the created broker instance, or NULL on failure.
+ */
+struct pouch_serial_broker *pouch_serial_broker_create(
+    const struct pouch_serial_broker_adapter *adapter);
+
+/**
+ * Start the Pouch exchange sequence with a device.
+ *
+ * Drives the full sequence:
+ *   Info -> Server Cert (if needed) -> Device Cert (if needed) ->
+ *   Uplink drain -> Downlink delivery
+ *
+ * The adapter's @c end callback is invoked when the sequence completes or
+ * fails. Only one exchange may be in progress at a time.
+ *
+ * @param broker  Broker instance.
+ *
+ * @return 0 on success, negative error code if the exchange cannot be started.
+ */
+int pouch_serial_broker_start(struct pouch_serial_broker *broker);
+
+/**
+ * Deliver a received frame from the device to the broker transport layer.
+ *
+ * Called by the transport adapter with each complete frame received from the
+ * device. The first byte of @p frame is the encoded header; the remaining
+ * bytes are the payload.
+ *
+ * @param broker  Broker instance.
+ * @param frame   Frame bytes, starting with the 1-byte header.
+ * @param len     Total frame length in bytes (header + payload).
+ * @return 0 on success, negative error code on failure.
+ */
+int pouch_serial_broker_recv(struct pouch_serial_broker *broker, const void *frame, size_t len);
+
+/**
+ * Get a frame of data to send over the serial link.
+ *
+ * Called by the transport adapter when it needs to send data to the device.
+ * The broker fills @p buf with the next pending frame (header + payload).
+ *
+ * @param broker  Broker instance.
+ * @param buf     Buffer that should be filled with the frame to send.
+ * @param maxlen  Maximum number of bytes to write to @p buf. The broker will
+ *                not write more than this many bytes.
+ *
+ * @return Number of bytes written to @p buf, or 0 if there is no frame ready.
+ */
+size_t pouch_serial_broker_frame_get(struct pouch_serial_broker *broker,
+                                     uint8_t *buf,
+                                     size_t maxlen);
+
+/**
+ * Signal to the broker that the device has data available to send.
+ *
+ * Called by the transport adapter when the device asserts an interrupt line or
+ * otherwise indicates it has uplink data ready. The broker will issue a prompt
+ * on the uplink channel at its next opportunity.
+ *
+ * @param broker  Broker instance.
+ */
+void pouch_serial_broker_notify(struct pouch_serial_broker *broker);
+
+/**
+ * Get the adapter associated with a broker instance.
+ *
+ * @param broker  Broker instance.
+ * @return Pointer to the adapter passed to @ref pouch_serial_broker_create.
+ */
+const struct pouch_serial_broker_adapter *pouch_serial_broker_adapter_get(
+    const struct pouch_serial_broker *broker);

--- a/include/pouch/transport/serial/common.h
+++ b/include/pouch/transport/serial/common.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#define POUCH_SERIAL_HEADER_LEN 1
+#define POUCH_SERIAL_CH_BROKER_TO_DEVICE(ch) ((ch) & 1)
+
+enum pouch_serial_channel_id
+{
+    POUCH_SERIAL_CH_INFO,        /**< Device -> Broker: device metadata and flags */
+    POUCH_SERIAL_CH_SERVER_CERT, /**< Broker -> Device: Golioth server certificate chain */
+    POUCH_SERIAL_CH_DEVICE_CERT, /**< Device -> Broker: device leaf certificate */
+    POUCH_SERIAL_CH_DOWNLINK,    /**< Broker -> Device: inbound pouches */
+    POUCH_SERIAL_CH_UPLINK,      /**< Device -> Broker: outbound pouches */
+
+    POUCH_SERIAL_CHANNEL_COUNT,
+};

--- a/include/pouch/transport/serial/device.h
+++ b/include/pouch/transport/serial/device.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @file device.h
+ * @brief Pouch Serial transport - device side.
+ *
+ * The device side is a singleton module: there is no per-instance struct
+ * exposed to the transport adapter. The adapter calls the module-level
+ * @ref pouch_serial_device_recv function to deliver received frames and
+ * implements the @ref pouch_serial_device_adapter vtable to transmit frames
+ * and optionally signal the broker when data is available.
+ */
+
+typedef void (*pouch_serial_device_ready_cb_t)(void);
+
+/**
+ * Initialize the serial device transport.
+ *
+ * Must be called once before any frames are delivered via @ref pouch_serial_device_recv.
+ *
+ * @param ready_cb Optional callback to signal when the device has data available to send.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+void pouch_serial_device_init(pouch_serial_device_ready_cb_t ready_cb);
+
+/**
+ * Deliver a received frame from the broker to the device transport layer.
+ *
+ * Called by the transport adapter with each complete frame received from the
+ * broker. The first byte of @p frame is the encoded header; the remaining
+ * bytes are the payload.
+ *
+ * @param frame  Frame bytes, starting with the 1-byte header.
+ * @param len    Total frame length in bytes (header + payload).
+ * @return 0 on success, negative error code on failure.
+ */
+int pouch_serial_device_recv(const void *frame, size_t len);
+
+/**
+ * Get a frame of data to send over the serial link.
+ *
+ * Called by the transport adapter when it needs to send data.
+ *
+ * @param buf      Buffer that should be filled with data to send.
+ * @param maxlen   Maximum number of bytes to send in the buffer. The device transport
+ *                 layer will not write more than this many bytes to the buffer.
+ *
+ * @return Number of bytes written to the buffer.
+ */
+size_t pouch_serial_device_frame_get(uint8_t *buf, size_t maxlen);

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -13,9 +13,6 @@ menuconfig POUCH
     Pouch is a protocol for communicating with Golioth from devices not
     directly connected to the internet.
 
-# Port-specific log-level constants
-rsource "Kconfig.port_log_levels"
-
 if POUCH
 
 # Pouch common
@@ -95,6 +92,9 @@ endmenu
 
 # Transport choices
 rsource "transport/Kconfig"
+
+# Port-specific log-level constants
+rsource "Kconfig.port_log_levels"
 
 endif
 

--- a/port/zephyr/transport/Kconfig
+++ b/port/zephyr/transport/Kconfig
@@ -5,13 +5,10 @@
 choice
   prompt "Pouch transport"
   optional
+  default POUCH_TRANSPORT_SERIAL if POUCH_TRANSPORT_SERIAL_BROKER
+  default POUCH_TRANSPORT_BLE_GATT if BT
   help
     Select the transport protocol that will carry Pouch
-
-config POUCH_TRANSPORT_NONE
-  bool "NONE"
-  help
-    No transport is selected. Useful for unit testing.
 
 config POUCH_TRANSPORT_BLE_GATT
   bool "BLE GATT"
@@ -23,6 +20,7 @@ config POUCH_TRANSPORT_BLE_GATT
 
 config POUCH_TRANSPORT_HTTP_CLIENT
   bool "HTTP"
+  depends on POUCH
   imply HTTP_CLIENT
   select EVENTS
   select NET_CONNECTION_MANAGER
@@ -31,11 +29,18 @@ config POUCH_TRANSPORT_HTTP_CLIENT
 
 config POUCH_TRANSPORT_COAP_CLIENT
   bool "CoAP"
+  depends on POUCH
   select COAP
   select NET_SOCKETS_SOCKOPT_TLS
   select NET_SOCKETS_ENABLE_DTLS
   help
     CoAP/DTLS transport for Pouch
+
+config POUCH_TRANSPORT_SERIAL
+  bool "Serial"
+  help
+    Serial transport for Pouch. Implements the core serial transport,
+    running on top of a serial transport adapter.
 
 endchoice
 
@@ -51,6 +56,7 @@ config POUCH_TRANSPORT_ACK_TIMEOUT_MS
 rsource "gatt/Kconfig"
 rsource "http/Kconfig"
 rsource "coap/Kconfig"
+rsource "serial/Kconfig"
 
 module = POUCH_TRANSPORT
 module-str = Pouch Transport

--- a/port/zephyr/transport/serial/Kconfig
+++ b/port/zephyr/transport/serial/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Pouch Serial Transport"
+    visible if POUCH_TRANSPORT_SERIAL
+
+config POUCH_TRANSPORT_SERIAL_BROKER
+    bool
+    depends on POUCH_GATEWAY
+    default y
+    help
+        Enable the broker-based implementation of the Pouch Serial transport.
+
+config POUCH_TRANSPORT_SERIAL_DEVICE
+    bool
+    depends on POUCH
+    default y
+    help
+        Enable the device implementation of the Pouch Serial transport, which
+        runs on the node device and communicates with a gateway running the
+        broker implementation.
+
+module = POUCH_SERIAL
+module-str = Pouch Serial Transport
+source "subsys/logging/Kconfig.template.log_config"
+
+endmenu

--- a/src/gateway/CMakeLists.txt
+++ b/src/gateway/CMakeLists.txt
@@ -14,6 +14,9 @@ zephyr_library_sources(
     ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/endpoints/broker/downlink.c
     ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/endpoints/broker/device_cert.c
     ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/endpoints/broker/server_cert.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_POUCH_GATEWAY_GATT
     ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/sar/packet.c
     ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/sar/receiver.c
     ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/sar/sender.c
@@ -22,6 +25,14 @@ zephyr_library_sources(
     ${ZEPHYR_POUCH_MODULE_DIR}/port/zephyr/transport/gatt/broker/broker.c
     ${ZEPHYR_POUCH_MODULE_DIR}/port/zephyr/transport/gatt/broker/scan.c
 )
+
+zephyr_library_sources_ifdef(CONFIG_POUCH_TRANSPORT_SERIAL
+    ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/serial/channel.c
+    ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/serial/packet.c
+    ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/serial/serial.c
+    ${ZEPHYR_POUCH_MODULE_DIR}/src/transport/serial/broker.c
+)
+
 zephyr_library_include_directories(${ZEPHYR_POUCH_MODULE_DIR}/src)
 
 zephyr_library_link_libraries(mbedTLS)

--- a/src/gateway/Kconfig
+++ b/src/gateway/Kconfig
@@ -1,4 +1,4 @@
-config POUCH_GATEWAY
+menuconfig POUCH_GATEWAY
     bool "Pouch Gateway"
 
 if POUCH_GATEWAY
@@ -54,6 +54,24 @@ config POUCH_TRANSPORT_ACK_TIMEOUT_MS
         The timeout, in milliseconds, that a receiver will wait
         for new packets before retransmitting an acknowledgement
 
+
+module = POUCH_GATEWAY
+module-str = Pouch Gateway Library
+source "subsys/logging/Kconfig.template.log_config"
+
+menu "Gateway Pouch Transport"
+
+menuconfig POUCH_GATEWAY_GATT
+    bool "BLE GATT broker transport"
+    depends on BT
+    default y if BT
+    help
+      Enable the BLE GATT broker transport for the Pouch gateway.
+      This builds the GATT central/broker side, including scanning,
+      discovery, and bonding support.
+
+if POUCH_GATEWAY_GATT
+
 config POUCH_GATT_WINDOW_SIZE
     int "GATT Window Size"
     range 1 127
@@ -62,10 +80,6 @@ config POUCH_GATT_WINDOW_SIZE
         The number of unacknowledged packets that can be received by
         the device. Larger numbers can increase throughput but will
         use more RAM.
-
-module = POUCH_GATEWAY
-module-str = Pouch Gateway Library
-source "subsys/logging/Kconfig.template.log_config"
 
 config POUCH_GATEWAY_GATT_SCAN_FILTER_BONDED
     bool "Scan filter by bonded status"
@@ -79,8 +93,22 @@ module = POUCH_GATEWAY_GATT
 module-str = Pouch Gateway GATT Library
 source "subsys/logging/Kconfig.template.log_config"
 
+endif # POUCH_GATEWAY_GATT
+
+config POUCH_TRANSPORT_SERIAL
+    bool
+
+config POUCH_TRANSPORT_SERIAL_BROKER
+    bool "Serial transport"
+    help
+      Enable the Pouch Serial transport. This transport can be
+      used in a gateway application that communicates with a
+      node device over a serial connection.
+
 module = POUCH_TRANSPORT
 module-str = Pouch Transport
 source "subsys/logging/Kconfig.template.log_config"
+
+endmenu # Gateway Pouch Transport
 
 endif # POUCH_GATEWAY

--- a/src/transport/CMakeLists.txt
+++ b/src/transport/CMakeLists.txt
@@ -5,8 +5,9 @@
 pouch_config_enabled(_pouch_encryption_saead CONFIG_POUCH_ENCRYPTION_SAEAD)
 pouch_config_enabled(_pouch_transport_sar CONFIG_POUCH_TRANSPORT_SAR)
 pouch_config_enabled(_pouch_transport_ble_gatt CONFIG_POUCH_TRANSPORT_BLE_GATT)
+pouch_config_enabled(_pouch_transport_serial CONFIG_POUCH_TRANSPORT_SERIAL)
 
-if(NOT _pouch_transport_sar AND NOT _pouch_transport_ble_gatt)
+if(NOT _pouch_transport_sar AND NOT _pouch_transport_ble_gatt AND NOT _pouch_transport_serial)
     return()
 endif()
 
@@ -29,38 +30,58 @@ target_include_directories(${_pouch_target} PRIVATE
     ${_pouch_generated_dir}/include
 )
 
-if(_pouch_transport_ble_gatt)
+target_sources(${_pouch_target} PRIVATE
+    ${_pouch_transport_root}/endpoints/device/info.c
+    ${_pouch_transport_root}/endpoints/device/uplink.c
+    ${_pouch_transport_root}/endpoints/device/downlink.c
+    ${_pouch_generated_dir}/info_encode.c
+)
+
+if(_pouch_encryption_saead)
     target_sources(${_pouch_target} PRIVATE
-        ${_pouch_transport_root}/endpoints/device/info.c
-        ${_pouch_transport_root}/endpoints/device/uplink.c
-        ${_pouch_transport_root}/endpoints/device/downlink.c
-        ${_pouch_generated_dir}/info_encode.c
+        ${_pouch_transport_root}/endpoints/device/device_cert.c
+        ${_pouch_transport_root}/endpoints/device/server_cert.c
+    )
+endif()
+
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    add_custom_command(
+        OUTPUT ${_pouch_generated_dir}/info_encode.c
+        COMMAND zcbor code -c ${_pouch_transport_root}/info.cddl -t pouch_gatt_info -e
+            --include-prefix cddl/ --output-c ${_pouch_generated_dir}/info_encode.c
+            --output-h ${_pouch_generated_dir}/include/cddl/info_encode.h
+        BYPRODUCTS
+            ${_pouch_generated_dir}/include/cddl/info_encode.h
+            ${_pouch_generated_dir}/include/cddl/info_encode_types.h
+        DEPENDS ${_pouch_transport_root}/info.cddl
+        WORKING_DIRECTORY ${_pouch_generated_dir}
     )
 
-    if(_pouch_encryption_saead)
+    string(REPLACE "::" "_" _pouch_transport_codegen_target ${_pouch_target})
+    set(_pouch_transport_codegen_target "${_pouch_transport_codegen_target}_generate_transport_info")
+    add_custom_target(${_pouch_transport_codegen_target}
+        DEPENDS ${_pouch_generated_dir}/info_encode.c)
+    add_dependencies(${_pouch_target} ${_pouch_transport_codegen_target})
+endif()
+
+if(_pouch_transport_serial)
+    target_sources(${_pouch_target} PRIVATE
+        ${_pouch_transport_root}/serial/channel.c
+        ${_pouch_transport_root}/serial/packet.c
+        ${_pouch_transport_root}/serial/serial.c
+    )
+
+    pouch_config_enabled(_pouch_transport_serial_broker CONFIG_POUCH_TRANSPORT_SERIAL_BROKER)
+    if (_pouch_transport_serial_broker)
         target_sources(${_pouch_target} PRIVATE
-            ${_pouch_transport_root}/endpoints/device/device_cert.c
-            ${_pouch_transport_root}/endpoints/device/server_cert.c
+            ${_pouch_transport_root}/serial/broker.c
         )
     endif()
 
-    if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-        add_custom_command(
-            OUTPUT ${_pouch_generated_dir}/info_encode.c
-            COMMAND zcbor code -c ${_pouch_transport_root}/info.cddl -t pouch_gatt_info -e
-                --include-prefix cddl/ --output-c ${_pouch_generated_dir}/info_encode.c
-                --output-h ${_pouch_generated_dir}/include/cddl/info_encode.h
-            BYPRODUCTS
-                ${_pouch_generated_dir}/include/cddl/info_encode.h
-                ${_pouch_generated_dir}/include/cddl/info_encode_types.h
-            DEPENDS ${_pouch_transport_root}/info.cddl
-            WORKING_DIRECTORY ${_pouch_generated_dir}
+    pouch_config_enabled(_pouch_transport_serial_device CONFIG_POUCH_TRANSPORT_SERIAL_DEVICE)
+    if (_pouch_transport_serial_device)
+        target_sources(${_pouch_target} PRIVATE
+            serial/device.c
         )
-
-        string(REPLACE "::" "_" _pouch_transport_codegen_target ${_pouch_target})
-        set(_pouch_transport_codegen_target "${_pouch_transport_codegen_target}_generate_transport_info")
-        add_custom_target(${_pouch_transport_codegen_target}
-            DEPENDS ${_pouch_generated_dir}/info_encode.c)
-        add_dependencies(${_pouch_target} ${_pouch_transport_codegen_target})
     endif()
 endif()

--- a/src/transport/Kconfig
+++ b/src/transport/Kconfig
@@ -6,7 +6,7 @@
 # This is approach is brittle and should be improved in future work.
 
 config POUCH_TRANSPORT_SAR
-  bool "Enable SAR core transport support"
+  bool "Enable SAR core transport support" if ZTEST
   help
     Enable shared Segmentation and Reassembly (SAR) sender/receiver
     packetization support used by transport backends and transport unit

--- a/src/transport/serial/broker.c
+++ b/src/transport/serial/broker.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <pouch/transport/serial/broker.h>
+#include "packet.h"
+#include "serial.h"
+#include "gateway/types.h"
+#include "transport/bearer.h"
+#include "transport/endpoints/broker/endpoints.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <pouch/port.h>
+
+POUCH_LOG_REGISTER(pouch_serial_broker, CONFIG_POUCH_SERIAL_LOG_LEVEL);
+
+enum flags
+{
+    FLAG_INFO_READ,
+    FLAG_SYNC,
+    FLAG_UPLINK_DONE,
+    FLAG_DOWNLINK_DONE,
+};
+
+struct pouch_serial_broker
+{
+    struct pouch_serial serial;
+    const struct pouch_serial_broker_adapter *adapter;
+    struct pouch_gateway_node_info node;
+    pouch_atomic_t flags;
+};
+
+static void signal_adapter_ready(struct pouch_serial_broker *broker)
+{
+    if (broker->adapter->ready)
+    {
+        broker->adapter->ready(broker);
+    }
+}
+
+static void channel_ready(struct pouch_serial_broker *broker, enum pouch_serial_channel_id ch)
+{
+    pouch_serial_ch_ready(&broker->serial.channels[ch]);
+}
+
+static void next(struct pouch_serial_broker *broker)
+{
+    if (!pouch_atomic_test_and_set_bit(&broker->flags, FLAG_INFO_READ))
+    {
+        channel_ready(broker, POUCH_SERIAL_CH_INFO);
+        signal_adapter_ready(broker);
+        return;
+    }
+
+    if (!broker->node.server_cert_provisioned)
+    {
+        channel_ready(broker, POUCH_SERIAL_CH_SERVER_CERT);
+        signal_adapter_ready(broker);
+        return;
+    }
+
+    if (!broker->node.device_cert_provisioned)
+    {
+        channel_ready(broker, POUCH_SERIAL_CH_DEVICE_CERT);
+        signal_adapter_ready(broker);
+        return;
+    }
+
+    if (!pouch_atomic_test_and_set_bit(&broker->flags, FLAG_SYNC))
+    {
+        channel_ready(broker, POUCH_SERIAL_CH_UPLINK);
+        channel_ready(broker, POUCH_SERIAL_CH_DOWNLINK);
+        signal_adapter_ready(broker);
+        return;
+    }
+
+    if (pouch_atomic_test_bit(&broker->flags, FLAG_DOWNLINK_DONE)
+        && pouch_atomic_test_bit(&broker->flags, FLAG_UPLINK_DONE))
+    {
+        if (broker->adapter->end)
+        {
+            broker->adapter->end(broker, true);
+        }
+    }
+}
+
+static void serial_ready(struct pouch_serial *s)
+{
+    struct pouch_serial_broker *broker = CONTAINER_OF(s, struct pouch_serial_broker, serial);
+    signal_adapter_ready(broker);
+}
+
+static void channel_closed(struct pouch_serial *s, enum pouch_serial_channel_id ch, bool success)
+{
+    struct pouch_serial_broker *broker = CONTAINER_OF(s, struct pouch_serial_broker, serial);
+    if (!success)
+    {
+        pouch_atomic_clear(&broker->flags);
+        if (broker->adapter->end)
+        {
+            broker->adapter->end(broker, false);
+        }
+        return;
+    }
+
+    POUCH_LOG_DBG("Channel %u completed successfully", ch);
+
+    if (ch == POUCH_SERIAL_CH_UPLINK)
+    {
+        pouch_atomic_set_bit(&broker->flags, FLAG_UPLINK_DONE);
+    }
+    else if (ch == POUCH_SERIAL_CH_DOWNLINK)
+    {
+        pouch_atomic_set_bit(&broker->flags, FLAG_DOWNLINK_DONE);
+    }
+
+    next(broker);
+}
+
+struct pouch_serial_broker *pouch_serial_broker_create(
+    const struct pouch_serial_broker_adapter *adapter)
+{
+    if (adapter == NULL)
+    {
+        return NULL;
+    }
+
+    struct pouch_serial_broker *broker = malloc(sizeof(*broker));
+    if (broker == NULL)
+    {
+        return NULL;
+    }
+
+    memset(broker, 0, sizeof(*broker));
+    broker->adapter = adapter;
+
+    broker->serial.channels[POUCH_SERIAL_CH_INFO].endpoint = &broker_endpoint_info;
+    broker->serial.channels[POUCH_SERIAL_CH_DEVICE_CERT].endpoint = &broker_endpoint_device_cert;
+    broker->serial.channels[POUCH_SERIAL_CH_SERVER_CERT].endpoint = &broker_endpoint_server_cert;
+    broker->serial.channels[POUCH_SERIAL_CH_DOWNLINK].endpoint = &broker_endpoint_downlink;
+    broker->serial.channels[POUCH_SERIAL_CH_UPLINK].endpoint = &broker_endpoint_uplink;
+
+    for (enum pouch_serial_channel_id i = 0; i < POUCH_SERIAL_CHANNEL_COUNT; i++)
+    {
+        broker->serial.channels[i].bearer.ctx = &broker->node;
+    }
+
+    pouch_serial_init(&broker->serial, serial_ready, channel_closed);
+
+    return broker;
+}
+
+int pouch_serial_broker_start(struct pouch_serial_broker *broker)
+{
+    if (broker == NULL)
+    {
+        return -EINVAL;
+    }
+
+    POUCH_LOG_DBG("Starting broker %p", broker);
+    pouch_atomic_clear_bit(&broker->flags, FLAG_INFO_READ);
+    pouch_atomic_clear_bit(&broker->flags, FLAG_SYNC);
+    pouch_atomic_clear_bit(&broker->flags, FLAG_DOWNLINK_DONE);
+    pouch_atomic_clear_bit(&broker->flags, FLAG_UPLINK_DONE);
+
+    next(broker);
+    return 0;
+}
+
+int pouch_serial_broker_recv(struct pouch_serial_broker *broker, const void *frame, size_t len)
+{
+    if (broker == NULL || frame == NULL || len == 0)
+    {
+        return -EINVAL;
+    }
+
+    int err = pouch_serial_recv(&broker->serial, frame, len);
+    if (err)
+    {
+        POUCH_LOG_ERR("Failed to process received frame (%d)", err);
+        return err;
+    }
+
+    return 0;
+}
+
+size_t pouch_serial_broker_frame_get(struct pouch_serial_broker *broker,
+                                     uint8_t *buf,
+                                     size_t maxlen)
+{
+    if (broker == NULL || buf == NULL)
+    {
+        return 0;
+    }
+
+    return pouch_serial_frame_get(&broker->serial, buf, maxlen);
+}
+
+void pouch_serial_broker_notify(struct pouch_serial_broker *broker)
+{
+    if (broker == NULL)
+    {
+        return;
+    }
+
+    pouch_serial_ch_ready(&broker->serial.channels[POUCH_SERIAL_CH_UPLINK]);
+}
+
+const struct pouch_serial_broker_adapter *pouch_serial_broker_adapter_get(
+    const struct pouch_serial_broker *broker)
+{
+    if (broker == NULL)
+    {
+        return NULL;
+    }
+
+    return broker->adapter;
+}

--- a/src/transport/serial/channel.c
+++ b/src/transport/serial/channel.c
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <pouch/transport/serial/common.h>
+#include "../endpoints/endpoint.h"
+#include "../bearer.h"
+#include "packet.h"
+#include "channel.h"
+
+#include <pouch/port.h>
+
+enum ch_flag
+{
+    CH_FLAG_OPEN,
+    CH_FLAG_FIRST_FRAGMENT,
+    CH_FLAG_PENDING,
+    CH_FLAG_ERROR,
+};
+
+static enum pouch_serial_channel_id channel_id(const struct pouch_serial_channel *ch)
+{
+    return ch->id;
+}
+
+static int handle_ack(struct pouch_serial_channel *ch, bool err)
+{
+    if (err)
+    {
+        pouch_serial_ch_close(ch, false);
+        return 0;
+    }
+
+    /* Receiver channels don't open via ACK - they open when the first DATA
+     * frame arrives (handle_data).  Just respond with an ACK so the remote
+     * sender knows it may proceed. */
+    if (ch->endpoint->send == NULL)
+    {
+        pouch_serial_ch_ready(ch);
+        return 0;
+    }
+
+    /* First prompt: open the transfer. */
+    if (!pouch_atomic_test_and_set_bit(&ch->flags, CH_FLAG_OPEN))
+    {
+        int ret = ch->endpoint->start(&ch->bearer);
+        if (ret)
+        {
+            pouch_atomic_set_bit(&ch->flags, CH_FLAG_ERROR);
+            pouch_serial_ch_close(ch, false);
+        }
+
+        pouch_atomic_set_bit(&ch->flags, CH_FLAG_FIRST_FRAGMENT);
+        pouch_serial_ch_ready(ch);
+    }
+
+    return 0;
+}
+
+/*
+ * Handle an incoming Data frame on a Broker->Device channel.
+ * The broker is writing data to the device.
+ */
+static int handle_data(struct pouch_serial_channel *ch,
+                       const struct pouch_serial_header *hdr,
+                       const void *payload,
+                       size_t len)
+{
+    if (hdr->err)
+    {
+        pouch_serial_ch_close(ch, false);
+        return 0;
+    }
+
+    if (!pouch_atomic_test_and_set_bit(&ch->flags, CH_FLAG_OPEN))
+    {
+        if (!hdr->first)
+        {
+            pouch_serial_ch_close(ch, false);
+            return -EINVAL;
+        }
+
+        int err = ch->endpoint->start(&ch->bearer);
+        if (err)
+        {
+            pouch_atomic_clear_bit(&ch->flags, CH_FLAG_OPEN);
+            pouch_atomic_set_bit(&ch->flags, CH_FLAG_ERROR);
+            pouch_serial_ch_ready(ch);  // nack
+            return err;
+        }
+
+        pouch_atomic_set_bit(&ch->flags, CH_FLAG_FIRST_FRAGMENT);
+    }
+    else if (hdr->first)
+    {
+        // Unexpected first fragment in an already-open channel
+        pouch_serial_ch_close(ch, false);
+        return -EINVAL;
+    }
+
+    if (len > 0)
+    {
+        int err = ch->endpoint->recv(&ch->bearer, payload, len);
+        if (err)
+        {
+            pouch_serial_ch_close(ch, false);
+            return err;
+        }
+    }
+
+    if (hdr->last)
+    {
+        pouch_serial_ch_close(ch, true);
+    }
+
+    return 0;
+}
+
+int pouch_serial_ch_recv(struct pouch_serial_channel *ch,
+                         const struct pouch_serial_header *header,
+                         const void *payload,
+                         size_t len)
+{
+    if (header->is_data)
+    {
+        return handle_data(ch, header, payload, len);
+    }
+
+    return handle_ack(ch, header->err);
+}
+
+
+size_t pouch_serial_ch_frame_get(struct pouch_serial_channel *ch, uint8_t *buf, size_t maxlen)
+{
+    if (!pouch_atomic_test_and_clear_bit(&ch->flags, CH_FLAG_PENDING))
+    {
+        return 0;
+    }
+
+    // If this is a receiver channel
+    if (ch->endpoint->send == NULL)
+    {
+        struct pouch_serial_header hdr = {
+            .is_data = false,
+            .err = pouch_atomic_test_bit(&ch->flags, CH_FLAG_ERROR),
+            .channel = channel_id(ch),
+        };
+        *buf = pouch_serial_header_encode(&hdr);
+
+        return POUCH_SERIAL_HEADER_LEN;
+    }
+
+    if (pouch_atomic_test_and_clear_bit(&ch->flags, CH_FLAG_ERROR))
+    {
+        struct pouch_serial_header hdr = {
+            .channel = channel_id(ch),
+            .is_data = true,
+            .err = true,
+            .first = pouch_atomic_test_and_clear_bit(&ch->flags, CH_FLAG_FIRST_FRAGMENT),
+            .last = true,
+        };
+
+        *buf = pouch_serial_header_encode(&hdr);
+        pouch_atomic_clear_bit(&ch->flags, CH_FLAG_OPEN);
+        return POUCH_SERIAL_HEADER_LEN;
+    }
+
+    if (!pouch_atomic_test_bit(&ch->flags, CH_FLAG_OPEN))
+    {
+        /* Sender is not yet open - produce an ACK prompt to request the
+         * remote side to open the channel (by ACK-ing back). */
+        struct pouch_serial_header hdr = {
+            .is_data = false,
+            .err = false,
+            .channel = channel_id(ch),
+        };
+        *buf = pouch_serial_header_encode(&hdr);
+
+        return POUCH_SERIAL_HEADER_LEN;
+    }
+
+    size_t len = maxlen - POUCH_SERIAL_HEADER_LEN;
+    enum pouch_result result = ch->endpoint->send(&ch->bearer, &buf[POUCH_SERIAL_HEADER_LEN], &len);
+    if (len == 0 && result == POUCH_MORE_DATA)
+    {
+        // Endpoint has no data ready to send, but expects to be called again later.
+        // Don't send an empty frame; just wait for the next call.
+        return 0;
+    }
+
+    bool error = (result == POUCH_ERROR);
+    bool is_last = (result == POUCH_NO_MORE_DATA) || error;
+
+    struct pouch_serial_header hdr = {
+        .channel = channel_id(ch),
+        .is_data = true,
+        .err = error,
+        .first = pouch_atomic_test_and_clear_bit(&ch->flags, CH_FLAG_FIRST_FRAGMENT),
+        .last = is_last,
+    };
+
+    *buf = pouch_serial_header_encode(&hdr);
+
+    if (is_last)
+    {
+        pouch_serial_ch_close(ch, !error);
+    }
+    else
+    {
+        pouch_serial_ch_ready(ch);
+    }
+
+    return POUCH_SERIAL_HEADER_LEN + len;
+}
+
+void pouch_serial_ch_ready(struct pouch_serial_channel *ch)
+{
+    pouch_atomic_set_bit(&ch->flags, CH_FLAG_PENDING);
+}
+
+void pouch_serial_ch_close(struct pouch_serial_channel *ch, bool success)
+{
+    if (!pouch_atomic_test_and_clear_bit(&ch->flags, CH_FLAG_OPEN))
+    {
+        return;
+    }
+
+    if (!success)
+    {
+        pouch_atomic_set_bit(&ch->flags, CH_FLAG_ERROR);
+    }
+
+    ch->endpoint->end(&ch->bearer, success);
+    if (ch->closed_cb)
+    {
+        ch->closed_cb(ch, success);
+    }
+
+    if (!success)
+    {
+        pouch_serial_ch_ready(ch);
+    }
+}
+
+bool pouch_serial_ch_is_open(struct pouch_serial_channel *ch)
+{
+    return pouch_atomic_test_bit(&ch->flags, CH_FLAG_OPEN);
+}
+
+bool pouch_serial_ch_has_error(struct pouch_serial_channel *ch)
+{
+    return pouch_atomic_test_bit(&ch->flags, CH_FLAG_ERROR);
+}

--- a/src/transport/serial/channel.c
+++ b/src/transport/serial/channel.c
@@ -184,8 +184,15 @@ size_t pouch_serial_ch_frame_get(struct pouch_serial_channel *ch, uint8_t *buf, 
     enum pouch_result result = ch->endpoint->send(&ch->bearer, &buf[POUCH_SERIAL_HEADER_LEN], &len);
     if (len == 0 && result == POUCH_MORE_DATA)
     {
-        // Endpoint has no data ready to send, but expects to be called again later.
-        // Don't send an empty frame; just wait for the next call.
+        /* Endpoint has no data ready to send, but expects to be called again
+         * later. CH_FLAG_PENDING was consumed on entry, so it must be restored
+         * here or the channel is never polled again: the device uplink
+         * endpoint produces its data asynchronously (the pouch work queue
+         * encrypts a block a few hundred ms after the broker's prompt) and
+         * never calls bearer_ready(). Without this the uplink transfer stalls
+         * forever and the broker times out.
+         */
+        pouch_serial_ch_ready(ch);
         return 0;
     }
 
@@ -231,7 +238,13 @@ void pouch_serial_ch_close(struct pouch_serial_channel *ch, bool success)
         pouch_atomic_set_bit(&ch->flags, CH_FLAG_ERROR);
     }
 
-    ch->endpoint->end(&ch->bearer, success);
+    /* end is optional, like in the SAR sender/receiver: endpoints that have
+     * nothing to tear down (e.g. the device info endpoint) leave it NULL.
+     */
+    if (ch->endpoint->end)
+    {
+        ch->endpoint->end(&ch->bearer, success);
+    }
     if (ch->closed_cb)
     {
         ch->closed_cb(ch, success);

--- a/src/transport/serial/channel.h
+++ b/src/transport/serial/channel.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "../bearer.h"
+#include "packet.h"
+
+#include <pouch/port.h>
+
+struct pouch_serial_channel;
+struct pouch_endpoint;
+
+typedef void (*pouch_serial_ch_closed_cb_t)(struct pouch_serial_channel *ch, bool success);
+
+struct pouch_serial_channel
+{
+    struct pouch_bearer bearer;
+    const struct pouch_endpoint *endpoint;
+    pouch_serial_ch_closed_cb_t closed_cb;
+    pouch_atomic_t flags;
+    uint8_t id;
+};
+
+int pouch_serial_ch_recv(struct pouch_serial_channel *ch,
+                         const struct pouch_serial_header *header,
+                         const void *payload,
+                         size_t len);
+
+size_t pouch_serial_ch_frame_get(struct pouch_serial_channel *ch, uint8_t *buf, size_t maxlen);
+
+void pouch_serial_ch_ready(struct pouch_serial_channel *ch);
+void pouch_serial_ch_close(struct pouch_serial_channel *ch, bool success);
+bool pouch_serial_ch_is_open(struct pouch_serial_channel *ch);
+bool pouch_serial_ch_has_error(struct pouch_serial_channel *ch);
+
+static inline struct pouch_serial_channel *pouch_serial_ch_from_bearer(struct pouch_bearer *bearer)
+{
+    return CONTAINER_OF(bearer, struct pouch_serial_channel, bearer);
+}

--- a/src/transport/serial/device.c
+++ b/src/transport/serial/device.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pouch/transport/serial/device.h>
+#include "serial.h"
+#include "../endpoints/device/endpoints.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define CHANNEL(_endpoint) {.endpoint = _endpoint}
+
+static struct pouch_serial serial = {
+    .channels =
+        {
+            [POUCH_SERIAL_CH_INFO] = CHANNEL(&pouch_device_endpoint_info),
+            [POUCH_SERIAL_CH_SERVER_CERT] = CHANNEL(&pouch_device_endpoint_server_cert),
+            [POUCH_SERIAL_CH_DEVICE_CERT] = CHANNEL(&pouch_device_endpoint_device_cert),
+            [POUCH_SERIAL_CH_DOWNLINK] = CHANNEL(&pouch_device_endpoint_downlink),
+            [POUCH_SERIAL_CH_UPLINK] = CHANNEL(&pouch_device_endpoint_uplink),
+        },
+};
+
+static pouch_serial_device_ready_cb_t ready_cb;
+
+static void ready(struct pouch_serial *s)
+{
+    if (ready_cb)
+    {
+        ready_cb();
+    }
+}
+
+void pouch_serial_device_init(pouch_serial_device_ready_cb_t cb)
+{
+    ready_cb = cb;
+    pouch_serial_init(&serial, ready, NULL);
+}
+
+int pouch_serial_device_recv(const void *frame, size_t len)
+{
+    return pouch_serial_recv(&serial, frame, len);
+}
+
+size_t pouch_serial_device_frame_get(uint8_t *buf, size_t maxlen)
+{
+    return pouch_serial_frame_get(&serial, buf, maxlen);
+}

--- a/src/transport/serial/packet.c
+++ b/src/transport/serial/packet.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "packet.h"
+
+#include <errno.h>
+
+/* Header byte bit positions */
+#define HDR_DATA (1 << 7)
+#define HDR_ERR (1 << 6)
+#define HDR_FIRST (1 << 5)
+#define HDR_LAST (1 << 4)
+#define HDR_CH_MASK 0x0f
+
+/* Reserved bits in an ACK frame must be zero. */
+#define HDR_ACK_RESERVED_MASK (HDR_FIRST | HDR_LAST)
+
+uint8_t pouch_serial_header_encode(const struct pouch_serial_header *hdr)
+{
+    uint8_t byte = hdr->channel & HDR_CH_MASK;
+
+    if (hdr->is_data)
+    {
+        byte |= HDR_DATA;
+        if (hdr->first)
+        {
+            byte |= HDR_FIRST;
+        }
+        if (hdr->last)
+        {
+            byte |= HDR_LAST;
+        }
+    }
+
+    if (hdr->err)
+    {
+        byte |= HDR_ERR;
+    }
+
+    return byte;
+}
+
+int pouch_serial_header_decode(uint8_t byte, struct pouch_serial_header *hdr)
+{
+    hdr->is_data = !!(byte & HDR_DATA);
+    hdr->err = !!(byte & HDR_ERR);
+    hdr->channel = byte & HDR_CH_MASK;
+
+    if (hdr->is_data)
+    {
+        hdr->first = !!(byte & HDR_FIRST);
+        hdr->last = !!(byte & HDR_LAST);
+
+        /* ERR must always be accompanied by LAST on data frames. */
+        if (hdr->err && !hdr->last)
+        {
+            hdr->last = true;
+        }
+    }
+    else
+    {
+        hdr->first = false;
+        hdr->last = false;
+
+        /* Reserved bits must be zero in ACK frames. */
+        if (byte & HDR_ACK_RESERVED_MASK)
+        {
+            return -EINVAL;
+        }
+    }
+
+    return 0;
+}

--- a/src/transport/serial/packet.h
+++ b/src/transport/serial/packet.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * Decoded representation of a 1-byte Pouch Serial frame header.
+ *
+ * Bit layout:
+ *   ACK frame  (bit 7 = 0): [ 0 | ERR | 0 | 0 | channel[3:0] ]
+ *   Data frame (bit 7 = 1): [ 1 | ERR | FIRST | LAST | channel[3:0] ]
+ */
+struct pouch_serial_header
+{
+    /** True for Data frames, false for ACK frames. */
+    bool is_data;
+    /**
+     * Error flag. For Data frames, the transfer has been abandoned by the sender; must be sent
+     * with LAST set. For ACK frames, the transfer has been abandoned by the receiver.
+     */
+    bool err;
+    /** First fragment of a transfer. Data frames only. */
+    bool first;
+    /** Last fragment of a transfer. Data frames only. */
+    bool last;
+    /** Logical channel identifier (4 bits). */
+    uint8_t channel;
+};
+
+/**
+ * Encode a header into its 1-byte wire representation.
+ *
+ * @param hdr Header to encode.
+ * @return Encoded byte.
+ */
+uint8_t pouch_serial_header_encode(const struct pouch_serial_header *hdr);
+
+/**
+ * Decode a 1-byte wire header.
+ *
+ * @param byte   Wire byte to decode.
+ * @param hdr    Output header.
+ * @return 0 on success, -EINVAL if the byte is malformed.
+ */
+int pouch_serial_header_decode(uint8_t byte, struct pouch_serial_header *hdr);

--- a/src/transport/serial/serial.c
+++ b/src/transport/serial/serial.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <pouch/transport/serial/device.h>
+#include "packet.h"
+#include "serial.h"
+#include "../bearer.h"
+#include "../endpoints/device/endpoints.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <pouch/port.h>
+
+POUCH_LOG_REGISTER(pouch_serial, CONFIG_POUCH_SERIAL_LOG_LEVEL);
+
+static struct pouch_serial_channel *channel_from_bearer(struct pouch_bearer *bearer)
+{
+    return CONTAINER_OF(bearer, struct pouch_serial_channel, bearer);
+}
+
+static struct pouch_serial *transport_from_channel(struct pouch_serial_channel *ch)
+{
+    return CONTAINER_OF(ch, struct pouch_serial, channels[ch->id]);
+}
+
+/*
+ * Called by an endpoint when it has new data ready to send. Signal the broker
+ * via the adapter's notify callback if one is registered.
+ */
+static void bearer_ready(struct pouch_bearer *bearer)
+{
+    struct pouch_serial_channel *ch = channel_from_bearer(bearer);
+    struct pouch_serial *transport = transport_from_channel(ch);
+
+    pouch_serial_ch_ready(ch);
+    if (transport->ready)
+    {
+        transport->ready(transport);
+    }
+}
+
+static void channel_closed(struct pouch_serial_channel *ch, bool success)
+{
+    struct pouch_serial *transport = transport_from_channel(ch);
+    if (transport->ch_closed)
+    {
+        transport->ch_closed(transport, ch->id, success);
+    }
+}
+
+/*
+ * Called by an endpoint when it encounters an error and wants to abort the
+ * current transfer. For Device->Broker channels, send an ERR|LAST Data frame
+ * to notify the broker of the abort.
+ */
+static void bearer_close(struct pouch_bearer *bearer, bool success)
+{
+    pouch_serial_ch_close(pouch_serial_ch_from_bearer(bearer), success);
+}
+
+void pouch_serial_init(struct pouch_serial *s,
+                       pouch_serial_ready_cb_t ready,
+                       pouch_serial_ch_closed_t ch_closed)
+{
+    for (enum pouch_serial_channel_id i = 0; i < POUCH_SERIAL_CHANNEL_COUNT; i++)
+    {
+        s->channels[i].id = i;
+        s->channels[i].flags = 0;
+        s->channels[i].bearer.ready = bearer_ready;
+        s->channels[i].bearer.close = bearer_close;
+        s->channels[i].bearer.send = NULL;
+        s->channels[i].closed_cb = channel_closed;
+    }
+    s->ready = ready;
+    s->ch_closed = ch_closed;
+}
+
+int pouch_serial_recv(struct pouch_serial *s, const void *frame, size_t len)
+{
+    if (frame == NULL || len == 0)
+    {
+        return -EINVAL;
+    }
+
+    const uint8_t *bytes = frame;
+    struct pouch_serial_header header;
+    int err = pouch_serial_header_decode(bytes[0], &header);
+    if (err)
+    {
+        POUCH_LOG_WRN("malformed header 0x%02x, ignoring", bytes[0]);
+        return err;
+    }
+
+    const void *payload = NULL;
+    size_t payload_len = 0;
+    if (len > POUCH_SERIAL_HEADER_LEN)
+    {
+        payload = &bytes[POUCH_SERIAL_HEADER_LEN];
+        payload_len = len - POUCH_SERIAL_HEADER_LEN;
+    }
+
+    if (header.channel >= POUCH_SERIAL_CHANNEL_COUNT)
+    {
+        POUCH_LOG_WRN("unknown channel %u, ignoring", header.channel);
+        return -EINVAL;
+    }
+
+    err = pouch_serial_ch_recv(&s->channels[header.channel], &header, payload, payload_len);
+    if (err)
+    {
+        POUCH_LOG_ERR("failed to process frame for channel %u: %d", header.channel, err);
+        return err;
+    }
+
+    return 0;
+}
+
+size_t pouch_serial_frame_get(struct pouch_serial *s, uint8_t *buf, size_t maxlen)
+{
+    for (enum pouch_serial_channel_id i = 0; i < POUCH_SERIAL_CHANNEL_COUNT; i++)
+    {
+        size_t len = pouch_serial_ch_frame_get(&s->channels[i], buf, maxlen);
+        if (len > 0)
+        {
+            return len;
+        }
+    }
+
+    return 0;
+}

--- a/src/transport/serial/serial.h
+++ b/src/transport/serial/serial.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <pouch/transport/serial/common.h>
+#include "channel.h"
+
+struct pouch_serial;
+typedef void (*pouch_serial_ready_cb_t)(struct pouch_serial *serial);
+typedef void (*pouch_serial_ch_closed_t)(struct pouch_serial *serial,
+                                         enum pouch_serial_channel_id ch,
+                                         bool success);
+
+/**
+ * Pouch serial instance, representing one serial bus that runs the Pouch Serial protocol.
+ */
+struct pouch_serial
+{
+    struct pouch_serial_channel channels[POUCH_SERIAL_CHANNEL_COUNT];
+    pouch_serial_ready_cb_t ready;
+    pouch_serial_ch_closed_t ch_closed;
+};
+
+void pouch_serial_init(struct pouch_serial *s,
+                       pouch_serial_ready_cb_t ready,
+                       pouch_serial_ch_closed_t ch_closed);
+
+int pouch_serial_recv(struct pouch_serial *s, const void *frame, size_t len);
+
+size_t pouch_serial_frame_get(struct pouch_serial *s, uint8_t *buf, size_t maxlen);

--- a/tests/pouch/serial/broker/CMakeLists.txt
+++ b/tests/pouch/serial/broker/CMakeLists.txt
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(serial_broker_test)
+
+set(POUCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../..)
+
+# Golioth SDK path (needed by gateway/types.h included from broker.c)
+set(GOLIOTH_SDK ${ZEPHYR_BASE}/../modules/lib/golioth-firmware-sdk)
+
+# Include paths: pouch public + private src headers
+target_include_directories(app PRIVATE
+    ${POUCH_DIR}/include
+    ${POUCH_DIR}/port/include
+    ${POUCH_DIR}/port/zephyr/include
+    ${POUCH_DIR}/src
+    ${GOLIOTH_SDK}/include
+    ${GOLIOTH_SDK}/port/zephyr/include
+)
+
+# The serial transport log macro needs CONFIG_POUCH_SERIAL_LOG_LEVEL, which is
+# normally provided by Kconfig when CONFIG_POUCH is enabled. Since this test
+# builds serial sources in isolation, define it directly.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
+
+# Serial transport sources
+target_sources(app PRIVATE
+    ${POUCH_DIR}/src/transport/serial/broker.c
+    ${POUCH_DIR}/src/transport/serial/serial.c
+    ${POUCH_DIR}/src/transport/serial/channel.c
+    ${POUCH_DIR}/src/transport/serial/packet.c
+)
+
+# Test sources
+target_sources(app PRIVATE
+    src/stub_endpoints.c
+    src/test_broker.c
+)

--- a/tests/pouch/serial/broker/prj.conf
+++ b/tests/pouch/serial/broker/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/pouch/serial/broker/src/stub_endpoints.c
+++ b/tests/pouch/serial/broker/src/stub_endpoints.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Stub endpoint implementations for broker-side serial transport tests.
+ *
+ * Each of the 5 broker endpoints is replaced by a simple stub that records
+ * lifecycle events and either feeds canned data (senders) or captures received
+ * data (receivers). The test accesses the stubs through the global
+ * broker_stubs instance.
+ */
+
+#include "stub_endpoints.h"
+#include "transport/bearer.h"
+
+#include <string.h>
+
+/* ---- Generic helpers ----------------------------------------------------- */
+
+void stub_sender_reset(struct stub_sender *s)
+{
+    s->tx_len = 0;
+    s->tx_offset = 0;
+    s->start_count = 0;
+    s->end_success_count = 0;
+    s->end_fail_count = 0;
+    s->start_err = 0;
+    s->send_err = false;
+    s->bearer = NULL;
+}
+
+void stub_sender_set_data(struct stub_sender *s, const uint8_t *data, size_t len)
+{
+    if (len > STUB_EP_BUF_SIZE)
+    {
+        len = STUB_EP_BUF_SIZE;
+    }
+
+    memcpy(s->tx_buf, data, len);
+    s->tx_len = len;
+    s->tx_offset = 0;
+}
+
+static enum pouch_result sender_fill(struct stub_sender *s, void *dst, size_t *dst_len)
+{
+    if (s->send_err)
+    {
+        *dst_len = 0;
+        return POUCH_ERROR;
+    }
+
+    size_t remaining = s->tx_len - s->tx_offset;
+
+    if (*dst_len > remaining)
+    {
+        *dst_len = remaining;
+    }
+
+    memcpy(dst, &s->tx_buf[s->tx_offset], *dst_len);
+    s->tx_offset += *dst_len;
+
+    return (s->tx_offset >= s->tx_len) ? POUCH_NO_MORE_DATA : POUCH_MORE_DATA;
+}
+
+void stub_receiver_reset(struct stub_receiver *r)
+{
+    r->rx_len = 0;
+    r->start_count = 0;
+    r->end_success_count = 0;
+    r->end_fail_count = 0;
+    r->start_err = 0;
+    r->recv_err = 0;
+    r->bearer = NULL;
+}
+
+static void receiver_push(struct stub_receiver *r, const void *buf, size_t len)
+{
+    size_t space = STUB_EP_BUF_SIZE - r->rx_len;
+
+    if (len > space)
+    {
+        len = space;
+    }
+
+    memcpy(&r->rx_buf[r->rx_len], buf, len);
+    r->rx_len += len;
+}
+
+/* ---- Broker endpoint stubs ----------------------------------------------- */
+
+struct broker_stubs broker_stubs;
+
+/* INFO: broker receives from device (receiver) */
+
+static int b_info_start(struct pouch_bearer *bearer)
+{
+    broker_stubs.info.bearer = bearer;
+    broker_stubs.info.rx_len = 0;
+    broker_stubs.info.start_count++;
+    return broker_stubs.info.start_err;
+}
+
+static int b_info_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    if (broker_stubs.info.recv_err != 0)
+    {
+        return broker_stubs.info.recv_err;
+    }
+    receiver_push(&broker_stubs.info, buf, len);
+    return 0;
+}
+
+static void b_info_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.info.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.info.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_info = {
+    .start = b_info_start,
+    .recv = b_info_recv,
+    .end = b_info_end,
+};
+
+/* SERVER_CERT: broker sends to device (sender) */
+
+static int b_server_cert_start(struct pouch_bearer *bearer)
+{
+    broker_stubs.server_cert.bearer = bearer;
+    broker_stubs.server_cert.tx_offset = 0;
+    broker_stubs.server_cert.start_count++;
+    return broker_stubs.server_cert.start_err;
+}
+
+static enum pouch_result b_server_cert_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&broker_stubs.server_cert, dst, dst_len);
+}
+
+static void b_server_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.server_cert.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.server_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_server_cert = {
+    .start = b_server_cert_start,
+    .send = b_server_cert_send,
+    .end = b_server_cert_end,
+};
+
+/* DEVICE_CERT: broker receives from device (receiver) */
+
+static int b_device_cert_start(struct pouch_bearer *bearer)
+{
+    broker_stubs.device_cert.bearer = bearer;
+    broker_stubs.device_cert.rx_len = 0;
+    broker_stubs.device_cert.start_count++;
+    return broker_stubs.device_cert.start_err;
+}
+
+static int b_device_cert_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    if (broker_stubs.device_cert.recv_err != 0)
+    {
+        return broker_stubs.device_cert.recv_err;
+    }
+    receiver_push(&broker_stubs.device_cert, buf, len);
+    return 0;
+}
+
+static void b_device_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.device_cert.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.device_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_device_cert = {
+    .start = b_device_cert_start,
+    .recv = b_device_cert_recv,
+    .end = b_device_cert_end,
+};
+
+/* DOWNLINK: broker sends to device (sender) */
+
+static int b_downlink_start(struct pouch_bearer *bearer)
+{
+    broker_stubs.downlink.bearer = bearer;
+    broker_stubs.downlink.tx_offset = 0;
+    broker_stubs.downlink.start_count++;
+    return broker_stubs.downlink.start_err;
+}
+
+static enum pouch_result b_downlink_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&broker_stubs.downlink, dst, dst_len);
+}
+
+static void b_downlink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.downlink.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.downlink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_downlink = {
+    .start = b_downlink_start,
+    .send = b_downlink_send,
+    .end = b_downlink_end,
+};
+
+/* UPLINK: broker receives from device (receiver) */
+
+static int b_uplink_start(struct pouch_bearer *bearer)
+{
+    broker_stubs.uplink.bearer = bearer;
+    broker_stubs.uplink.rx_len = 0;
+    broker_stubs.uplink.start_count++;
+    return broker_stubs.uplink.start_err;
+}
+
+static int b_uplink_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    if (broker_stubs.uplink.recv_err != 0)
+    {
+        return broker_stubs.uplink.recv_err;
+    }
+    receiver_push(&broker_stubs.uplink, buf, len);
+    return 0;
+}
+
+static void b_uplink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.uplink.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.uplink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_uplink = {
+    .start = b_uplink_start,
+    .recv = b_uplink_recv,
+    .end = b_uplink_end,
+};

--- a/tests/pouch/serial/broker/src/stub_endpoints.h
+++ b/tests/pouch/serial/broker/src/stub_endpoints.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "transport/endpoints/endpoint.h"
+
+#define STUB_EP_BUF_SIZE 512
+
+struct stub_sender
+{
+    uint8_t tx_buf[STUB_EP_BUF_SIZE];
+    size_t tx_len;
+    size_t tx_offset;
+
+    int start_count;
+    int end_success_count;
+    int end_fail_count;
+
+    /** If non-zero, start() returns this error code. */
+    int start_err;
+
+    /** If true, send() returns POUCH_ERROR. */
+    bool send_err;
+
+    /** Bearer pointer captured during start(). */
+    struct pouch_bearer *bearer;
+};
+
+struct stub_receiver
+{
+    uint8_t rx_buf[STUB_EP_BUF_SIZE];
+    size_t rx_len;
+
+    int start_count;
+    int end_success_count;
+    int end_fail_count;
+
+    /** If non-zero, start() returns this error code. */
+    int start_err;
+    /** If non-zero, recv() returns this error code. */
+    int recv_err;
+
+    /** Bearer pointer captured during start(). */
+    struct pouch_bearer *bearer;
+};
+
+struct broker_stubs
+{
+    struct stub_receiver info;
+    struct stub_sender server_cert;
+    struct stub_receiver device_cert;
+    struct stub_sender downlink;
+    struct stub_receiver uplink;
+};
+
+extern struct broker_stubs broker_stubs;
+
+void stub_sender_reset(struct stub_sender *s);
+void stub_sender_set_data(struct stub_sender *s, const uint8_t *data, size_t len);
+void stub_receiver_reset(struct stub_receiver *r);

--- a/tests/pouch/serial/broker/src/test_broker.c
+++ b/tests/pouch/serial/broker/src/test_broker.c
@@ -1,0 +1,1362 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <string.h>
+#include <errno.h>
+
+#include <pouch/transport/serial/broker.h>
+#include <pouch/transport/serial/common.h>
+#include "transport/bearer.h"
+#include "transport/serial/packet.h"
+#include "gateway/types.h"
+#include "stub_endpoints.h"
+
+#define FRAME_BUF_SIZE 64
+#define MAX_FRAMES 200
+
+/* ---- Adapter mock -------------------------------------------------------- */
+
+static int ready_count;
+static int end_count;
+static bool end_success;
+static struct pouch_serial_broker *test_broker;
+
+static void adapter_ready(const struct pouch_serial_broker *broker)
+{
+    (void) broker;
+    ready_count++;
+}
+
+static void adapter_end(const struct pouch_serial_broker *broker, bool success)
+{
+    (void) broker;
+    end_count++;
+    end_success = success;
+}
+
+static const struct pouch_serial_broker_adapter test_adapter = {
+    .ready = adapter_ready,
+    .end = adapter_end,
+};
+
+/* ---- Frame helpers ------------------------------------------------------- */
+
+static size_t build_frame(uint8_t *buf,
+                          size_t bufsize,
+                          const struct pouch_serial_header *hdr,
+                          const void *payload,
+                          size_t payload_len)
+{
+    zassert_true(POUCH_SERIAL_HEADER_LEN + payload_len <= bufsize);
+    buf[0] = pouch_serial_header_encode(hdr);
+
+    if (payload_len > 0)
+    {
+        memcpy(&buf[POUCH_SERIAL_HEADER_LEN], payload, payload_len);
+    }
+
+    return POUCH_SERIAL_HEADER_LEN + payload_len;
+}
+
+/** Send a frame to the broker (simulating device -> broker). */
+static int send_frame(const struct pouch_serial_header *hdr,
+                      const void *payload,
+                      size_t payload_len)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    size_t len = build_frame(buf, sizeof(buf), hdr, payload, payload_len);
+
+    return pouch_serial_broker_recv(test_broker, buf, len);
+}
+
+/** Send an ACK frame to the broker. */
+static int send_ack(uint8_t channel, bool err)
+{
+    struct pouch_serial_header hdr = {
+        .is_data = false,
+        .err = err,
+        .channel = channel,
+    };
+
+    return send_frame(&hdr, NULL, 0);
+}
+
+/** Send a DATA frame to the broker (simulating device sending data). */
+static int send_data(uint8_t channel,
+                     bool first,
+                     bool last,
+                     bool err,
+                     const void *payload,
+                     size_t payload_len)
+{
+    struct pouch_serial_header hdr = {
+        .is_data = true,
+        .first = first,
+        .last = last,
+        .err = err,
+        .channel = channel,
+    };
+
+    return send_frame(&hdr, payload, payload_len);
+}
+
+/**
+ * Get a frame from the broker and decode its header.
+ *
+ * @return Total frame length, or 0 if no frame was available.
+ */
+static size_t get_frame(struct pouch_serial_header *hdr,
+                        const uint8_t **payload,
+                        size_t *payload_len,
+                        uint8_t *buf,
+                        size_t bufsize)
+{
+    size_t len = pouch_serial_broker_frame_get(test_broker, buf, bufsize);
+    if (len == 0)
+    {
+        return 0;
+    }
+
+    zassert_true(len >= POUCH_SERIAL_HEADER_LEN, "frame too short: %zu", len);
+    int err = pouch_serial_header_decode(buf[0], hdr);
+    zassert_ok(err, "failed to decode header: %d", err);
+
+    if (len > POUCH_SERIAL_HEADER_LEN)
+    {
+        *payload = &buf[POUCH_SERIAL_HEADER_LEN];
+        *payload_len = len - POUCH_SERIAL_HEADER_LEN;
+    }
+    else
+    {
+        *payload = NULL;
+        *payload_len = 0;
+    }
+
+    return len;
+}
+
+/**
+ * Drain a broker sender channel: get the prompt ACK, send ACK to open it,
+ * then collect all DATA frames.
+ *
+ * The serial protocol requires the sender to produce a prompt ACK when it has
+ * data to send. The remote side responds with an ACK to open the channel,
+ * after which the sender produces DATA frames.
+ */
+static void drain_sender_channel(uint8_t channel,
+                                 uint8_t *out,
+                                 size_t *out_len,
+                                 size_t out_size,
+                                 int *frame_count,
+                                 bool *saw_first,
+                                 bool *saw_last,
+                                 bool *saw_err)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    *out_len = 0;
+    *frame_count = 0;
+    *saw_first = false;
+    *saw_last = false;
+    *saw_err = false;
+
+    /* Get the prompt ACK from the sender */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected prompt ACK for channel %u", channel);
+    zassert_equal(hdr.channel,
+                  channel,
+                  "unexpected channel %u (expected %u)",
+                  hdr.channel,
+                  channel);
+    zassert_false(hdr.is_data, "expected ACK prompt, got DATA");
+    zassert_false(hdr.err, "unexpected ERR on prompt ACK");
+
+    /* Send ACK to open the sender channel */
+    zassert_ok(send_ack(channel, false));
+
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        if (len == 0)
+        {
+            break;
+        }
+
+        zassert_equal(hdr.channel,
+                      channel,
+                      "unexpected channel %u (expected %u)",
+                      hdr.channel,
+                      channel);
+        zassert_true(hdr.is_data, "expected DATA frame, got ACK");
+
+        if (hdr.first)
+        {
+            *saw_first = true;
+        }
+        if (hdr.err)
+        {
+            *saw_err = true;
+        }
+
+        if (payload_len > 0)
+        {
+            zassert_true(*out_len + payload_len <= out_size, "output buffer overflow");
+            memcpy(&out[*out_len], payload, payload_len);
+            *out_len += payload_len;
+        }
+
+        (*frame_count)++;
+
+        if (hdr.last)
+        {
+            *saw_last = true;
+            break;
+        }
+    }
+}
+
+/**
+ * Complete a receiver channel exchange: get the broker's ACK prompt,
+ * then send DATA frames with the given payload.
+ */
+static void complete_receiver_channel(uint8_t channel, const void *data, size_t data_len)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get the ACK prompt from the broker */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected ACK prompt for channel %u", channel);
+    zassert_equal(hdr.channel, channel);
+    zassert_false(hdr.is_data, "expected ACK prompt, got DATA");
+    zassert_false(hdr.err);
+
+    /* Send DATA response (first+last, with optional payload) */
+    zassert_ok(send_data(channel, true, true, false, data, data_len));
+}
+
+/**
+ * Complete a sender channel exchange: drain all DATA frames from the broker,
+ * ACKing each one.
+ */
+static void complete_sender_channel(uint8_t channel)
+{
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+
+    drain_sender_channel(channel,
+                         out,
+                         &out_len,
+                         sizeof(out),
+                         &frame_count,
+                         &saw_first,
+                         &saw_last,
+                         &saw_err);
+}
+
+/**
+ * Run the broker sequence from start through all channels up to (but not
+ * including) the sync phase.
+ *
+ * The provisioning flags must be set BEFORE the INFO channel closes, because
+ * the broker's next() function checks them immediately when INFO completes.
+ * To achieve this, we send INFO data as two fragments: the first fragment
+ * opens the channel and captures the bearer (giving us access to the node),
+ * then we set the flags, then the second fragment closes INFO.
+ *
+ * After this call, both UPLINK and DOWNLINK channels are active.
+ */
+static void advance_to_sync(bool skip_server_cert, bool skip_device_cert)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    zassert_ok(pouch_serial_broker_start(test_broker));
+
+    /* 1. INFO: get the ACK prompt */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected INFO prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_INFO);
+    zassert_false(hdr.is_data);
+
+    /* Send first DATA fragment (opens the channel, captures bearer) */
+    zassert_ok(send_data(POUCH_SERIAL_CH_INFO, true, false, false, NULL, 0));
+
+    /* Now set provisioning flags BEFORE closing INFO */
+    struct pouch_gateway_node_info *node = broker_stubs.info.bearer->ctx;
+    zassert_not_null(node);
+    node->server_cert_provisioned = skip_server_cert;
+    node->device_cert_provisioned = skip_device_cert;
+
+    /* Send last DATA fragment to close INFO: triggers next() */
+    zassert_ok(send_data(POUCH_SERIAL_CH_INFO, false, true, false, NULL, 0));
+
+    /* 2. SERVER_CERT (if not provisioned): broker sends data.
+     * Get prompt ACK, open the channel, then drain DATA frames. */
+    if (!skip_server_cert)
+    {
+        /* Get prompt ACK from the SERVER_CERT sender */
+        len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        zassert_true(len > 0, "expected SERVER_CERT prompt ACK");
+        zassert_equal(hdr.channel, POUCH_SERIAL_CH_SERVER_CERT);
+        zassert_false(hdr.is_data);
+
+        /* Mark as provisioned before opening (ch_close triggers next()) */
+        node->server_cert_provisioned = true;
+
+        /* Send ACK to open the sender channel */
+        zassert_ok(send_ack(POUCH_SERIAL_CH_SERVER_CERT, false));
+
+        /* Drain all DATA frames */
+        for (int i = 0; i < MAX_FRAMES; i++)
+        {
+            len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+            if (len == 0)
+            {
+                break;
+            }
+            zassert_equal(hdr.channel, POUCH_SERIAL_CH_SERVER_CERT);
+            zassert_true(hdr.is_data);
+            if (hdr.last)
+            {
+                break;
+            }
+        }
+    }
+
+    /* 3. DEVICE_CERT (if not provisioned): broker prompts, we send data.
+     * Must set device_cert_provisioned BEFORE the channel closes. */
+    if (!skip_device_cert)
+    {
+        /* Get prompt ACK */
+        len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        zassert_true(len > 0, "expected DEVICE_CERT prompt");
+        zassert_equal(hdr.channel, POUCH_SERIAL_CH_DEVICE_CERT);
+        zassert_false(hdr.is_data);
+
+        /* Mark as provisioned before sending last DATA (ch_close triggers next()) */
+        node->device_cert_provisioned = true;
+
+        /* Send DATA (first+last): closing triggers next() */
+        zassert_ok(send_data(POUCH_SERIAL_CH_DEVICE_CERT, true, true, false, NULL, 0));
+    }
+
+    /* Now broker enters sync: both UPLINK and DOWNLINK are activated */
+}
+
+/**
+ * Complete the sync phase: handle DOWNLINK (sender) and UPLINK (receiver)
+ * frames until both are done.
+ *
+ * DOWNLINK is a sender channel: we send ACK to open it, then drain DATA.
+ * UPLINK is a receiver channel: broker sends ACK prompt, we send DATA back.
+ */
+static void complete_sync(void)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    bool downlink_done = false;
+    bool uplink_done = false;
+
+    for (int i = 0; i < MAX_FRAMES && !(downlink_done && uplink_done); i++)
+    {
+        size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        if (len == 0)
+        {
+            break;
+        }
+
+        if (hdr.channel == POUCH_SERIAL_CH_DOWNLINK)
+        {
+            if (!hdr.is_data)
+            {
+                /* Prompt ACK: open the sender channel */
+                send_ack(POUCH_SERIAL_CH_DOWNLINK, false);
+            }
+            else if (hdr.last)
+            {
+                downlink_done = true;
+            }
+        }
+        else if (hdr.channel == POUCH_SERIAL_CH_UPLINK)
+        {
+            zassert_false(hdr.is_data, "expected ACK on UPLINK");
+            /* Send empty DATA response */
+            send_data(POUCH_SERIAL_CH_UPLINK, true, true, false, NULL, 0);
+            uplink_done = true;
+        }
+    }
+
+    zassert_true(downlink_done, "downlink did not complete");
+    zassert_true(uplink_done, "uplink did not complete");
+}
+
+/**
+ * Run a full exchange to completion with both certs provisioned and no data.
+ */
+static void run_empty_exchange(void)
+{
+    advance_to_sync(true, true);
+    complete_sync();
+    zassert_equal(end_count, 1, "expected end callback");
+    zassert_true(end_success, "expected successful end");
+}
+
+/* ---- Reset helpers ------------------------------------------------------- */
+
+static void reset_stubs(void)
+{
+    stub_receiver_reset(&broker_stubs.info);
+    stub_sender_reset(&broker_stubs.server_cert);
+    stub_receiver_reset(&broker_stubs.device_cert);
+    stub_sender_reset(&broker_stubs.downlink);
+    stub_receiver_reset(&broker_stubs.uplink);
+}
+
+static void reset_all(void)
+{
+    reset_stubs();
+    ready_count = 0;
+    end_count = 0;
+    end_success = false;
+}
+
+/* ---- Test fixture -------------------------------------------------------- */
+
+static void *suite_setup(void)
+{
+    test_broker = pouch_serial_broker_create(&test_adapter);
+    zassert_not_null(test_broker);
+    return NULL;
+}
+
+static void before(void *f)
+{
+    (void) f;
+    if (test_broker != NULL)
+    {
+        free(test_broker);
+    }
+    test_broker = pouch_serial_broker_create(&test_adapter);
+    zassert_not_null(test_broker);
+    reset_all();
+}
+
+ZTEST_SUITE(serial_broker, NULL, suite_setup, before, NULL, NULL);
+
+/* ==========================================================================
+ * Broker lifecycle tests
+ * ========================================================================== */
+
+ZTEST(serial_broker, test_create_null_adapter)
+{
+    struct pouch_serial_broker *b = pouch_serial_broker_create(NULL);
+    zassert_is_null(b);
+}
+
+ZTEST(serial_broker, test_start_null_broker)
+{
+    zassert_equal(pouch_serial_broker_start(NULL), -EINVAL);
+}
+
+ZTEST(serial_broker, test_recv_null_params)
+{
+    uint8_t buf[4] = {0};
+    zassert_equal(pouch_serial_broker_recv(NULL, buf, 1), -EINVAL);
+    zassert_equal(pouch_serial_broker_recv(test_broker, NULL, 1), -EINVAL);
+    zassert_equal(pouch_serial_broker_recv(test_broker, buf, 0), -EINVAL);
+}
+
+ZTEST(serial_broker, test_frame_get_null_params)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    zassert_equal(pouch_serial_broker_frame_get(NULL, buf, sizeof(buf)), 0);
+    zassert_equal(pouch_serial_broker_frame_get(test_broker, NULL, sizeof(buf)), 0);
+}
+
+ZTEST(serial_broker, test_adapter_get)
+{
+    zassert_equal_ptr(pouch_serial_broker_adapter_get(test_broker), &test_adapter);
+}
+
+ZTEST(serial_broker, test_adapter_get_null)
+{
+    zassert_is_null(pouch_serial_broker_adapter_get(NULL));
+}
+
+ZTEST(serial_broker, test_frame_get_no_pending)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    size_t len = pouch_serial_broker_frame_get(test_broker, buf, sizeof(buf));
+    zassert_equal(len, 0, "expected no frames from idle broker");
+}
+
+ZTEST(serial_broker, test_start_triggers_info_prompt)
+{
+    zassert_ok(pouch_serial_broker_start(test_broker));
+    zassert_true(ready_count > 0, "ready callback not called after start");
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected frame after start");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_INFO);
+    zassert_false(hdr.is_data, "expected ACK prompt for INFO");
+}
+
+/* ==========================================================================
+ * Full exchange sequence tests
+ * ========================================================================== */
+
+ZTEST(serial_broker, test_full_exchange_all_provisioned)
+{
+    run_empty_exchange();
+
+    zassert_equal(broker_stubs.info.start_count, 1);
+    zassert_equal(broker_stubs.info.end_success_count, 1);
+    zassert_equal(broker_stubs.server_cert.start_count, 0);
+    zassert_equal(broker_stubs.device_cert.start_count, 0);
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.downlink.start_count, 1);
+}
+
+ZTEST(serial_broker, test_full_exchange_needs_server_cert)
+{
+    static const uint8_t cert[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    stub_sender_set_data(&broker_stubs.server_cert, cert, sizeof(cert));
+
+    advance_to_sync(false, true);
+    complete_sync();
+
+    zassert_equal(end_count, 1);
+    zassert_true(end_success);
+    zassert_equal(broker_stubs.server_cert.start_count, 1);
+    zassert_equal(broker_stubs.server_cert.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_full_exchange_needs_device_cert)
+{
+    advance_to_sync(true, false);
+    complete_sync();
+
+    zassert_equal(end_count, 1);
+    zassert_true(end_success);
+    zassert_equal(broker_stubs.device_cert.start_count, 1);
+    zassert_equal(broker_stubs.device_cert.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_full_exchange_needs_both_certs)
+{
+    advance_to_sync(false, false);
+    complete_sync();
+
+    zassert_equal(end_count, 1);
+    zassert_true(end_success);
+    zassert_equal(broker_stubs.server_cert.start_count, 1);
+    zassert_equal(broker_stubs.device_cert.start_count, 1);
+}
+
+ZTEST(serial_broker, test_consecutive_exchanges)
+{
+    for (int i = 0; i < 2; i++)
+    {
+        /* Recreate broker to get clean channel state */
+        free(test_broker);
+        test_broker = pouch_serial_broker_create(&test_adapter);
+        zassert_not_null(test_broker);
+        reset_all();
+
+        advance_to_sync(true, true);
+        complete_sync();
+        zassert_equal(end_count, 1, "exchange %d: end not called", i);
+        zassert_true(end_success, "exchange %d: failed", i);
+    }
+}
+
+/* ==========================================================================
+ * Sender channel tests (SERVER_CERT=1, DOWNLINK=3)
+ *
+ * For sender channels, the broker sends DATA frames and the device (test)
+ * responds with ACK frames.
+ * ========================================================================== */
+
+ZTEST(serial_broker, test_sender_single_fragment)
+{
+    static const uint8_t payload[] = {0x10, 0x20, 0x30};
+    stub_sender_set_data(&broker_stubs.downlink, payload, sizeof(payload));
+
+    advance_to_sync(true, true);
+
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+
+    drain_sender_channel(POUCH_SERIAL_CH_DOWNLINK,
+                         out,
+                         &out_len,
+                         sizeof(out),
+                         &frame_count,
+                         &saw_first,
+                         &saw_last,
+                         &saw_err);
+
+    zassert_true(saw_first, "missing FIRST flag");
+    zassert_true(saw_last, "missing LAST flag");
+    zassert_false(saw_err, "unexpected ERR flag");
+    zassert_equal(out_len, sizeof(payload));
+    zassert_mem_equal(out, payload, sizeof(payload));
+    zassert_equal(broker_stubs.downlink.start_count, 1);
+    zassert_equal(broker_stubs.downlink.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_sender_multi_fragment)
+{
+    /* Create payload larger than frame buffer to force multi-frame transfer */
+    uint8_t payload[FRAME_BUF_SIZE * 2];
+    memset(payload, 0xAB, sizeof(payload));
+    stub_sender_set_data(&broker_stubs.downlink, payload, sizeof(payload));
+
+    advance_to_sync(true, true);
+
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+
+    drain_sender_channel(POUCH_SERIAL_CH_DOWNLINK,
+                         out,
+                         &out_len,
+                         sizeof(out),
+                         &frame_count,
+                         &saw_first,
+                         &saw_last,
+                         &saw_err);
+
+    zassert_true(saw_first);
+    zassert_true(saw_last);
+    zassert_false(saw_err);
+    zassert_true(frame_count > 1, "expected multiple frames for large payload");
+    zassert_equal(out_len, sizeof(payload));
+    zassert_mem_equal(out, payload, sizeof(payload));
+}
+
+ZTEST(serial_broker, test_sender_empty_transfer)
+{
+    /* No data loaded on DOWNLINK sender */
+    advance_to_sync(true, true);
+
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+
+    drain_sender_channel(POUCH_SERIAL_CH_DOWNLINK,
+                         out,
+                         &out_len,
+                         sizeof(out),
+                         &frame_count,
+                         &saw_first,
+                         &saw_last,
+                         &saw_err);
+
+    zassert_true(saw_first);
+    zassert_true(saw_last);
+    zassert_false(saw_err);
+    zassert_equal(out_len, 0);
+    zassert_equal(broker_stubs.downlink.start_count, 1);
+    zassert_equal(broker_stubs.downlink.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_sender_ack_err_aborts)
+{
+    /* Use a payload large enough to require multiple frames so that
+     * the first DATA frame is not also the last. */
+    uint8_t payload[FRAME_BUF_SIZE * 2];
+    memset(payload, 0xAB, sizeof(payload));
+    stub_sender_set_data(&broker_stubs.downlink, payload, sizeof(payload));
+
+    advance_to_sync(true, true);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *resp_payload;
+    size_t resp_len;
+
+    /* Get DOWNLINK prompt ACK */
+    size_t len = get_frame(&hdr, &resp_payload, &resp_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected DOWNLINK prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_false(hdr.is_data);
+
+    /* Open the DOWNLINK sender channel with an ACK */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DOWNLINK, false));
+
+    /* Get the first DATA frame from DOWNLINK */
+    len = get_frame(&hdr, &resp_payload, &resp_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_true(hdr.first);
+    zassert_false(hdr.last, "expected multi-fragment transfer");
+
+    /* Send ACK+ERR to abort */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DOWNLINK, true));
+
+    zassert_equal(broker_stubs.downlink.end_fail_count, 1);
+    zassert_equal(broker_stubs.downlink.end_success_count, 0);
+}
+
+ZTEST(serial_broker, test_sender_ack_err_during_multi_fragment)
+{
+    uint8_t payload[FRAME_BUF_SIZE * 2];
+    memset(payload, 0xAB, sizeof(payload));
+    stub_sender_set_data(&broker_stubs.downlink, payload, sizeof(payload));
+
+    advance_to_sync(true, true);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *resp_payload;
+    size_t resp_len;
+
+    /* Get DOWNLINK prompt ACK */
+    size_t len = get_frame(&hdr, &resp_payload, &resp_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected DOWNLINK prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_false(hdr.is_data);
+
+    /* Open the DOWNLINK sender channel with an ACK */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DOWNLINK, false));
+
+    /* Get first DATA frame */
+    len = get_frame(&hdr, &resp_payload, &resp_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+    zassert_true(hdr.first);
+    zassert_false(hdr.last, "expected multi-fragment");
+
+    /* Get second DATA frame (no intermediate ACK needed) */
+    len = get_frame(&hdr, &resp_payload, &resp_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+
+    /* Now send ACK+ERR to abort mid-transfer */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DOWNLINK, true));
+
+    zassert_equal(broker_stubs.downlink.end_fail_count, 1);
+    zassert_equal(broker_stubs.downlink.end_success_count, 0);
+}
+
+ZTEST(serial_broker, test_sender_start_error)
+{
+    broker_stubs.downlink.start_err = -ENOMEM;
+
+    advance_to_sync(true, true);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get DOWNLINK prompt ACK */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected DOWNLINK prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_false(hdr.is_data);
+
+    /* Send ACK to open the channel: start will fail */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DOWNLINK, false));
+
+    /* Broker should produce an error DATA frame for DOWNLINK */
+    len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected error frame");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_true(hdr.is_data);
+    zassert_true(hdr.err);
+    zassert_true(hdr.last);
+
+    zassert_equal(broker_stubs.downlink.start_count, 1);
+    zassert_equal(broker_stubs.downlink.end_fail_count, 1);
+}
+
+ZTEST(serial_broker, test_sender_send_error)
+{
+    broker_stubs.downlink.send_err = true;
+
+    advance_to_sync(true, true);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get DOWNLINK prompt ACK */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected DOWNLINK prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_false(hdr.is_data);
+
+    /* Send ACK to open the channel */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DOWNLINK, false));
+
+    /* Broker should produce an error DATA frame */
+    len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected error frame");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_true(hdr.is_data);
+    zassert_true(hdr.err);
+    zassert_true(hdr.last);
+}
+
+ZTEST(serial_broker, test_sender_server_cert_with_data)
+{
+    static const uint8_t cert[] = {0xCA, 0xFE, 0xBA, 0xBE, 0x01, 0x02};
+    stub_sender_set_data(&broker_stubs.server_cert, cert, sizeof(cert));
+
+    zassert_ok(pouch_serial_broker_start(test_broker));
+
+    /* Complete INFO */
+    complete_receiver_channel(POUCH_SERIAL_CH_INFO, NULL, 0);
+
+    /* Set only device cert as provisioned */
+    struct pouch_gateway_node_info *node = broker_stubs.info.bearer->ctx;
+    node->server_cert_provisioned = false;
+    node->device_cert_provisioned = true;
+
+    /* Drain SERVER_CERT sender */
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+
+    drain_sender_channel(POUCH_SERIAL_CH_SERVER_CERT,
+                         out,
+                         &out_len,
+                         sizeof(out),
+                         &frame_count,
+                         &saw_first,
+                         &saw_last,
+                         &saw_err);
+
+    zassert_true(saw_first);
+    zassert_true(saw_last);
+    zassert_false(saw_err);
+    zassert_equal(out_len, sizeof(cert));
+    zassert_mem_equal(out, cert, sizeof(cert));
+}
+
+/* ==========================================================================
+ * Receiver channel tests (INFO=0, DEVICE_CERT=2, UPLINK=4)
+ *
+ * For receiver channels, the broker sends ACK prompts and the device (test)
+ * responds with DATA frames.
+ * ========================================================================== */
+
+ZTEST(serial_broker, test_receiver_single_fragment)
+{
+    static const uint8_t payload[] = {0xCA, 0xFE, 0xBA, 0xBE};
+
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *resp_payload;
+    size_t resp_len;
+
+    /* Get UPLINK prompt */
+    size_t len = get_frame(&hdr, &resp_payload, &resp_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected UPLINK prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+    zassert_false(hdr.is_data);
+    zassert_false(hdr.err);
+
+    /* Send data to UPLINK */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, true, true, false, payload, sizeof(payload)));
+
+    zassert_equal(broker_stubs.uplink.rx_len, sizeof(payload));
+    zassert_mem_equal(broker_stubs.uplink.rx_buf, payload, sizeof(payload));
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_receiver_multi_fragment)
+{
+    static const uint8_t frag1[] = {0x01, 0x02};
+    static const uint8_t frag2[] = {0x03, 0x04};
+    static const uint8_t frag3[] = {0x05};
+
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+
+    /* First fragment */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, true, false, false, frag1, sizeof(frag1)));
+
+    /* Middle fragment */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, false, false, false, frag2, sizeof(frag2)));
+
+    /* Last fragment */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, false, true, false, frag3, sizeof(frag3)));
+
+    uint8_t expected[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+    zassert_equal(broker_stubs.uplink.rx_len, sizeof(expected));
+    zassert_mem_equal(broker_stubs.uplink.rx_buf, expected, sizeof(expected));
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_receiver_empty_transfer)
+{
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+
+    /* Send empty DATA (first+last, no payload) */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, true, true, false, NULL, 0));
+
+    zassert_equal(broker_stubs.uplink.rx_len, 0);
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_receiver_data_err_aborts)
+{
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+
+    /* Start a transfer */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, true, false, false, (uint8_t[]){0xAA}, 1));
+
+    /* Send error frame */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, false, true, true, NULL, 0));
+
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_fail_count, 1);
+    zassert_equal(broker_stubs.uplink.end_success_count, 0);
+}
+
+ZTEST(serial_broker, test_receiver_missing_first_flag)
+{
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+
+    /* Send DATA without FIRST flag to a channel that isn't open yet */
+    int err = send_data(POUCH_SERIAL_CH_UPLINK, false, false, false, (uint8_t[]){0x01}, 1);
+    zassert_not_equal(err, 0, "expected error for missing FIRST flag");
+}
+
+ZTEST(serial_broker, test_receiver_duplicate_first_flag)
+{
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+
+    /* Send first DATA */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, true, false, false, (uint8_t[]){0x01}, 1));
+
+    /* Send another FIRST: should fail */
+    int err = send_data(POUCH_SERIAL_CH_UPLINK, true, false, false, (uint8_t[]){0x02}, 1);
+    zassert_not_equal(err, 0, "expected error for duplicate FIRST");
+
+    zassert_equal(broker_stubs.uplink.end_fail_count, 1);
+}
+
+ZTEST(serial_broker, test_receiver_start_error)
+{
+    broker_stubs.uplink.start_err = -EBUSY;
+
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+
+    /* Send DATA: start should fail, broker should NACK */
+    send_data(POUCH_SERIAL_CH_UPLINK, true, true, false, (uint8_t[]){0x01}, 1);
+
+    /* Get the NACK */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected NACK");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+    zassert_false(hdr.is_data);
+    zassert_true(hdr.err, "expected ERR on NACK");
+}
+
+ZTEST(serial_broker, test_receiver_recv_error)
+{
+    broker_stubs.uplink.recv_err = -ENOMEM;
+
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+
+    /* Send DATA: recv should fail */
+    int err = send_data(POUCH_SERIAL_CH_UPLINK, true, true, false, (uint8_t[]){0xAA}, 1);
+    zassert_not_equal(err, 0);
+
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_fail_count, 1);
+}
+
+ZTEST(serial_broker, test_receiver_info_with_data)
+{
+    static const uint8_t info_data[] = {0x01, 0x02, 0x03};
+
+    zassert_ok(pouch_serial_broker_start(test_broker));
+
+    /* Get INFO prompt */
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_INFO);
+    zassert_false(hdr.is_data);
+
+    /* Send info data */
+    zassert_ok(send_data(POUCH_SERIAL_CH_INFO, true, true, false, info_data, sizeof(info_data)));
+
+    zassert_equal(broker_stubs.info.rx_len, sizeof(info_data));
+    zassert_mem_equal(broker_stubs.info.rx_buf, info_data, sizeof(info_data));
+    zassert_equal(broker_stubs.info.start_count, 1);
+    zassert_equal(broker_stubs.info.end_success_count, 1);
+}
+
+ZTEST(serial_broker, test_receiver_device_cert_with_data)
+{
+    static const uint8_t cert_data[] = {0xDE, 0xAD, 0xBE, 0xEF};
+
+    zassert_ok(pouch_serial_broker_start(test_broker));
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get INFO prompt */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_INFO);
+
+    /* Send first (non-last) INFO fragment to open the channel and capture bearer */
+    zassert_ok(send_data(POUCH_SERIAL_CH_INFO, true, false, false, NULL, 0));
+
+    /* Set provisioning flags BEFORE closing INFO */
+    struct pouch_gateway_node_info *node = broker_stubs.info.bearer->ctx;
+    node->server_cert_provisioned = true;
+    node->device_cert_provisioned = false;
+
+    /* Close INFO: triggers next() which sees device_cert not provisioned */
+    zassert_ok(send_data(POUCH_SERIAL_CH_INFO, false, true, false, NULL, 0));
+
+    /* Get DEVICE_CERT prompt */
+    len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DEVICE_CERT);
+    zassert_false(hdr.is_data);
+
+    /* Send cert data */
+    zassert_ok(
+        send_data(POUCH_SERIAL_CH_DEVICE_CERT, true, true, false, cert_data, sizeof(cert_data)));
+
+    zassert_equal(broker_stubs.device_cert.rx_len, sizeof(cert_data));
+    zassert_mem_equal(broker_stubs.device_cert.rx_buf, cert_data, sizeof(cert_data));
+    zassert_equal(broker_stubs.device_cert.start_count, 1);
+    zassert_equal(broker_stubs.device_cert.end_success_count, 1);
+}
+
+/* ==========================================================================
+ * Cross-channel and invalid behavior tests
+ * ========================================================================== */
+
+ZTEST(serial_broker, test_invalid_channel_id)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr = {
+        .is_data = false,
+        .channel = POUCH_SERIAL_CHANNEL_COUNT, /* Out of range */
+    };
+    size_t len = build_frame(buf, sizeof(buf), &hdr, NULL, 0);
+    int err = pouch_serial_broker_recv(test_broker, buf, len);
+    zassert_equal(err, -EINVAL);
+}
+
+ZTEST(serial_broker, test_malformed_ack_header)
+{
+    /*
+     * An ACK frame with reserved bits (FIRST or LAST) set is malformed.
+     * Manually encode: bit7=0 (ACK), bit5=1 (FIRST, reserved), channel=0
+     */
+    uint8_t frame[] = {0x20}; /* 0b00100000 = ACK with FIRST bit set */
+    int err = pouch_serial_broker_recv(test_broker, frame, sizeof(frame));
+    zassert_equal(err, -EINVAL);
+}
+
+ZTEST(serial_broker, test_concurrent_uplink_and_downlink)
+{
+    static const uint8_t dl_data[] = {0xAA, 0xBB};
+    static const uint8_t ul_data[] = {0xCC, 0xDD, 0xEE};
+
+    stub_sender_set_data(&broker_stubs.downlink, dl_data, sizeof(dl_data));
+
+    advance_to_sync(true, true);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    uint8_t dl_out[STUB_EP_BUF_SIZE];
+    size_t dl_len = 0;
+    bool dl_done = false;
+    bool ul_done = false;
+
+    for (int i = 0; i < MAX_FRAMES && !(dl_done && ul_done); i++)
+    {
+        size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        if (len == 0)
+        {
+            break;
+        }
+
+        if (hdr.channel == POUCH_SERIAL_CH_DOWNLINK)
+        {
+            if (!hdr.is_data)
+            {
+                /* Prompt ACK: open the sender channel */
+                send_ack(POUCH_SERIAL_CH_DOWNLINK, false);
+            }
+            else
+            {
+                if (payload_len > 0)
+                {
+                    memcpy(&dl_out[dl_len], payload, payload_len);
+                    dl_len += payload_len;
+                }
+                if (hdr.last)
+                {
+                    dl_done = true;
+                }
+            }
+        }
+        else if (hdr.channel == POUCH_SERIAL_CH_UPLINK)
+        {
+            zassert_false(hdr.is_data);
+            /* Send uplink data */
+            send_data(POUCH_SERIAL_CH_UPLINK, true, true, false, ul_data, sizeof(ul_data));
+            ul_done = true;
+        }
+    }
+
+    zassert_true(dl_done, "downlink not completed");
+    zassert_true(ul_done, "uplink not completed");
+    zassert_equal(dl_len, sizeof(dl_data));
+    zassert_mem_equal(dl_out, dl_data, sizeof(dl_data));
+    zassert_equal(broker_stubs.uplink.rx_len, sizeof(ul_data));
+    zassert_mem_equal(broker_stubs.uplink.rx_buf, ul_data, sizeof(ul_data));
+
+    /* Both channels done: end callback should have fired */
+    zassert_equal(end_count, 1);
+    zassert_true(end_success);
+}
+
+ZTEST(serial_broker, test_notify_triggers_uplink)
+{
+    advance_to_sync(true, true);
+
+    /* Complete DOWNLINK so only UPLINK remains */
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    /* Consume the UPLINK ACK prompt */
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected initial UPLINK prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+
+    /* Verify no more frames are pending */
+    zassert_equal(pouch_serial_broker_frame_get(test_broker, buf, sizeof(buf)), 0);
+
+    /* Notify should set UPLINK as pending, producing a new prompt */
+    pouch_serial_broker_notify(test_broker);
+
+    len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected UPLINK prompt after notify");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+    zassert_false(hdr.is_data);
+}
+
+ZTEST(serial_broker, test_notify_null_broker)
+{
+    /* Should not crash */
+    pouch_serial_broker_notify(NULL);
+}
+
+ZTEST(serial_broker, test_info_error_ends_exchange)
+{
+    broker_stubs.info.start_err = -ENOMEM;
+
+    zassert_ok(pouch_serial_broker_start(test_broker));
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get INFO prompt */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0);
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_INFO);
+
+    /* Send INFO data: start will fail */
+    send_data(POUCH_SERIAL_CH_INFO, true, true, false, NULL, 0);
+
+    /* Broker should produce a NACK (ACK+ERR) for the channel */
+    len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected NACK frame");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_INFO);
+    zassert_false(hdr.is_data);
+    zassert_true(hdr.err, "expected ERR on NACK");
+
+    /*
+     * Receiver start errors don't close the channel (OPEN was never fully
+     * set), so channel_closed doesn't fire and adapter->end is NOT called.
+     */
+    zassert_equal(end_count, 0);
+    zassert_equal(broker_stubs.info.start_count, 1);
+}
+
+ZTEST(serial_broker, test_downlink_error_ends_exchange)
+{
+    broker_stubs.downlink.start_err = -ENOMEM;
+
+    advance_to_sync(true, true);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get DOWNLINK prompt ACK */
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected DOWNLINK prompt");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_false(hdr.is_data);
+
+    /* DOWNLINK is a sender channel: send ACK to open it (triggers start error) */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DOWNLINK, false));
+
+    /* Broker should produce an error DATA frame */
+    len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected error frame");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_true(hdr.is_data);
+    zassert_true(hdr.err);
+    zassert_true(hdr.last);
+
+    /* The exchange should have ended with failure */
+    zassert_equal(end_count, 1);
+    zassert_false(end_success);
+}
+
+ZTEST(serial_broker, test_uplink_with_data)
+{
+    static const uint8_t ul_data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+
+    advance_to_sync(true, true);
+    complete_sender_channel(POUCH_SERIAL_CH_DOWNLINK);
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    /* Get UPLINK prompt */
+    get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+
+    /* Send uplink data */
+    zassert_ok(send_data(POUCH_SERIAL_CH_UPLINK, true, true, false, ul_data, sizeof(ul_data)));
+
+    zassert_equal(broker_stubs.uplink.rx_len, sizeof(ul_data));
+    zassert_mem_equal(broker_stubs.uplink.rx_buf, ul_data, sizeof(ul_data));
+
+    /* Exchange should complete */
+    zassert_equal(end_count, 1);
+    zassert_true(end_success);
+}

--- a/tests/pouch/serial/broker/testcase.yaml
+++ b/tests/pouch/serial/broker/testcase.yaml
@@ -1,0 +1,9 @@
+tests:
+  pouch.serial.broker:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+    tags: test_framework

--- a/tests/pouch/serial/device/CMakeLists.txt
+++ b/tests/pouch/serial/device/CMakeLists.txt
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(serial_device_test)
+
+set(POUCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../..)
+
+# Include paths: pouch public + private src headers
+target_include_directories(app PRIVATE
+    ${POUCH_DIR}/include
+    ${POUCH_DIR}/port/include
+    ${POUCH_DIR}/port/zephyr/include
+    ${POUCH_DIR}/src
+)
+
+# The serial transport log macro needs CONFIG_POUCH_SERIAL_LOG_LEVEL, which is
+# normally provided by Kconfig when CONFIG_POUCH is enabled. Since this test
+# builds serial sources in isolation, define it directly.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
+
+# Serial transport sources (device side only, no broker)
+target_sources(app PRIVATE
+    ${POUCH_DIR}/src/transport/serial/device.c
+    ${POUCH_DIR}/src/transport/serial/serial.c
+    ${POUCH_DIR}/src/transport/serial/channel.c
+    ${POUCH_DIR}/src/transport/serial/packet.c
+)
+
+# Test sources
+target_sources(app PRIVATE
+    src/stub_endpoints.c
+    src/test_device.c
+)

--- a/tests/pouch/serial/device/prj.conf
+++ b/tests/pouch/serial/device/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/pouch/serial/device/src/stub_endpoints.c
+++ b/tests/pouch/serial/device/src/stub_endpoints.c
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Stub endpoint implementations for device-side serial transport tests.
+ *
+ * Each of the 5 device endpoints is replaced by a simple stub that records
+ * lifecycle events and either feeds canned data (senders) or captures received
+ * data (receivers). The test accesses the stubs through the global
+ * device_stubs pointer.
+ */
+
+#include "stub_endpoints.h"
+#include "transport/bearer.h"
+
+#include <string.h>
+
+/* ---- Generic helpers ----------------------------------------------------- */
+
+void stub_sender_reset(struct stub_sender *s)
+{
+    s->tx_len = 0;
+    s->tx_offset = 0;
+    s->start_count = 0;
+    s->end_success_count = 0;
+    s->end_fail_count = 0;
+    s->start_err = 0;
+    s->bearer = NULL;
+}
+
+void stub_sender_set_data(struct stub_sender *s, const uint8_t *data, size_t len)
+{
+    if (len > STUB_EP_BUF_SIZE)
+    {
+        len = STUB_EP_BUF_SIZE;
+    }
+
+    memcpy(s->tx_buf, data, len);
+    s->tx_len = len;
+    s->tx_offset = 0;
+}
+
+static enum pouch_result sender_fill(struct stub_sender *s, void *dst, size_t *dst_len)
+{
+    size_t remaining = s->tx_len - s->tx_offset;
+
+    if (*dst_len > remaining)
+    {
+        *dst_len = remaining;
+    }
+
+    memcpy(dst, &s->tx_buf[s->tx_offset], *dst_len);
+    s->tx_offset += *dst_len;
+
+    return (s->tx_offset >= s->tx_len) ? POUCH_NO_MORE_DATA : POUCH_MORE_DATA;
+}
+
+void stub_receiver_reset(struct stub_receiver *r)
+{
+    r->rx_len = 0;
+    r->start_count = 0;
+    r->end_success_count = 0;
+    r->end_fail_count = 0;
+    r->start_err = 0;
+    r->recv_err = 0;
+}
+
+static void receiver_push(struct stub_receiver *r, const void *buf, size_t len)
+{
+    size_t space = STUB_EP_BUF_SIZE - r->rx_len;
+
+    if (len > space)
+    {
+        len = space;
+    }
+
+    memcpy(&r->rx_buf[r->rx_len], buf, len);
+    r->rx_len += len;
+}
+
+/* ---- Device endpoint stubs ----------------------------------------------- */
+
+struct device_stubs device_stubs;
+
+/* INFO: device sends to broker (sender) */
+
+static int d_info_start(struct pouch_bearer *bearer)
+{
+    device_stubs.info.bearer = bearer;
+    device_stubs.info.tx_offset = 0;
+    device_stubs.info.start_count++;
+    return device_stubs.info.start_err;
+}
+
+static enum pouch_result d_info_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.info, dst, dst_len);
+}
+
+static void d_info_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.info.end_success_count++;
+    }
+    else
+    {
+        device_stubs.info.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_info = {
+    .start = d_info_start,
+    .send = d_info_send,
+    .end = d_info_end,
+};
+
+/* SERVER_CERT: device receives from broker (receiver) */
+
+static int d_server_cert_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    device_stubs.server_cert.rx_len = 0;
+    device_stubs.server_cert.start_count++;
+    return device_stubs.server_cert.start_err;
+}
+
+static int d_server_cert_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    if (device_stubs.server_cert.recv_err != 0)
+    {
+        return device_stubs.server_cert.recv_err;
+    }
+    receiver_push(&device_stubs.server_cert, buf, len);
+    return 0;
+}
+
+static void d_server_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.server_cert.end_success_count++;
+    }
+    else
+    {
+        device_stubs.server_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_server_cert = {
+    .start = d_server_cert_start,
+    .recv = d_server_cert_recv,
+    .end = d_server_cert_end,
+};
+
+/* DEVICE_CERT: device sends to broker (sender) */
+
+static int d_device_cert_start(struct pouch_bearer *bearer)
+{
+    device_stubs.device_cert.bearer = bearer;
+    device_stubs.device_cert.tx_offset = 0;
+    device_stubs.device_cert.start_count++;
+    return device_stubs.device_cert.start_err;
+}
+
+static enum pouch_result d_device_cert_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.device_cert, dst, dst_len);
+}
+
+static void d_device_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.device_cert.end_success_count++;
+    }
+    else
+    {
+        device_stubs.device_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_device_cert = {
+    .start = d_device_cert_start,
+    .send = d_device_cert_send,
+    .end = d_device_cert_end,
+};
+
+/* DOWNLINK: device receives from broker (receiver) */
+
+static int d_downlink_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    device_stubs.downlink.rx_len = 0;
+    device_stubs.downlink.start_count++;
+    return device_stubs.downlink.start_err;
+}
+
+static int d_downlink_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    if (device_stubs.downlink.recv_err != 0)
+    {
+        return device_stubs.downlink.recv_err;
+    }
+    receiver_push(&device_stubs.downlink, buf, len);
+    return 0;
+}
+
+static void d_downlink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.downlink.end_success_count++;
+    }
+    else
+    {
+        device_stubs.downlink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_downlink = {
+    .start = d_downlink_start,
+    .recv = d_downlink_recv,
+    .end = d_downlink_end,
+};
+
+/* UPLINK: device sends to broker (sender) */
+
+static int d_uplink_start(struct pouch_bearer *bearer)
+{
+    device_stubs.uplink.bearer = bearer;
+    device_stubs.uplink.tx_offset = 0;
+    device_stubs.uplink.start_count++;
+    return device_stubs.uplink.start_err;
+}
+
+static enum pouch_result d_uplink_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.uplink, dst, dst_len);
+}
+
+static void d_uplink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.uplink.end_success_count++;
+    }
+    else
+    {
+        device_stubs.uplink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_uplink = {
+    .start = d_uplink_start,
+    .send = d_uplink_send,
+    .end = d_uplink_end,
+};

--- a/tests/pouch/serial/device/src/stub_endpoints.h
+++ b/tests/pouch/serial/device/src/stub_endpoints.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "transport/endpoints/endpoint.h"
+
+#define STUB_EP_BUF_SIZE 512
+
+struct stub_sender
+{
+    uint8_t tx_buf[STUB_EP_BUF_SIZE];
+    size_t tx_len;
+    size_t tx_offset;
+
+    int start_count;
+    int end_success_count;
+    int end_fail_count;
+
+    /** If non-zero, start() returns this error code. */
+    int start_err;
+
+    /** Bearer pointer captured during start(), for calling bearer->ready(). */
+    struct pouch_bearer *bearer;
+};
+
+struct stub_receiver
+{
+    uint8_t rx_buf[STUB_EP_BUF_SIZE];
+    size_t rx_len;
+
+    int start_count;
+    int end_success_count;
+    int end_fail_count;
+
+    /** If non-zero, start() returns this error code. */
+    int start_err;
+    /** If non-zero, recv() returns this error code. */
+    int recv_err;
+};
+
+struct device_stubs
+{
+    struct stub_sender info;
+    struct stub_receiver server_cert;
+    struct stub_sender device_cert;
+    struct stub_receiver downlink;
+    struct stub_sender uplink;
+};
+
+extern struct device_stubs device_stubs;
+
+void stub_sender_reset(struct stub_sender *s);
+void stub_sender_set_data(struct stub_sender *s, const uint8_t *data, size_t len);
+void stub_receiver_reset(struct stub_receiver *r);

--- a/tests/pouch/serial/device/src/test_device.c
+++ b/tests/pouch/serial/device/src/test_device.c
@@ -1,0 +1,865 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <string.h>
+
+#include <pouch/transport/serial/device.h>
+#include <pouch/transport/serial/common.h>
+#include "transport/serial/packet.h"
+#include "transport/bearer.h"
+#include "stub_endpoints.h"
+
+#define FRAME_BUF_SIZE 64
+#define MAX_FRAMES 200
+
+/* ---- Ready callback tracking --------------------------------------------- */
+
+static int ready_count;
+
+static void ready_cb(void)
+{
+    ready_count++;
+}
+
+/* ---- Frame helpers ------------------------------------------------------- */
+
+/**
+ * Build a raw frame from a header and optional payload.
+ *
+ * @return Total frame length (header + payload).
+ */
+static size_t build_frame(uint8_t *buf,
+                          size_t bufsize,
+                          const struct pouch_serial_header *hdr,
+                          const void *payload,
+                          size_t payload_len)
+{
+    zassert_true(POUCH_SERIAL_HEADER_LEN + payload_len <= bufsize);
+    buf[0] = pouch_serial_header_encode(hdr);
+
+    if (payload_len > 0)
+    {
+        memcpy(&buf[POUCH_SERIAL_HEADER_LEN], payload, payload_len);
+    }
+
+    return POUCH_SERIAL_HEADER_LEN + payload_len;
+}
+
+/** Build and send a frame to the device. */
+static int send_frame(const struct pouch_serial_header *hdr,
+                      const void *payload,
+                      size_t payload_len)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    size_t len = build_frame(buf, sizeof(buf), hdr, payload, payload_len);
+    return pouch_serial_device_recv(buf, len);
+}
+
+/** Send an ACK frame to a channel. */
+static int send_ack(uint8_t channel, bool err)
+{
+    struct pouch_serial_header hdr = {
+        .is_data = false,
+        .err = err,
+        .channel = channel,
+    };
+    return send_frame(&hdr, NULL, 0);
+}
+
+/** Send a DATA frame to a channel. */
+static int send_data(uint8_t channel,
+                     bool first,
+                     bool last,
+                     bool err,
+                     const void *payload,
+                     size_t payload_len)
+{
+    struct pouch_serial_header hdr = {
+        .is_data = true,
+        .first = first,
+        .last = last,
+        .err = err,
+        .channel = channel,
+    };
+    return send_frame(&hdr, payload, payload_len);
+}
+
+/**
+ * Get a frame from the device and decode its header.
+ *
+ * @param[out] hdr         Decoded header.
+ * @param[out] payload     Pointer to payload within buf (may be NULL if no payload).
+ * @param[out] payload_len Payload length.
+ * @param      buf         Buffer for frame_get to write into.
+ * @param      bufsize     Size of buf.
+ *
+ * @return Total frame length, or 0 if no frame was available.
+ */
+static size_t get_frame(struct pouch_serial_header *hdr,
+                        const uint8_t **payload,
+                        size_t *payload_len,
+                        uint8_t *buf,
+                        size_t bufsize)
+{
+    size_t len = pouch_serial_device_frame_get(buf, bufsize);
+    if (len == 0)
+    {
+        return 0;
+    }
+
+    zassert_true(len >= POUCH_SERIAL_HEADER_LEN, "frame too short: %zu", len);
+    int err = pouch_serial_header_decode(buf[0], hdr);
+    zassert_ok(err, "failed to decode response header: %d", err);
+
+    if (len > POUCH_SERIAL_HEADER_LEN)
+    {
+        *payload = &buf[POUCH_SERIAL_HEADER_LEN];
+        *payload_len = len - POUCH_SERIAL_HEADER_LEN;
+    }
+    else
+    {
+        *payload = NULL;
+        *payload_len = 0;
+    }
+
+    return len;
+}
+
+/**
+ * Drain all pending frames from the device into a contiguous buffer.
+ *
+ * @param      channel     Only collect frames for this channel (ignore others).
+ * @param[out] out         Buffer to accumulate payload data.
+ * @param[out] out_len     Total accumulated payload length.
+ * @param      out_size    Size of out buffer.
+ * @param[out] frame_count Number of frames collected.
+ * @param[out] saw_first   Whether any frame had the FIRST flag.
+ * @param[out] saw_last    Whether the final frame had the LAST flag.
+ * @param[out] saw_err     Whether any frame had the ERR flag.
+ */
+static void drain_sender_frames(uint8_t channel,
+                                uint8_t *out,
+                                size_t *out_len,
+                                size_t out_size,
+                                int *frame_count,
+                                bool *saw_first,
+                                bool *saw_last,
+                                bool *saw_err)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    *out_len = 0;
+    *frame_count = 0;
+    *saw_first = false;
+    *saw_last = false;
+    *saw_err = false;
+
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        if (len == 0)
+        {
+            break;
+        }
+
+        zassert_equal(hdr.channel,
+                      channel,
+                      "unexpected channel %u (expected %u)",
+                      hdr.channel,
+                      channel);
+        zassert_true(hdr.is_data, "expected DATA frame, got ACK");
+
+        if (hdr.first)
+        {
+            *saw_first = true;
+        }
+        if (hdr.err)
+        {
+            *saw_err = true;
+        }
+
+        if (payload_len > 0)
+        {
+            zassert_true(*out_len + payload_len <= out_size, "output buffer overflow");
+            memcpy(&out[*out_len], payload, payload_len);
+            *out_len += payload_len;
+        }
+
+        (*frame_count)++;
+
+        if (hdr.last)
+        {
+            *saw_last = true;
+            break;
+        }
+    }
+}
+
+/* ---- Stub reset helper --------------------------------------------------- */
+
+static void reset_stubs(void)
+{
+    stub_sender_reset(&device_stubs.info);
+    stub_receiver_reset(&device_stubs.server_cert);
+    stub_sender_reset(&device_stubs.device_cert);
+    stub_receiver_reset(&device_stubs.downlink);
+    stub_sender_reset(&device_stubs.uplink);
+}
+
+/* ---- Test fixture -------------------------------------------------------- */
+
+static void *setup(void)
+{
+    pouch_serial_device_init(ready_cb);
+    return NULL;
+}
+
+static void before(void *f)
+{
+    (void) f;
+    reset_stubs();
+    ready_count = 0;
+
+    /* Re-init to clear channel state from previous test */
+    pouch_serial_device_init(ready_cb);
+}
+
+ZTEST_SUITE(serial_device, NULL, setup, before, NULL, NULL);
+
+/* ==========================================================================
+ * Sender channel tests (INFO=0, DEVICE_CERT=2, UPLINK=4)
+ *
+ * For sender channels, the broker sends an ACK to prompt the device, and
+ * the device responds with DATA frames.
+ * ========================================================================== */
+
+ZTEST(serial_device, test_sender_single_fragment)
+{
+    static const uint8_t payload[] = {0x10, 0x20, 0x30};
+    stub_sender_set_data(&device_stubs.uplink, payload, sizeof(payload));
+
+    /* Prompt the device */
+    int err = send_ack(POUCH_SERIAL_CH_UPLINK, false);
+    zassert_ok(err);
+
+    /* Read response */
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+    drain_sender_frames(POUCH_SERIAL_CH_UPLINK,
+                        out,
+                        &out_len,
+                        sizeof(out),
+                        &frame_count,
+                        &saw_first,
+                        &saw_last,
+                        &saw_err);
+
+    zassert_true(saw_first, "missing FIRST flag");
+    zassert_true(saw_last, "missing LAST flag");
+    zassert_false(saw_err, "unexpected ERR flag");
+    zassert_equal(out_len, sizeof(payload));
+    zassert_mem_equal(out, payload, sizeof(payload));
+
+    zassert_equal(device_stubs.uplink.start_count, 1);
+    zassert_equal(device_stubs.uplink.end_success_count, 1);
+}
+
+ZTEST(serial_device, test_sender_empty_transfer)
+{
+    /* No data loaded: tx_len stays 0 */
+
+    int err = send_ack(POUCH_SERIAL_CH_UPLINK, false);
+    zassert_ok(err);
+
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+    drain_sender_frames(POUCH_SERIAL_CH_UPLINK,
+                        out,
+                        &out_len,
+                        sizeof(out),
+                        &frame_count,
+                        &saw_first,
+                        &saw_last,
+                        &saw_err);
+
+    zassert_true(saw_first);
+    zassert_true(saw_last);
+    zassert_false(saw_err);
+    zassert_equal(out_len, 0);
+    zassert_equal(device_stubs.uplink.start_count, 1);
+    zassert_equal(device_stubs.uplink.end_success_count, 1);
+}
+
+ZTEST(serial_device, test_sender_ack_err_aborts)
+{
+    static const uint8_t payload[] = {0xAA, 0xBB};
+    stub_sender_set_data(&device_stubs.info, payload, sizeof(payload));
+
+    /* Send ACK+ERR: should abort without starting */
+    int err = send_ack(POUCH_SERIAL_CH_INFO, true);
+    zassert_ok(err);
+
+    /* Device should not produce any data frames */
+    uint8_t buf[FRAME_BUF_SIZE];
+    size_t len = pouch_serial_device_frame_get(buf, sizeof(buf));
+    zassert_equal(len, 0, "expected no frames after ACK+ERR on closed channel");
+
+    /* Endpoint should not have been started */
+    zassert_equal(device_stubs.info.start_count, 0);
+}
+
+ZTEST(serial_device, test_sender_no_data_without_prompt)
+{
+    static const uint8_t payload[] = {0x01};
+    stub_sender_set_data(&device_stubs.uplink, payload, sizeof(payload));
+
+    /* Don't send any ACK: device should have no frames to send */
+    uint8_t buf[FRAME_BUF_SIZE];
+    size_t len = pouch_serial_device_frame_get(buf, sizeof(buf));
+    zassert_equal(len, 0, "device produced frames without ACK prompt");
+}
+
+ZTEST(serial_device, test_sender_all_channels)
+{
+    static const uint8_t info_data[] = {0x01, 0x02};
+    static const uint8_t cert_data[] = {0x03, 0x04, 0x05};
+    static const uint8_t uplink_data[] = {0x06};
+
+    stub_sender_set_data(&device_stubs.info, info_data, sizeof(info_data));
+    stub_sender_set_data(&device_stubs.device_cert, cert_data, sizeof(cert_data));
+    stub_sender_set_data(&device_stubs.uplink, uplink_data, sizeof(uplink_data));
+
+    /* Prompt all sender channels */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_INFO, false));
+    zassert_ok(send_ack(POUCH_SERIAL_CH_DEVICE_CERT, false));
+    zassert_ok(send_ack(POUCH_SERIAL_CH_UPLINK, false));
+
+    /* Drain all frames: frame_get uses round-robin so we collect by channel */
+    uint8_t info_out[STUB_EP_BUF_SIZE] = {0};
+    uint8_t cert_out[STUB_EP_BUF_SIZE] = {0};
+    uint8_t uplink_out[STUB_EP_BUF_SIZE] = {0};
+    size_t info_len = 0, cert_len = 0, uplink_len = 0;
+
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        if (len == 0)
+        {
+            break;
+        }
+
+        uint8_t *dst = NULL;
+        size_t *dst_len = NULL;
+
+        if (hdr.channel == POUCH_SERIAL_CH_INFO)
+        {
+            dst = info_out;
+            dst_len = &info_len;
+        }
+        else if (hdr.channel == POUCH_SERIAL_CH_DEVICE_CERT)
+        {
+            dst = cert_out;
+            dst_len = &cert_len;
+        }
+        else if (hdr.channel == POUCH_SERIAL_CH_UPLINK)
+        {
+            dst = uplink_out;
+            dst_len = &uplink_len;
+        }
+        else
+        {
+            zassert_unreachable("unexpected channel %u", hdr.channel);
+        }
+
+        if (payload_len > 0)
+        {
+            memcpy(&dst[*dst_len], payload, payload_len);
+            *dst_len += payload_len;
+        }
+    }
+
+    zassert_equal(info_len, sizeof(info_data));
+    zassert_mem_equal(info_out, info_data, sizeof(info_data));
+
+    zassert_equal(cert_len, sizeof(cert_data));
+    zassert_mem_equal(cert_out, cert_data, sizeof(cert_data));
+
+    zassert_equal(uplink_len, sizeof(uplink_data));
+    zassert_mem_equal(uplink_out, uplink_data, sizeof(uplink_data));
+}
+
+ZTEST(serial_device, test_sender_start_error)
+{
+    device_stubs.uplink.start_err = -ENOMEM;
+
+    int err = send_ack(POUCH_SERIAL_CH_UPLINK, false);
+    zassert_ok(err);
+
+    /* Device should produce an error DATA frame */
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+
+    zassert_true(len > 0, "expected error frame");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_UPLINK);
+    zassert_true(hdr.is_data);
+    zassert_true(hdr.err);
+    zassert_true(hdr.last);
+
+    zassert_equal(device_stubs.uplink.start_count, 1);
+    zassert_equal(device_stubs.uplink.end_fail_count, 1);
+}
+
+/* ==========================================================================
+ * Receiver channel tests (SERVER_CERT=1, DOWNLINK=3)
+ *
+ * For receiver channels, the broker sends DATA frames to the device, and
+ * the device responds with ACK frames.
+ * ========================================================================== */
+
+ZTEST(serial_device, test_receiver_single_fragment)
+{
+    static const uint8_t payload[] = {0xCA, 0xFE, 0xBA, 0xBE};
+
+    int err = send_data(POUCH_SERIAL_CH_DOWNLINK, true, true, false, payload, sizeof(payload));
+    zassert_ok(err);
+
+    /* No ACK is produced for the last (or only) data frame. */
+
+    /* Verify endpoint received the data */
+    zassert_equal(device_stubs.downlink.rx_len, sizeof(payload));
+    zassert_mem_equal(device_stubs.downlink.rx_buf, payload, sizeof(payload));
+    zassert_equal(device_stubs.downlink.start_count, 1);
+    zassert_equal(device_stubs.downlink.end_success_count, 1);
+}
+
+ZTEST(serial_device, test_receiver_multi_fragment)
+{
+    static const uint8_t frag1[] = {0x01, 0x02};
+    static const uint8_t frag2[] = {0x03, 0x04};
+    static const uint8_t frag3[] = {0x05};
+
+    /* First fragment */
+    zassert_ok(send_data(POUCH_SERIAL_CH_SERVER_CERT, true, false, false, frag1, sizeof(frag1)));
+
+    /* Middle fragment */
+    zassert_ok(send_data(POUCH_SERIAL_CH_SERVER_CERT, false, false, false, frag2, sizeof(frag2)));
+
+    /* Last fragment */
+    zassert_ok(send_data(POUCH_SERIAL_CH_SERVER_CERT, false, true, false, frag3, sizeof(frag3)));
+
+    /* No intermediate ACKs are produced; receiver processes data silently. */
+
+    /* Verify accumulated data */
+    uint8_t expected[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+    zassert_equal(device_stubs.server_cert.rx_len, sizeof(expected));
+    zassert_mem_equal(device_stubs.server_cert.rx_buf, expected, sizeof(expected));
+    zassert_equal(device_stubs.server_cert.start_count, 1);
+    zassert_equal(device_stubs.server_cert.end_success_count, 1);
+}
+
+ZTEST(serial_device, test_receiver_empty_transfer)
+{
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK, true, true, false, NULL, 0));
+
+    /* No ACK is produced for the last (or only) data frame. */
+    zassert_equal(device_stubs.downlink.rx_len, 0);
+    zassert_equal(device_stubs.downlink.start_count, 1);
+    zassert_equal(device_stubs.downlink.end_success_count, 1);
+}
+
+ZTEST(serial_device, test_receiver_data_err_aborts)
+{
+    static const uint8_t frag1[] = {0xAA};
+
+    /* Start a transfer */
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK, true, false, false, frag1, sizeof(frag1)));
+
+    /* Send error frame */
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK, false, true, true, NULL, 0));
+
+    /* Drain NACK response */
+    uint8_t buf[FRAME_BUF_SIZE];
+    pouch_serial_device_frame_get(buf, sizeof(buf));
+
+    zassert_equal(device_stubs.downlink.start_count, 1);
+    zassert_equal(device_stubs.downlink.end_fail_count, 1);
+    zassert_equal(device_stubs.downlink.end_success_count, 0);
+}
+
+ZTEST(serial_device, test_receiver_missing_first_flag)
+{
+    /* Send a DATA frame without FIRST to a channel that isn't open */
+    int err = send_data(POUCH_SERIAL_CH_DOWNLINK, false, false, false, (uint8_t[]){0x01}, 1);
+    zassert_not_equal(err, 0, "expected error for missing FIRST flag");
+
+    /* Endpoint should not have been started successfully */
+    zassert_equal(device_stubs.downlink.end_success_count, 0);
+}
+
+ZTEST(serial_device, test_receiver_both_channels)
+{
+    static const uint8_t server_cert[] = {0x10, 0x20};
+    static const uint8_t downlink[] = {0x30, 0x40, 0x50};
+
+    zassert_ok(send_data(POUCH_SERIAL_CH_SERVER_CERT,
+                         true,
+                         true,
+                         false,
+                         server_cert,
+                         sizeof(server_cert)));
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK, true, true, false, downlink, sizeof(downlink)));
+
+    /* Drain all ACKs */
+    uint8_t buf[FRAME_BUF_SIZE];
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        if (pouch_serial_device_frame_get(buf, sizeof(buf)) == 0)
+        {
+            break;
+        }
+    }
+
+    zassert_equal(device_stubs.server_cert.rx_len, sizeof(server_cert));
+    zassert_mem_equal(device_stubs.server_cert.rx_buf, server_cert, sizeof(server_cert));
+
+    zassert_equal(device_stubs.downlink.rx_len, sizeof(downlink));
+    zassert_mem_equal(device_stubs.downlink.rx_buf, downlink, sizeof(downlink));
+}
+
+ZTEST(serial_device, test_receiver_start_error)
+{
+    device_stubs.downlink.start_err = -EBUSY;
+
+    int err = send_data(POUCH_SERIAL_CH_DOWNLINK, true, true, false, (uint8_t[]){0x01}, 1);
+    zassert_not_equal(err, 0);
+
+    /* Device should produce a NACK */
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+    size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+
+    zassert_true(len > 0, "expected NACK frame");
+    zassert_equal(hdr.channel, POUCH_SERIAL_CH_DOWNLINK);
+    zassert_false(hdr.is_data, "expected ACK (NACK), got DATA");
+    zassert_true(hdr.err, "expected ERR flag on NACK");
+}
+
+ZTEST(serial_device, test_receiver_recv_error)
+{
+    device_stubs.server_cert.recv_err = -ENOMEM;
+
+    int err = send_data(POUCH_SERIAL_CH_SERVER_CERT, true, true, false, (uint8_t[]){0xAA}, 1);
+    zassert_not_equal(err, 0);
+
+    zassert_equal(device_stubs.server_cert.start_count, 1);
+    zassert_equal(device_stubs.server_cert.end_fail_count, 1);
+}
+
+/* ==========================================================================
+ * Cross-channel and invalid behavior tests
+ * ========================================================================== */
+
+ZTEST(serial_device, test_invalid_channel_id)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr = {
+        .is_data = false,
+        .channel = POUCH_SERIAL_CHANNEL_COUNT, /* Out of range */
+    };
+    size_t len = build_frame(buf, sizeof(buf), &hdr, NULL, 0);
+    int err = pouch_serial_device_recv(buf, len);
+    zassert_equal(err, -EINVAL);
+}
+
+ZTEST(serial_device, test_recv_null_frame)
+{
+    int err = pouch_serial_device_recv(NULL, 1);
+    zassert_equal(err, -EINVAL);
+}
+
+ZTEST(serial_device, test_recv_zero_length)
+{
+    uint8_t buf[4] = {0};
+    int err = pouch_serial_device_recv(buf, 0);
+    zassert_equal(err, -EINVAL);
+}
+
+ZTEST(serial_device, test_malformed_ack_header)
+{
+    /*
+     * An ACK frame with reserved bits (FIRST or LAST) set is malformed.
+     * Manually encode: bit7=0 (ACK), bit5=1 (FIRST, reserved), channel=0
+     */
+    uint8_t frame[] = {0x20}; /* 0b00100000 = ACK with FIRST bit set */
+    int err = pouch_serial_device_recv(frame, sizeof(frame));
+    zassert_equal(err, -EINVAL);
+}
+
+ZTEST(serial_device, test_interrupt_ongoing_receive)
+{
+    static const uint8_t frag[] = {0x01, 0x02};
+
+    /* Start a multi-fragment receive */
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK, true, false, false, frag, sizeof(frag)));
+
+    /* Send another FIRST frame: interrupts the ongoing transfer */
+    int err = send_data(POUCH_SERIAL_CH_DOWNLINK, true, false, false, frag, sizeof(frag));
+    zassert_not_equal(err, 0, "expected error when sending FIRST to already-open channel");
+
+    /* The first transfer should have been aborted */
+    zassert_equal(device_stubs.downlink.end_fail_count, 1);
+}
+
+ZTEST(serial_device, test_concurrent_sender_and_receiver)
+{
+    static const uint8_t uplink_data[] = {0xAA, 0xBB};
+    static const uint8_t downlink_data[] = {0xCC, 0xDD, 0xEE};
+
+    stub_sender_set_data(&device_stubs.uplink, uplink_data, sizeof(uplink_data));
+
+    /* Start both: prompt uplink sender and push downlink data */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_UPLINK, false));
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK,
+                         true,
+                         true,
+                         false,
+                         downlink_data,
+                         sizeof(downlink_data)));
+
+    /* Drain all frames */
+    uint8_t buf[FRAME_BUF_SIZE];
+    uint8_t uplink_out[STUB_EP_BUF_SIZE];
+    size_t uplink_len = 0;
+    struct pouch_serial_header hdr;
+    const uint8_t *payload;
+    size_t payload_len;
+
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        size_t len = get_frame(&hdr, &payload, &payload_len, buf, sizeof(buf));
+        if (len == 0)
+        {
+            break;
+        }
+
+        if (hdr.channel == POUCH_SERIAL_CH_UPLINK && hdr.is_data && payload_len > 0)
+        {
+            memcpy(&uplink_out[uplink_len], payload, payload_len);
+            uplink_len += payload_len;
+        }
+    }
+
+    /* Verify uplink data was sent correctly */
+    zassert_equal(uplink_len, sizeof(uplink_data));
+    zassert_mem_equal(uplink_out, uplink_data, sizeof(uplink_data));
+
+    /* Verify downlink data was received correctly */
+    zassert_equal(device_stubs.downlink.rx_len, sizeof(downlink_data));
+    zassert_mem_equal(device_stubs.downlink.rx_buf, downlink_data, sizeof(downlink_data));
+}
+
+ZTEST(serial_device, test_ready_callback)
+{
+    static const uint8_t payload[] = {0x01};
+    stub_sender_set_data(&device_stubs.uplink, payload, sizeof(payload));
+
+    /* Start a transfer so the stub captures the bearer pointer */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_UPLINK, false));
+
+    /* Drain all frames to complete the transfer */
+    uint8_t buf[FRAME_BUF_SIZE];
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        if (pouch_serial_device_frame_get(buf, sizeof(buf)) == 0)
+        {
+            break;
+        }
+    }
+
+    /* Set up a new transfer and use bearer->ready() to signal readiness */
+    stub_sender_set_data(&device_stubs.uplink, payload, sizeof(payload));
+    zassert_ok(send_ack(POUCH_SERIAL_CH_UPLINK, false));
+
+    /* Drain the first frame */
+    pouch_serial_device_frame_get(buf, sizeof(buf));
+
+    int count_before = ready_count;
+
+    /* Simulate endpoint signalling readiness via bearer */
+    zassert_not_null(device_stubs.uplink.bearer);
+    pouch_bearer_ready(device_stubs.uplink.bearer);
+
+    zassert_true(ready_count > count_before,
+                 "ready callback not called (before=%d, after=%d)",
+                 count_before,
+                 ready_count);
+}
+
+ZTEST(serial_device, test_frame_get_no_pending)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+    size_t len = pouch_serial_device_frame_get(buf, sizeof(buf));
+    zassert_equal(len, 0, "expected no frames from idle device");
+}
+
+ZTEST(serial_device, test_sender_ack_err_during_transfer)
+{
+    /* Payload must span multiple frames so the channel stays open after the first frame.
+     * Each frame carries at most FRAME_BUF_SIZE - POUCH_SERIAL_HEADER_LEN payload bytes.
+     */
+    uint8_t payload[FRAME_BUF_SIZE * 2];
+    memset(payload, 0xAB, sizeof(payload));
+    stub_sender_set_data(&device_stubs.info, payload, sizeof(payload));
+
+    /* Start the transfer */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_INFO, false));
+
+    /* Drain the first data frame (don't drain all: we want to interrupt) */
+    uint8_t buf[FRAME_BUF_SIZE];
+    struct pouch_serial_header hdr;
+    const uint8_t *resp_payload;
+    size_t resp_len;
+    size_t len = get_frame(&hdr, &resp_payload, &resp_len, buf, sizeof(buf));
+    zassert_true(len > 0, "expected first data frame");
+    zassert_true(hdr.first, "expected FIRST flag on first frame");
+    zassert_false(hdr.last, "first frame should not be LAST for multi-fragment transfer");
+
+    /* Now send ACK+ERR to abort the ongoing sender transfer */
+    zassert_ok(send_ack(POUCH_SERIAL_CH_INFO, true));
+
+    /* Endpoint should have been aborted */
+    zassert_equal(device_stubs.info.end_fail_count, 1);
+    zassert_equal(device_stubs.info.end_success_count, 0);
+}
+
+ZTEST(serial_device, test_successive_transfers_same_channel)
+{
+    static const uint8_t data1[] = {0x01, 0x02};
+    static const uint8_t data2[] = {0x03, 0x04, 0x05};
+
+    /* First transfer */
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK, true, true, false, data1, sizeof(data1)));
+
+    /* Drain ACK */
+    uint8_t buf[FRAME_BUF_SIZE];
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        if (pouch_serial_device_frame_get(buf, sizeof(buf)) == 0)
+        {
+            break;
+        }
+    }
+
+    zassert_equal(device_stubs.downlink.end_success_count, 1);
+
+    /* Second transfer on same channel */
+    zassert_ok(send_data(POUCH_SERIAL_CH_DOWNLINK, true, true, false, data2, sizeof(data2)));
+
+    for (int i = 0; i < MAX_FRAMES; i++)
+    {
+        if (pouch_serial_device_frame_get(buf, sizeof(buf)) == 0)
+        {
+            break;
+        }
+    }
+
+    zassert_equal(device_stubs.downlink.start_count, 2);
+    zassert_equal(device_stubs.downlink.end_success_count, 2);
+    zassert_equal(device_stubs.downlink.rx_len, sizeof(data2));
+    zassert_mem_equal(device_stubs.downlink.rx_buf, data2, sizeof(data2));
+}
+
+ZTEST(serial_device, test_successive_sender_transfers)
+{
+    static const uint8_t data1[] = {0xAA};
+    static const uint8_t data2[] = {0xBB, 0xCC};
+
+    /* First uplink transfer */
+    stub_sender_set_data(&device_stubs.uplink, data1, sizeof(data1));
+    zassert_ok(send_ack(POUCH_SERIAL_CH_UPLINK, false));
+
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+    drain_sender_frames(POUCH_SERIAL_CH_UPLINK,
+                        out,
+                        &out_len,
+                        sizeof(out),
+                        &frame_count,
+                        &saw_first,
+                        &saw_last,
+                        &saw_err);
+
+    zassert_equal(out_len, sizeof(data1));
+    zassert_equal(device_stubs.uplink.end_success_count, 1);
+
+    /* Second uplink transfer */
+    stub_sender_set_data(&device_stubs.uplink, data2, sizeof(data2));
+    zassert_ok(send_ack(POUCH_SERIAL_CH_UPLINK, false));
+
+    drain_sender_frames(POUCH_SERIAL_CH_UPLINK,
+                        out,
+                        &out_len,
+                        sizeof(out),
+                        &frame_count,
+                        &saw_first,
+                        &saw_last,
+                        &saw_err);
+
+    zassert_equal(out_len, sizeof(data2));
+    zassert_mem_equal(out, data2, sizeof(data2));
+    zassert_equal(device_stubs.uplink.start_count, 2);
+    zassert_equal(device_stubs.uplink.end_success_count, 2);
+}
+
+ZTEST(serial_device, test_init_with_null_callback)
+{
+    /* Should not crash with NULL ready callback */
+    pouch_serial_device_init(NULL);
+
+    static const uint8_t payload[] = {0x01};
+    stub_sender_set_data(&device_stubs.uplink, payload, sizeof(payload));
+
+    zassert_ok(send_ack(POUCH_SERIAL_CH_UPLINK, false));
+
+    uint8_t out[STUB_EP_BUF_SIZE];
+    size_t out_len;
+    int frame_count;
+    bool saw_first, saw_last, saw_err;
+    drain_sender_frames(POUCH_SERIAL_CH_UPLINK,
+                        out,
+                        &out_len,
+                        sizeof(out),
+                        &frame_count,
+                        &saw_first,
+                        &saw_last,
+                        &saw_err);
+
+    zassert_true(saw_last);
+    zassert_equal(out_len, sizeof(payload));
+
+    /* Restore for other tests */
+    pouch_serial_device_init(ready_cb);
+}

--- a/tests/pouch/serial/device/testcase.yaml
+++ b/tests/pouch/serial/device/testcase.yaml
@@ -1,0 +1,9 @@
+tests:
+  pouch.serial.device:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+    tags: test_framework

--- a/tests/pouch/serial/exchange/CMakeLists.txt
+++ b/tests/pouch/serial/exchange/CMakeLists.txt
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(serial_exchange_test)
+
+set(POUCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../..)
+
+# Golioth SDK path (needed by gateway/types.h included from broker.c)
+set(GOLIOTH_SDK ${ZEPHYR_BASE}/../modules/lib/golioth-firmware-sdk)
+
+# Include paths: pouch public + private src headers
+target_include_directories(app PRIVATE
+    ${POUCH_DIR}/include
+    ${POUCH_DIR}/port/include
+    ${POUCH_DIR}/port/zephyr/include
+    ${POUCH_DIR}/src
+    ${GOLIOTH_SDK}/include
+    ${GOLIOTH_SDK}/port/zephyr/include
+)
+
+# The serial transport log macro needs CONFIG_POUCH_SERIAL_LOG_LEVEL, which is
+# normally provided by Kconfig when CONFIG_POUCH is enabled. Since this test
+# builds serial sources in isolation, define it directly.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
+
+# Serial transport sources (both broker and device)
+target_sources(app PRIVATE
+    ${POUCH_DIR}/src/transport/serial/broker.c
+    ${POUCH_DIR}/src/transport/serial/device.c
+    ${POUCH_DIR}/src/transport/serial/serial.c
+    ${POUCH_DIR}/src/transport/serial/channel.c
+    ${POUCH_DIR}/src/transport/serial/packet.c
+)
+
+# Test sources
+target_sources(app PRIVATE
+    src/stub_endpoints.c
+    src/test_exchange.c
+)

--- a/tests/pouch/serial/exchange/prj.conf
+++ b/tests/pouch/serial/exchange/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/pouch/serial/exchange/src/stub_endpoints.c
+++ b/tests/pouch/serial/exchange/src/stub_endpoints.c
@@ -1,0 +1,478 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Stub endpoint implementations for the serial exchange integration test.
+ *
+ * Provides all 10 endpoint symbols (5 broker + 5 device) so that the test
+ * links both broker.c and device.c without pulling in the real endpoint
+ * implementations or their gateway/transport dependencies.
+ *
+ * Broker server_cert and device_cert stubs set the corresponding provisioning
+ * flags on the gateway node (via bearer->ctx), matching the real endpoint
+ * behaviour required by the broker's next() state machine.
+ */
+
+#include "stub_endpoints.h"
+#include "transport/bearer.h"
+#include "gateway/types.h"
+
+#include <string.h>
+
+struct broker_stubs broker_stubs;
+struct device_stubs device_stubs;
+
+static void sender_reset(struct stub_sender *s)
+{
+    memset(s, 0, sizeof(*s));
+    s->send_err_after = -1;
+}
+
+static void receiver_reset(struct stub_receiver *r)
+{
+    memset(r, 0, sizeof(*r));
+}
+
+void stubs_reset(void)
+{
+    sender_reset(&device_stubs.info);
+    receiver_reset(&device_stubs.server_cert);
+    sender_reset(&device_stubs.device_cert);
+    receiver_reset(&device_stubs.downlink);
+    sender_reset(&device_stubs.uplink);
+
+    receiver_reset(&broker_stubs.info);
+    sender_reset(&broker_stubs.server_cert);
+    receiver_reset(&broker_stubs.device_cert);
+    sender_reset(&broker_stubs.downlink);
+    receiver_reset(&broker_stubs.uplink);
+}
+
+void stub_sender_set_data(struct stub_sender *s, const uint8_t *data, size_t len)
+{
+    if (len > STUB_EP_BUF_SIZE)
+    {
+        len = STUB_EP_BUF_SIZE;
+    }
+
+    memcpy(s->tx_buf, data, len);
+    s->tx_len = len;
+    s->tx_offset = 0;
+}
+
+static enum pouch_result sender_fill(struct stub_sender *s, void *dst, size_t *dst_len)
+{
+    if (s->send_err_after >= 0 && s->send_count >= s->send_err_after)
+    {
+        s->send_count++;
+        *dst_len = 0;
+        return POUCH_ERROR;
+    }
+
+    s->send_count++;
+
+    size_t remaining = s->tx_len - s->tx_offset;
+
+    if (*dst_len > remaining)
+    {
+        *dst_len = remaining;
+    }
+
+    memcpy(dst, &s->tx_buf[s->tx_offset], *dst_len);
+    s->tx_offset += *dst_len;
+
+    return (s->tx_offset >= s->tx_len) ? POUCH_NO_MORE_DATA : POUCH_MORE_DATA;
+}
+
+static int receiver_push(struct stub_receiver *r, const void *buf, size_t len)
+{
+    if (r->recv_err)
+    {
+        return r->recv_err;
+    }
+
+    size_t space = STUB_EP_BUF_SIZE - r->rx_len;
+
+    if (len > space)
+    {
+        len = space;
+    }
+
+    memcpy(&r->rx_buf[r->rx_len], buf, len);
+    r->rx_len += len;
+    return 0;
+}
+
+static int sender_start_helper(struct stub_sender *s)
+{
+    s->start_count++;
+    if (s->start_err)
+    {
+        return s->start_err;
+    }
+
+    s->tx_offset = 0;
+    return 0;
+}
+
+static int receiver_start_helper(struct stub_receiver *r)
+{
+    r->start_count++;
+    if (r->start_err)
+    {
+        return r->start_err;
+    }
+
+    r->rx_len = 0;
+    return 0;
+}
+
+/* ---- Broker endpoint stubs ----------------------------------------------- */
+
+/* INFO: broker receives from device (receiver) */
+
+static int b_info_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return receiver_start_helper(&broker_stubs.info);
+}
+
+static int b_info_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    return receiver_push(&broker_stubs.info, buf, len);
+}
+
+static void b_info_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.info.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.info.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_info = {
+    .start = b_info_start,
+    .recv = b_info_recv,
+    .end = b_info_end,
+};
+
+/* SERVER_CERT: broker sends to device (sender) */
+
+static int b_server_cert_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return sender_start_helper(&broker_stubs.server_cert);
+}
+
+static enum pouch_result b_server_cert_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&broker_stubs.server_cert, dst, dst_len);
+}
+
+static void b_server_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    if (success)
+    {
+        broker_stubs.server_cert.end_success_count++;
+
+        /* Match real endpoint: mark server cert as provisioned so the broker's
+         * next() state machine advances past the SERVER_CERT phase. */
+        struct pouch_gateway_node_info *node = bearer->ctx;
+        if (node != NULL)
+        {
+            node->server_cert_provisioned = true;
+        }
+    }
+    else
+    {
+        broker_stubs.server_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_server_cert = {
+    .start = b_server_cert_start,
+    .send = b_server_cert_send,
+    .end = b_server_cert_end,
+};
+
+/* DEVICE_CERT: broker receives from device (receiver) */
+
+static int b_device_cert_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return receiver_start_helper(&broker_stubs.device_cert);
+}
+
+static int b_device_cert_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    return receiver_push(&broker_stubs.device_cert, buf, len);
+}
+
+static void b_device_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    if (success)
+    {
+        broker_stubs.device_cert.end_success_count++;
+
+        /* Match real endpoint: mark device cert as provisioned. */
+        struct pouch_gateway_node_info *node = bearer->ctx;
+        if (node != NULL)
+        {
+            node->device_cert_provisioned = true;
+        }
+    }
+    else
+    {
+        broker_stubs.device_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_device_cert = {
+    .start = b_device_cert_start,
+    .recv = b_device_cert_recv,
+    .end = b_device_cert_end,
+};
+
+/* DOWNLINK: broker sends to device (sender) */
+
+static int b_downlink_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return sender_start_helper(&broker_stubs.downlink);
+}
+
+static enum pouch_result b_downlink_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&broker_stubs.downlink, dst, dst_len);
+}
+
+static void b_downlink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.downlink.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.downlink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_downlink = {
+    .start = b_downlink_start,
+    .send = b_downlink_send,
+    .end = b_downlink_end,
+};
+
+/* UPLINK: broker receives from device (receiver) */
+
+static int b_uplink_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return receiver_start_helper(&broker_stubs.uplink);
+}
+
+static int b_uplink_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    return receiver_push(&broker_stubs.uplink, buf, len);
+}
+
+static void b_uplink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        broker_stubs.uplink.end_success_count++;
+    }
+    else
+    {
+        broker_stubs.uplink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint broker_endpoint_uplink = {
+    .start = b_uplink_start,
+    .recv = b_uplink_recv,
+    .end = b_uplink_end,
+};
+
+/* ---- Device endpoint stubs ----------------------------------------------- */
+
+/* INFO: device sends to broker (sender) */
+
+static int d_info_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return sender_start_helper(&device_stubs.info);
+}
+
+static enum pouch_result d_info_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.info, dst, dst_len);
+}
+
+static void d_info_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.info.end_success_count++;
+    }
+    else
+    {
+        device_stubs.info.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_info = {
+    .start = d_info_start,
+    .send = d_info_send,
+    .end = d_info_end,
+};
+
+/* SERVER_CERT: device receives from broker (receiver) */
+
+static int d_server_cert_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return receiver_start_helper(&device_stubs.server_cert);
+}
+
+static int d_server_cert_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    return receiver_push(&device_stubs.server_cert, buf, len);
+}
+
+static void d_server_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.server_cert.end_success_count++;
+    }
+    else
+    {
+        device_stubs.server_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_server_cert = {
+    .start = d_server_cert_start,
+    .recv = d_server_cert_recv,
+    .end = d_server_cert_end,
+};
+
+/* DEVICE_CERT: device sends to broker (sender) */
+
+static int d_device_cert_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return sender_start_helper(&device_stubs.device_cert);
+}
+
+static enum pouch_result d_device_cert_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.device_cert, dst, dst_len);
+}
+
+static void d_device_cert_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.device_cert.end_success_count++;
+    }
+    else
+    {
+        device_stubs.device_cert.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_device_cert = {
+    .start = d_device_cert_start,
+    .send = d_device_cert_send,
+    .end = d_device_cert_end,
+};
+
+/* DOWNLINK: device receives from broker (receiver) */
+
+static int d_downlink_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return receiver_start_helper(&device_stubs.downlink);
+}
+
+static int d_downlink_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    return receiver_push(&device_stubs.downlink, buf, len);
+}
+
+static void d_downlink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.downlink.end_success_count++;
+    }
+    else
+    {
+        device_stubs.downlink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_downlink = {
+    .start = d_downlink_start,
+    .recv = d_downlink_recv,
+    .end = d_downlink_end,
+};
+
+/* UPLINK: device sends to broker (sender) */
+
+static int d_uplink_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return sender_start_helper(&device_stubs.uplink);
+}
+
+static enum pouch_result d_uplink_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.uplink, dst, dst_len);
+}
+
+static void d_uplink_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.uplink.end_success_count++;
+    }
+    else
+    {
+        device_stubs.uplink.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_uplink = {
+    .start = d_uplink_start,
+    .send = d_uplink_send,
+    .end = d_uplink_end,
+};

--- a/tests/pouch/serial/exchange/src/stub_endpoints.h
+++ b/tests/pouch/serial/exchange/src/stub_endpoints.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "transport/endpoints/endpoint.h"
+
+#define STUB_EP_BUF_SIZE 512
+
+struct stub_sender
+{
+    uint8_t tx_buf[STUB_EP_BUF_SIZE];
+    size_t tx_len;
+    size_t tx_offset;
+
+    int start_count;
+    int end_success_count;
+    int end_fail_count;
+
+    /* Error injection: return this from start(), 0 = success. */
+    int start_err;
+    /* Error injection: return POUCH_ERROR after N successful send() calls,
+     * -1 = never. */
+    int send_err_after;
+    int send_count;
+};
+
+struct stub_receiver
+{
+    uint8_t rx_buf[STUB_EP_BUF_SIZE];
+    size_t rx_len;
+
+    int start_count;
+    int end_success_count;
+    int end_fail_count;
+
+    /* Error injection: return this from start(), 0 = success. */
+    int start_err;
+    /* Error injection: return this from recv(), 0 = success. */
+    int recv_err;
+};
+
+struct broker_stubs
+{
+    struct stub_receiver info;
+    struct stub_sender server_cert;
+    struct stub_receiver device_cert;
+    struct stub_sender downlink;
+    struct stub_receiver uplink;
+};
+
+struct device_stubs
+{
+    struct stub_sender info;
+    struct stub_receiver server_cert;
+    struct stub_sender device_cert;
+    struct stub_receiver downlink;
+    struct stub_sender uplink;
+};
+
+extern struct broker_stubs broker_stubs;
+extern struct device_stubs device_stubs;
+
+void stubs_reset(void);
+void stub_sender_set_data(struct stub_sender *s, const uint8_t *data, size_t len);

--- a/tests/pouch/serial/exchange/src/test_exchange.c
+++ b/tests/pouch/serial/exchange/src/test_exchange.c
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Serial exchange integration test.
+ *
+ * Exercises a full broker ↔ device serial exchange using a mock transport
+ * adapter that synchronously pumps frames between the two parties.  Both sets
+ * of endpoints are replaced by stubs (see stub_endpoints.c), so the test
+ * validates the serial transport layer in isolation from the real gateway and
+ * device transport stacks.
+ */
+
+#include "stub_endpoints.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zephyr/ztest.h>
+
+#include <pouch/transport/serial/broker.h>
+#include <pouch/transport/serial/device.h>
+
+#define MAX_FRAME_SIZE 64
+#define MAX_PUMP_ITER 200
+
+static struct pouch_serial_broker *test_broker;
+static bool broker_done;
+static bool broker_success;
+
+static void broker_ready(const struct pouch_serial_broker *broker)
+{
+    (void) broker;
+}
+
+static void broker_end(const struct pouch_serial_broker *broker, bool success)
+{
+    (void) broker;
+    broker_done = true;
+    broker_success = success;
+}
+
+static const struct pouch_serial_broker_adapter adapter = {
+    .ready = broker_ready,
+    .end = broker_end,
+};
+
+static void device_ready(void)
+{
+    pouch_serial_broker_notify(test_broker);
+}
+
+/*
+ * Pump frames between broker and device until both sides are idle.
+ *
+ * Each iteration delivers a single frame: first checking the broker for a
+ * pending frame, then the device.  Single-frame delivery mirrors the
+ * sequential nature of a serial link and prevents stale intermediate ACKs
+ * from arriving after a sender has closed its channel.
+ *
+ * Returns the number of iterations performed.
+ */
+static int pump(int max_iter)
+{
+    uint8_t buf[MAX_FRAME_SIZE];
+    int iter;
+
+    for (iter = 0; iter < max_iter; iter++)
+    {
+        size_t blen = pouch_serial_broker_frame_get(test_broker, buf, sizeof(buf));
+        if (blen > 0)
+        {
+            int err = pouch_serial_device_recv(buf, blen);
+            zassert_ok(err, "device_recv failed: %d", err);
+            continue;
+        }
+
+        size_t dlen = pouch_serial_device_frame_get(buf, sizeof(buf));
+        if (dlen > 0)
+        {
+            int err = pouch_serial_broker_recv(test_broker, buf, dlen);
+            zassert_ok(err, "broker_recv failed: %d", err);
+            continue;
+        }
+
+        break;
+    }
+
+    zassert_true(iter < max_iter, "exchange did not converge within %d iterations", max_iter);
+    return iter;
+}
+
+/*
+ * Pump variant that tolerates recv errors and stops as soon as the broker
+ * signals completion (success or failure).  Used by error-injection tests
+ * where one side's recv may legitimately return a negative error code.
+ */
+static int pump_until_done(int max_iter)
+{
+    uint8_t buf[MAX_FRAME_SIZE];
+    int iter;
+
+    for (iter = 0; iter < max_iter; iter++)
+    {
+        if (broker_done)
+        {
+            break;
+        }
+
+        size_t blen = pouch_serial_broker_frame_get(test_broker, buf, sizeof(buf));
+        if (blen > 0)
+        {
+            (void) pouch_serial_device_recv(buf, blen);
+            continue;
+        }
+
+        size_t dlen = pouch_serial_device_frame_get(buf, sizeof(buf));
+        if (dlen > 0)
+        {
+            (void) pouch_serial_broker_recv(test_broker, buf, dlen);
+            continue;
+        }
+
+        break;
+    }
+
+    zassert_true(iter < max_iter, "exchange did not converge within %d iterations", max_iter);
+    return iter;
+}
+
+static void run_exchange(void)
+{
+    broker_done = false;
+    broker_success = false;
+
+    int err = pouch_serial_broker_start(test_broker);
+    zassert_ok(err, "broker_start failed: %d", err);
+
+    pump(MAX_PUMP_ITER);
+
+    zassert_true(broker_done, "exchange did not complete");
+    zassert_true(broker_success, "exchange ended with failure");
+}
+
+static void *suite_setup(void)
+{
+    test_broker = pouch_serial_broker_create(&adapter);
+    zassert_not_null(test_broker, "broker_create returned NULL");
+
+    pouch_serial_device_init(device_ready);
+
+    return NULL;
+}
+
+static void before(void *f)
+{
+    (void) f;
+
+    free(test_broker);
+    test_broker = pouch_serial_broker_create(&adapter);
+    zassert_not_null(test_broker, "broker_create returned NULL");
+
+    stubs_reset();
+    pouch_serial_device_init(device_ready);
+
+    broker_done = false;
+    broker_success = false;
+}
+
+ZTEST_SUITE(serial_exchange, NULL, suite_setup, before, NULL, NULL);
+
+static const uint8_t info_payload[] = "device-info-stub";
+static const uint8_t server_cert_payload[] = "server-certificate-data";
+static const uint8_t device_cert_payload[] = "device-certificate-data";
+static const uint8_t downlink_payload[] = "downlink-payload";
+static const uint8_t uplink_payload[] = "uplink-payload";
+
+static void load_payloads(const uint8_t *info,
+                          size_t info_len,
+                          const uint8_t *server_cert,
+                          size_t server_cert_len,
+                          const uint8_t *device_cert,
+                          size_t device_cert_len,
+                          const uint8_t *downlink,
+                          size_t downlink_len,
+                          const uint8_t *uplink,
+                          size_t uplink_len)
+{
+    stub_sender_set_data(&device_stubs.info, info, info_len);
+    stub_sender_set_data(&broker_stubs.server_cert, server_cert, server_cert_len);
+    stub_sender_set_data(&device_stubs.device_cert, device_cert, device_cert_len);
+    stub_sender_set_data(&broker_stubs.downlink, downlink, downlink_len);
+    stub_sender_set_data(&device_stubs.uplink, uplink, uplink_len);
+}
+
+static void load_default_payloads(void)
+{
+    load_payloads(info_payload,
+                  sizeof(info_payload),
+                  server_cert_payload,
+                  sizeof(server_cert_payload),
+                  device_cert_payload,
+                  sizeof(device_cert_payload),
+                  downlink_payload,
+                  sizeof(downlink_payload),
+                  uplink_payload,
+                  sizeof(uplink_payload));
+}
+
+ZTEST(serial_exchange, test_single_fragment)
+{
+    load_default_payloads();
+    run_exchange();
+
+    /* Broker received correct data from device. */
+    zassert_equal(broker_stubs.info.rx_len, sizeof(info_payload));
+    zassert_mem_equal(broker_stubs.info.rx_buf, info_payload, sizeof(info_payload));
+
+    zassert_equal(broker_stubs.device_cert.rx_len, sizeof(device_cert_payload));
+    zassert_mem_equal(broker_stubs.device_cert.rx_buf,
+                      device_cert_payload,
+                      sizeof(device_cert_payload));
+
+    zassert_equal(broker_stubs.uplink.rx_len, sizeof(uplink_payload));
+    zassert_mem_equal(broker_stubs.uplink.rx_buf, uplink_payload, sizeof(uplink_payload));
+
+    /* Device received correct data from broker. */
+    zassert_equal(device_stubs.server_cert.rx_len, sizeof(server_cert_payload));
+    zassert_mem_equal(device_stubs.server_cert.rx_buf,
+                      server_cert_payload,
+                      sizeof(server_cert_payload));
+
+    zassert_equal(device_stubs.downlink.rx_len, sizeof(downlink_payload));
+    zassert_mem_equal(device_stubs.downlink.rx_buf, downlink_payload, sizeof(downlink_payload));
+}
+
+#define LARGE_PAYLOAD_SIZE 200
+
+static void fill_pattern(uint8_t *buf, size_t len, uint8_t seed)
+{
+    for (size_t i = 0; i < len; i++)
+    {
+        buf[i] = (uint8_t) (seed + i);
+    }
+}
+
+ZTEST(serial_exchange, test_multi_fragment)
+{
+    uint8_t info_large[LARGE_PAYLOAD_SIZE];
+    uint8_t server_cert_large[LARGE_PAYLOAD_SIZE];
+    uint8_t device_cert_large[LARGE_PAYLOAD_SIZE];
+    uint8_t downlink_large[LARGE_PAYLOAD_SIZE];
+    uint8_t uplink_large[LARGE_PAYLOAD_SIZE];
+
+    fill_pattern(info_large, sizeof(info_large), 0x10);
+    fill_pattern(server_cert_large, sizeof(server_cert_large), 0x20);
+    fill_pattern(device_cert_large, sizeof(device_cert_large), 0x30);
+    fill_pattern(downlink_large, sizeof(downlink_large), 0x40);
+    fill_pattern(uplink_large, sizeof(uplink_large), 0x50);
+
+    load_payloads(info_large,
+                  sizeof(info_large),
+                  server_cert_large,
+                  sizeof(server_cert_large),
+                  device_cert_large,
+                  sizeof(device_cert_large),
+                  downlink_large,
+                  sizeof(downlink_large),
+                  uplink_large,
+                  sizeof(uplink_large));
+
+    run_exchange();
+
+    zassert_equal(broker_stubs.info.rx_len, sizeof(info_large));
+    zassert_mem_equal(broker_stubs.info.rx_buf, info_large, sizeof(info_large));
+
+    zassert_equal(broker_stubs.device_cert.rx_len, sizeof(device_cert_large));
+    zassert_mem_equal(broker_stubs.device_cert.rx_buf,
+                      device_cert_large,
+                      sizeof(device_cert_large));
+
+    zassert_equal(broker_stubs.uplink.rx_len, sizeof(uplink_large));
+    zassert_mem_equal(broker_stubs.uplink.rx_buf, uplink_large, sizeof(uplink_large));
+
+    zassert_equal(device_stubs.server_cert.rx_len, sizeof(server_cert_large));
+    zassert_mem_equal(device_stubs.server_cert.rx_buf,
+                      server_cert_large,
+                      sizeof(server_cert_large));
+
+    zassert_equal(device_stubs.downlink.rx_len, sizeof(downlink_large));
+    zassert_mem_equal(device_stubs.downlink.rx_buf, downlink_large, sizeof(downlink_large));
+}
+
+ZTEST(serial_exchange, test_empty_senders)
+{
+    /* All sender tx_len fields are zero after stubs_reset(). */
+    run_exchange();
+
+    zassert_equal(broker_stubs.info.rx_len, 0);
+    zassert_equal(broker_stubs.device_cert.rx_len, 0);
+    zassert_equal(broker_stubs.uplink.rx_len, 0);
+    zassert_equal(device_stubs.server_cert.rx_len, 0);
+    zassert_equal(device_stubs.downlink.rx_len, 0);
+}
+
+ZTEST(serial_exchange, test_endpoint_lifecycle)
+{
+    load_default_payloads();
+    run_exchange();
+
+    /* Every broker endpoint started and ended successfully exactly once. */
+    zassert_equal(broker_stubs.info.start_count, 1);
+    zassert_equal(broker_stubs.info.end_success_count, 1);
+    zassert_equal(broker_stubs.info.end_fail_count, 0);
+
+    zassert_equal(broker_stubs.server_cert.start_count, 1);
+    zassert_equal(broker_stubs.server_cert.end_success_count, 1);
+    zassert_equal(broker_stubs.server_cert.end_fail_count, 0);
+
+    zassert_equal(broker_stubs.device_cert.start_count, 1);
+    zassert_equal(broker_stubs.device_cert.end_success_count, 1);
+    zassert_equal(broker_stubs.device_cert.end_fail_count, 0);
+
+    zassert_equal(broker_stubs.downlink.start_count, 1);
+    zassert_equal(broker_stubs.downlink.end_success_count, 1);
+    zassert_equal(broker_stubs.downlink.end_fail_count, 0);
+
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_success_count, 1);
+    zassert_equal(broker_stubs.uplink.end_fail_count, 0);
+
+    /* Every device endpoint started and ended successfully exactly once. */
+    zassert_equal(device_stubs.info.start_count, 1);
+    zassert_equal(device_stubs.info.end_success_count, 1);
+    zassert_equal(device_stubs.info.end_fail_count, 0);
+
+    zassert_equal(device_stubs.server_cert.start_count, 1);
+    zassert_equal(device_stubs.server_cert.end_success_count, 1);
+    zassert_equal(device_stubs.server_cert.end_fail_count, 0);
+
+    zassert_equal(device_stubs.device_cert.start_count, 1);
+    zassert_equal(device_stubs.device_cert.end_success_count, 1);
+    zassert_equal(device_stubs.device_cert.end_fail_count, 0);
+
+    zassert_equal(device_stubs.downlink.start_count, 1);
+    zassert_equal(device_stubs.downlink.end_success_count, 1);
+    zassert_equal(device_stubs.downlink.end_fail_count, 0);
+
+    zassert_equal(device_stubs.uplink.start_count, 1);
+    zassert_equal(device_stubs.uplink.end_success_count, 1);
+    zassert_equal(device_stubs.uplink.end_fail_count, 0);
+}
+
+ZTEST(serial_exchange, test_asymmetric_payloads)
+{
+    uint8_t info_small[10];
+    uint8_t server_cert_large[LARGE_PAYLOAD_SIZE];
+    uint8_t device_cert_medium[50];
+    uint8_t uplink_large[150];
+
+    fill_pattern(info_small, sizeof(info_small), 0xA0);
+    fill_pattern(server_cert_large, sizeof(server_cert_large), 0xB0);
+    fill_pattern(device_cert_medium, sizeof(device_cert_medium), 0xC0);
+    fill_pattern(uplink_large, sizeof(uplink_large), 0xD0);
+
+    /* downlink is empty (zero-length), all others have varying sizes. */
+    stub_sender_set_data(&device_stubs.info, info_small, sizeof(info_small));
+    stub_sender_set_data(&broker_stubs.server_cert, server_cert_large, sizeof(server_cert_large));
+    stub_sender_set_data(&device_stubs.device_cert, device_cert_medium, sizeof(device_cert_medium));
+    /* broker_stubs.downlink left at zero length. */
+    stub_sender_set_data(&device_stubs.uplink, uplink_large, sizeof(uplink_large));
+
+    run_exchange();
+
+    zassert_equal(broker_stubs.info.rx_len, sizeof(info_small));
+    zassert_mem_equal(broker_stubs.info.rx_buf, info_small, sizeof(info_small));
+
+    zassert_equal(device_stubs.server_cert.rx_len, sizeof(server_cert_large));
+    zassert_mem_equal(device_stubs.server_cert.rx_buf,
+                      server_cert_large,
+                      sizeof(server_cert_large));
+
+    zassert_equal(broker_stubs.device_cert.rx_len, sizeof(device_cert_medium));
+    zassert_mem_equal(broker_stubs.device_cert.rx_buf,
+                      device_cert_medium,
+                      sizeof(device_cert_medium));
+
+    zassert_equal(device_stubs.downlink.rx_len, 0);
+
+    zassert_equal(broker_stubs.uplink.rx_len, sizeof(uplink_large));
+    zassert_mem_equal(broker_stubs.uplink.rx_buf, uplink_large, sizeof(uplink_large));
+}
+
+/*
+ * Broker receiver recv error: the broker's UPLINK recv callback returns an
+ * error.  The broker should close the channel with failure and signal
+ * adapter->end(false).
+ */
+ZTEST(serial_exchange, test_recv_error)
+{
+    load_default_payloads();
+    broker_stubs.uplink.recv_err = -EIO;
+
+    int err = pouch_serial_broker_start(test_broker);
+    zassert_ok(err, "broker_start failed: %d", err);
+
+    pump_until_done(MAX_PUMP_ITER);
+
+    zassert_true(broker_done, "exchange did not complete");
+    zassert_false(broker_success, "exchange should have failed");
+
+    /* The broker uplink receiver was started but ended with failure. */
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_fail_count, 1);
+    zassert_equal(broker_stubs.uplink.end_success_count, 0);
+}
+
+/*
+ * Broker sender send error: the broker's DOWNLINK send callback returns
+ * POUCH_ERROR on the first send() call.  The error DATA frame is produced,
+ * ch_close fires, and channel_closed terminates the exchange with failure.
+ */
+ZTEST(serial_exchange, test_send_error)
+{
+    load_default_payloads();
+    broker_stubs.downlink.send_err_after = 0;
+
+    int err = pouch_serial_broker_start(test_broker);
+    zassert_ok(err, "broker_start failed: %d", err);
+
+    pump_until_done(MAX_PUMP_ITER);
+
+    zassert_true(broker_done, "exchange did not complete");
+    zassert_false(broker_success, "exchange should have failed");
+
+    /* The broker downlink sender was started but ended with failure. */
+    zassert_equal(broker_stubs.downlink.start_count, 1);
+    zassert_equal(broker_stubs.downlink.end_fail_count, 1);
+    zassert_equal(broker_stubs.downlink.end_success_count, 0);
+}
+
+/*
+ * Device sender send error propagating to broker: the device's UPLINK send
+ * callback returns POUCH_ERROR after one successful send.  The error DATA
+ * reaches the broker's already-open UPLINK receiver, which closes with
+ * failure and terminates the exchange.
+ *
+ * Requires a multi-fragment uplink payload so the first DATA succeeds (opening
+ * the broker receiver) and the second DATA carries the error.
+ */
+ZTEST(serial_exchange, test_remote_send_error)
+{
+    uint8_t uplink_large[LARGE_PAYLOAD_SIZE];
+    fill_pattern(uplink_large, sizeof(uplink_large), 0xE0);
+
+    load_default_payloads();
+    stub_sender_set_data(&device_stubs.uplink, uplink_large, sizeof(uplink_large));
+    device_stubs.uplink.send_err_after = 1;
+
+    int err = pouch_serial_broker_start(test_broker);
+    zassert_ok(err, "broker_start failed: %d", err);
+
+    pump_until_done(MAX_PUMP_ITER);
+
+    zassert_true(broker_done, "exchange did not complete");
+    zassert_false(broker_success, "exchange should have failed");
+
+    /* Both the device sender and broker receiver ended with failure. */
+    zassert_equal(device_stubs.uplink.start_count, 1);
+    zassert_equal(device_stubs.uplink.end_fail_count, 1);
+    zassert_equal(device_stubs.uplink.end_success_count, 0);
+
+    zassert_equal(broker_stubs.uplink.start_count, 1);
+    zassert_equal(broker_stubs.uplink.end_fail_count, 1);
+    zassert_equal(broker_stubs.uplink.end_success_count, 0);
+}

--- a/tests/pouch/serial/exchange/testcase.yaml
+++ b/tests/pouch/serial/exchange/testcase.yaml
@@ -1,0 +1,9 @@
+tests:
+  pouch.serial.exchange:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+    tags: test_framework


### PR DESCRIPTION
Two bugs in the serial channel state machine, both found while running an rpmsg transport built on this branch against a real broker on hardware (i.MX95 Cortex-M7 under Linux remoteproc, connect-agent as the broker). Both were reported as review comments on #232 — [here](https://github.com/golioth/pouch/pull/232#discussion_r3695491746) and [here](https://github.com/golioth/pouch/pull/232#discussion_r3695492089) — this is the patch for them.

### 1. `pouch_serial_ch_close()` dereferences an optional callback

`ch->endpoint->end()` is called unconditionally, but `end` is optional in the same way it is for the SAR sender/receiver: endpoints with nothing to tear down, such as the device info endpoint, leave it `NULL`.

That means a jump through a NULL pointer on the **first ACK any broker sends** — so every device crashes as soon as it is talked to.

### 2. `pouch_serial_ch_frame_get()` drops the channel's pending flag

`CH_FLAG_PENDING` is consumed on entry, but when the endpoint reports `POUCH_MORE_DATA` with zero bytes — "nothing yet, call me again" — the function returns without restoring it, so the channel is never polled again.

The device uplink endpoint hits this every session: it produces its data asynchronously on the Pouch work queue a few hundred milliseconds after the broker's prompt, and never calls `bearer_ready()`. The uplink transfer then stalls until the broker times the session out.

### Why CI doesn't catch either

Both are invisible to the current tests. Every mock in `stub_endpoints.c` defines `.end` (20 of 20 vtables), so #1 never fires; and they are all synchronous, so none of them ever returns `MORE_DATA` with no bytes and #2 never fires. Adding one endpoint without `.end`, and one that defers its first block, would cover both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)