### PR TITLE
CI: Add fw_update to Zephyr HIL test

### DIFF
--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -86,10 +86,14 @@ jobs:
           cd "${{ matrix.dir }}"
           shopt -s globstar nullglob
 
+          # Preserve the sdkconfig; harness can read package name from it
+          cp sdkconfig build/sdkconfig.orig
+
           artifact_files=(
             build/flasher_args.json
             build/**/*.bin
             build/*.elf
+            build/sdkconfig.orig
           )
 
           tar -cf build-artifacts.tar "${artifact_files[@]}"
@@ -283,9 +287,6 @@ jobs:
             --port "${!PORT_VAR}"            \
             --app-path "$SAMPLE_DIR"         \
             --build-dir build                \
-            --fw-update-bin "$SAMPLE_DIR/build/${{ matrix.name }}_${{ inputs.idf_target }}_fwupdate.bin" \
-            --fw-update-ver "$(git rev-parse --short HEAD)" \
-            --fw-update-pkg-name "hil_ota_${IDF_TARGET}_${{ matrix.name }}"      \
             --erase-all n                    \
             --api-url "$GOLIOTH_API_URL"     \
             --api-key "$GOLIOTH_API_KEY"     \

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -99,8 +99,7 @@ jobs:
             -p nrf52_bsim/native                                                  \
             -T pouch/examples/zephyr/                                             \
             --pytest-args="--api-url=${{ inputs.api_url }}"                       \
-            --pytest-args="--api-key=${{ secrets[inputs.api_key_id] }}"           \
-            --pytest-args="--ota-dummy-binary"
+            --pytest-args="--api-key=${{ secrets[inputs.api_key_id] }}"
 
       - name: Safe upload twister artifacts
         if: success() || failure()

--- a/.github/workflows/test-nsim.yml
+++ b/.github/workflows/test-nsim.yml
@@ -93,7 +93,7 @@ jobs:
           export CONFIG_POUCH_SERVER_CERT_CN="pouch.${COAP_HOST#coap.}"
 
           zephyr/scripts/twister                                                  \
-            -c -v -W                                                              \
+            -c -vv -W                                                             \
             -p native_sim                                                         \
             -p native_sim/native/64                                               \
             -p nrf52_bsim/native                                                  \

--- a/.github/workflows/test-zephyr-hil.yml
+++ b/.github/workflows/test-zephyr-hil.yml
@@ -93,11 +93,56 @@ jobs:
 
           tar -cjf test_artifacts_${{ inputs.hil_board }}.tar twister-out
 
+      - name: Build update version of firmware
+        shell: bash
+        run: |
+          # Ensure we can query the short hash
+          git config --global --add safe.directory $GITHUB_WORKSPACE/pouch
+
+          # MCUboot doesn't allow strings version; convert short hash base-10 by byte
+          SHORT_HASH=$(git -C pouch rev-parse --short HEAD)
+          V_MAJOR=$((16#${SHORT_HASH:0:2}))
+          V_MINOR=$((16#${SHORT_HASH:2:2}))
+          V_PATCH=$((16#${SHORT_HASH:4:2}))
+          V_TWEAK=$((16#${SHORT_HASH:6:2}))
+
+          # Create version file with update version number
+          cat > "VERSION" <<EOF
+          VERSION_MAJOR = $V_MAJOR
+          VERSION_MINOR = $V_MINOR
+          PATCHLEVEL = $V_PATCH
+          VERSION_TWEAK = $V_TWEAK
+          EXTRAVERSION =
+          EOF
+
+          # Replace app version files with update version
+          find pouch/examples/zephyr/ -name VERSION -exec cp VERSION {} \;
+          rm VERSION
+
+          # Build update binaries
+          zephyr/scripts/twister                \
+            -v                                  \
+            --overflow-as-errors                \
+            --platform ${{ inputs.west_board }} \
+            -T pouch/examples/zephyr/           \
+            --build-only
+
+          # Create archive of update files, preserving path
+          find twister-out -name "zephyr.signed.bin" | \
+            tar -cf fw_update_bins_${{ inputs.hil_board }}.tar -T -
+
+          # Preserve update version number in a file
+          echo "$V_MAJOR.$V_MINOR.$V_PATCH" > twister-out/update-ver-num.txt
+          find twister-out -name "update-ver-num.txt" | \
+            tar -rf fw_update_bins_${{ inputs.hil_board }}.tar -T -
+
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zephyr-${{ inputs.hil_board }}-build
-          path: test_artifacts_${{ inputs.hil_board }}.tar
+          path: |
+            test_artifacts_${{ inputs.hil_board }}.tar
+            fw_update_bins_${{ inputs.hil_board }}.tar
 
   hil-test:
     permissions:
@@ -169,7 +214,13 @@ jobs:
       - name: Extract build artifact
         run: |
           rm -rf twister-out
+
+          # Build artifacts
           tar -xvf test_artifacts_${{ inputs.hil_board }}.tar
+
+          # FW Update artifacts
+          mkdir -p twister-out/fw_update_bins
+          tar -xvf fw_update_bins_${{ inputs.hil_board }}.tar --strip-components=1 -C twister-out/fw_update_bins
 
       - name: Run HIL test
         shell: bash

--- a/.github/workflows/test-zephyr-hil.yml
+++ b/.github/workflows/test-zephyr-hil.yml
@@ -234,7 +234,7 @@ jobs:
           SNR_VAR=CI_${hil_board^^}_SNR
 
           zephyr/scripts/twister                                        \
-            -v                                                          \
+            -vv                                                         \
             -p ${{ inputs.west_board }}                                 \
             -T pouch/examples/zephyr/                                   \
             --device-testing                                            \

--- a/examples/esp_idf/ble_gatt/pytest/README.md
+++ b/examples/esp_idf/ble_gatt/pytest/README.md
@@ -3,6 +3,9 @@
 This directory contains local pytest-based HIL tests for the
 `examples/esp_idf/ble_gatt` sample.
 
+You must have a gateway device provisioned and running to complete these
+tests. See: examples/zephyr/gateway.
+
 ## Prerequisites
 
 1. Activate ESP-IDF environment:
@@ -15,51 +18,77 @@ This directory contains local pytest-based HIL tests for the
    env:
 
 ```bash
-uv pip install --python "$IDF_PYTHON_ENV_PATH" -r requirements-ci-esp-idf.txt --require-hashes
+uv pip install --python "$IDF_PYTHON_ENV_PATH" \
+    -r requirements-ci-esp-idf.txt --require-hashes
 ```
 
 3. Install cloud tooling used by the test:
 
 ```bash
-uv pip install --python "$IDF_PYTHON_ENV_PATH" "golioth@git+https://github.com/golioth/python-golioth-tools@v0.8.1"
+uv pip install --python "$IDF_PYTHON_ENV_PATH" \
+    "golioth@git+https://github.com/golioth/python-golioth-tools@v0.8.1"
 ```
-
-## Build Firmware
-
-From the repository root (`pouch`):
-
-```bash
-idf.py -C examples/esp_idf/ble_gatt set-target esp32s3
-idf.py -C examples/esp_idf/ble_gatt build
-```
-
-## Run Test
 
 Set required environment variables:
 
 ```bash
 export GOLIOTH_API_URL="https://api.golioth.io"
 export GOLIOTH_API_KEY="your_project_api_key"
-
-# Manual cert mode: provide DER file paths
-export DEVICE_CRT_DER_PATH="/path/to/device.crt.der"
-export DEVICE_KEY_DER_PATH="/path/to/device.key.der"
-
-# Optional override (otherwise derived from cert CN in DEVICE_CRT_DER_PATH)
-export GOLIOTH_DEVICE_NAME="your_device_name"
 ```
 
-The test also accepts `python-golioth-tools`/SDK-style pytest flags:
+## Build Update Firmware
 
-- `--api-key` (fallback: `GOLIOTH_API_KEY`)
-- `--api-url` (fallback: `GOLIOTH_API_URL`, default: `https://api.golioth.io`)
-- `--device-name` (fallback: `GOLIOTH_DEVICE_NAME`)
+Note: if you prefer to skip the fw_update test you can ignore this
+section and simply add the following to the pytest command in place of
+fw_update specific flags:
 
-To generate device certificates automatically during the test run,
-pass `--generate-certs` and omit manual cert inputs
-(`DEVICE_CRT_DER_PATH`/`DEVICE_KEY_DER_PATH`).
+```
+--ota-mode=disabled
+```
 
-Then run from the repository root (`pouch`):
+OTA testing requires two firmware builds: an update version (unique
+version number) and an initial version (default version).
+
+Build the update firmware with a unique version and OTA package name:
+
+```bash
+# Create fw_update.defaults with OTA package name and version
+cat > examples/esp_idf/ble_gatt/fw_update.defaults <<EOF
+CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_esp32s3_ble_gatt"
+CONFIG_APP_PROJECT_VER="$(git rev-parse --short HEAD)"
+EOF
+
+idf.py -C examples/esp_idf/ble_gatt set-target esp32s3
+export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
+rm -f examples/esp_idf/ble_gatt/sdkconfig
+idf.py -C examples/esp_idf/ble_gatt reconfigure
+idf.py -C examples/esp_idf/ble_gatt build
+
+# Copy the update binary to a known location
+cp examples/esp_idf/ble_gatt/build/pouch_ble_gatt_example.bin /tmp/ble_gatt_esp32s3_fwupdate.bin
+```
+
+## Build Initial Version of Firmware
+
+Build the initial version of the firmware (defaults to 1.0.0) with a
+unique version and OTA package name:
+
+```bash
+# Create fw_update.defaults with OTA package name (no version override)
+cat > examples/esp_idf/ble_gatt/fw_update.defaults <<EOF
+CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_esp32s3_ble_gatt"
+EOF
+
+idf.py -C examples/esp_idf/ble_gatt set-target esp32s3
+export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
+rm -f examples/esp_idf/ble_gatt/sdkconfig
+idf.py -C examples/esp_idf/ble_gatt reconfigure
+idf.py -C examples/esp_idf/ble_gatt build
+```
+
+## Run Test
+
+Run all tests:
 
 ```bash
 # Full erase to remove existing credentials:
@@ -75,21 +104,9 @@ pytest -vv -rs -s \
   --app-path examples/esp_idf/ble_gatt \
   --build-dir build \
   --erase-all n \
-  examples/esp_idf/ble_gatt/pytest/test_sample.py
-```
-
-Example generated-cert run:
-
-```bash
-pytest -vv -rs -s \
-  -c examples/esp_idf/ble_gatt/pytest.ini \
-  --rootdir examples/esp_idf/ble_gatt \
-  --embedded-services esp,idf \
-  --target esp32s3 \
-  --port /dev/ttyUSB0 \
-  --app-path examples/esp_idf/ble_gatt \
-  --build-dir build \
-  --erase-all n \
   --generate-certs \
+  --fw-update-pkg-name hil_ota_esp32s3_ble_gatt \
+  --fw-update-bin /tmp/ble_gatt_esp32s3_fwupdate.bin \
+  --fw-update-ver "$(git rev-parse --short HEAD)" \
   examples/esp_idf/ble_gatt/pytest/test_sample.py
 ```

--- a/examples/esp_idf/ble_gatt/pytest/conftest.py
+++ b/examples/esp_idf/ble_gatt/pytest/conftest.py
@@ -15,8 +15,8 @@ sys.path.insert(
 
 pytest_plugins = [
     "pytest_pouch.plugin",
-    "pytest_pouch.esp_idf_harness",
     "pytest_pouch.ota_harness",
+    "pytest_pouch.esp_idf_harness",
     "pytest_pouch.gateway_provision",
 ]
 

--- a/examples/esp_idf/http_client/pytest/README.md
+++ b/examples/esp_idf/http_client/pytest/README.md
@@ -32,21 +32,6 @@ uv pip install --python "$IDF_PYTHON_ENV_PATH" "golioth@git+https://github.com/g
 
    - `examples/esp_idf/http_client/pytest/json-sensor-path-to-lightdb-stream.txt`
 
-## Build Firmware
-
-From the repository root (`pouch`):
-
-```bash
-idf.py -C examples/esp_idf/http_client set-target esp32s3
-export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults"
-idf.py -C examples/esp_idf/http_client build
-```
-
-This build command includes an overlay file that resets the sync
-interval to 10s. This may be omitted to use the default 30s period.
-
-## Run Test
-
 Set required environment variables (test auto-provisions before cloud
 checks):
 
@@ -55,28 +40,57 @@ export GOLIOTH_API_URL="https://api.golioth.io"
 export GOLIOTH_API_KEY="your_project_api_key"
 export WIFI_SSID="your_wifi_ssid"
 export WIFI_PSK="your_wifi_psk"
-
-# Manual cert mode: provide DER file paths
-export DEVICE_CRT_DER_PATH="/path/to/device.crt.der"
-export DEVICE_KEY_DER_PATH="/path/to/device.key.der"
-
-# Optional override (otherwise derived from cert CN in DEVICE_CRT_DER_PATH)
-export GOLIOTH_DEVICE_NAME="your_device_name"
 ```
 
-The test also accepts `python-golioth-tools`/SDK-style pytest flags:
+## Build Update Firmware
 
-- `--api-key` (fallback: `GOLIOTH_API_KEY`)
-- `--api-url` (fallback: `GOLIOTH_API_URL`, default: `https://api.golioth.io`)
-- `--device-name` (fallback: `GOLIOTH_DEVICE_NAME`)
-- `--wifi-ssid` (fallback: `WIFI_SSID`)
-- `--wifi-psk` (fallback: `WIFI_PSK`)
+Note: if you prefer to skip the fw_update test you can ignore this
+section and simply add the following to the pytest command in place of
+fw_update specific flags:
 
-To generate device certificates automatically during the test run,
-pass `--generate-certs` and omit manual cert inputs
-(`DEVICE_CRT_DER_PATH`/`DEVICE_KEY_DER_PATH`).
+```
+--ota-mode=disabled
+```
 
-Then run from the repository root (`pouch`):
+OTA testing requires two firmware builds: an update version (unique
+version number) and an initial version (default version).
+
+1. Build the update firmware with a unique version and OTA package name:
+
+```bash
+# Create fw_update.defaults with OTA package name and version
+cat > examples/esp_idf/http_client/fw_update.defaults <<EOF
+CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_esp32s3_http_client"
+CONFIG_APP_PROJECT_VER="$(git rev-parse --short HEAD)"
+EOF
+
+idf.py -C examples/esp_idf/http_client set-target esp32s3
+export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
+rm -f examples/esp_idf/http_client/sdkconfig
+idf.py -C examples/esp_idf/http_client reconfigure
+idf.py -C examples/esp_idf/http_client build
+
+# Copy the update binary to a known location
+cp examples/esp_idf/http_client/build/pouch_http_client_example.bin /tmp/http_client_esp32s3_fwupdate.bin
+```
+
+2. Build the initial version of the example:
+
+```bash
+# Create fw_update.defaults with OTA package name (no version override)
+cat > examples/esp_idf/http_client/fw_update.defaults <<EOF
+CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_esp32s3_http_client"
+EOF
+
+export SDKCONFIG_DEFAULTS="sdkconfig.defaults;pytest/sdkconfig.pytest.defaults;fw_update.defaults"
+rm -f examples/esp_idf/http_client/sdkconfig
+idf.py -C examples/esp_idf/http_client reconfigure
+idf.py -C examples/esp_idf/http_client build
+```
+
+## Run Test
+
+From the repository root (`pouch`):
 
 ```bash
 # Full erase to remove existing credentials:
@@ -92,21 +106,9 @@ pytest -vv -rs -s \
   --app-path examples/esp_idf/http_client \
   --build-dir build \
   --erase-all n \
-  examples/esp_idf/http_client/pytest/test_sample.py
-```
-
-Example generated-cert run:
-
-```bash
-pytest -vv -rs -s \
-  -c examples/esp_idf/http_client/pytest.ini \
-  --rootdir examples/esp_idf/http_client \
-  --embedded-services esp,idf \
-  --target esp32s3 \
-  --port /dev/ttyUSB0 \
-  --app-path examples/esp_idf/http_client \
-  --build-dir build \
-  --erase-all n \
   --generate-certs \
+  --fw-update-pkg-name hil_ota_esp32s3_http_client \
+  --fw-update-bin /tmp/http_client_esp32s3_fwupdate.bin \
+  --fw-update-ver "$(git rev-parse --short HEAD)" \
   examples/esp_idf/http_client/pytest/test_sample.py
 ```

--- a/examples/esp_idf/http_client/pytest/conftest.py
+++ b/examples/esp_idf/http_client/pytest/conftest.py
@@ -15,8 +15,8 @@ sys.path.insert(
 
 pytest_plugins = [
     "pytest_pouch.plugin",
-    "pytest_pouch.esp_idf_harness",
     "pytest_pouch.ota_harness",
+    "pytest_pouch.esp_idf_harness",
 ]
 
 

--- a/examples/zephyr/coap_client/pytest/test_ota.py
+++ b/examples/zephyr/coap_client/pytest/test_ota.py
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2026 Golioth, Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-from pytest_pouch.zephyr_ota_tests import *  # noqa: F403

--- a/examples/zephyr/coap_client/pytest/test_sample.py
+++ b/examples/zephyr/coap_client/pytest/test_sample.py
@@ -6,3 +6,4 @@
 
 from pytest_pouch.zephyr_settings_tests import *  # noqa: F403
 from pytest_pouch.zephyr_stream_tests import *  # noqa: F403
+from pytest_pouch.zephyr_ota_tests import *  # noqa: F403

--- a/examples/zephyr/coap_client/sample.yaml
+++ b/examples/zephyr/coap_client/sample.yaml
@@ -9,19 +9,8 @@ tests:
       pytest_dut_scope: module
       pytest_root:
         - pytest/test_sample.py
-    platform_allow:
-      - native_sim
-      - native_sim/native/64
-    extra_configs:
-      - CONFIG_FILE_SYSTEM_NSIM_MOUNT=y
-      - 'CONFIG_NATIVE_EXTRA_CMDLINE_ARGS="-volume=./creds:/creds"'
-      - 'CONFIG_EXAMPLE_CREDENTIALS_DIR="/creds"'
-      - CONFIG_EXAMPLE_COAP_CLIENT_SYNC_PERIOD_S=2
-  pouch.coap_client.ota:
-    harness_config:
-      pytest_dut_scope: module
-      pytest_root:
-        - pytest/test_ota.py
+      pytest_args:
+        - --ota-mode=dummy
     platform_allow:
       - native_sim
       - native_sim/native/64

--- a/examples/zephyr/http_client/pytest/README.md
+++ b/examples/zephyr/http_client/pytest/README.md
@@ -1,0 +1,99 @@
+# Zephry HTTP Client Pytest
+
+This directory contains local pytest-based HIL tests for the
+`examples/zephyr/http_client` sample.
+
+## Prerequisites
+
+1. Install pinned Python dependencies into the active Python env:
+
+```bash
+uv pip install -r requirements-ci-zephyr.txt --require-hashes
+```
+
+2. Install cloud tooling used by the test:
+
+```bash
+uv pip install "golioth@git+https://github.com/golioth/python-golioth-tools@v0.8.1"
+```
+
+3. Enable the required Golioth pipeline route for stream validation:
+
+   The stream test (`test_sensor_stream_uplink`) expects JSON data sent
+   on `.s/sensor` to be routed into LightDB Stream. Enable the pipeline
+   from this file in your Golioth project before running the test:
+
+   - `examples/zephyr/http_client/pytest/json-sensor-path-to-lightdb-stream.txt`
+
+## Build Update Firmware
+
+Note: if you prefer to skip the fw_update test you can ignore this
+section and simple add the following to the twister command in place of
+fw_update specific flags:
+
+```
+--pytest-args="--ota-mode=disabled"
+```
+
+While twister will build and flash the device firmware, to test
+fw_update you must build the update binary your self and supply the
+binary and version pytest args when calling twister.
+
+First, you must update the version number in the VERSION file:
+```
+# Update to your preferred version, like 2.0.0
+nano examples/zephyr/http_client/VERSION
+```
+
+The sample.yaml sets the package name, you must use the same value. For
+instance, the frdm_rw612 package name is set to
+`hil_ota_frdm_rw612_http_client`. Here's an example for building and
+staging the firmware:
+
+```
+# Build the update with specialized configuration
+west build -p -b frdm_rw612 --sysbuild examples/zephyr/http_client --     \
+  -DCONFIG_EXAMPLE_HTTP_CLIENT_SYNC_PERIOD_S=10                           \
+  -DCONFIG_GOLIOTH_OTA_MAX_PACKAGE_NAME_LEN=64                            \
+  -DCONFIG_GOLIOTH_OTA_MAX_VERSION_LEN=64                                 \
+  -DCONFIG_EXAMPLE_FW_UPDATE_COMPONENT=\"hil_ota_frdm_rw612_http_client\"
+
+# Copy the signed binary to a known location
+cp build/http_client/zephyr/zephyr.signed.bin /tmp/frdm_rw612_update_2.0.0.bin
+
+# Restore the VERSION file so defaults are used by twister
+git restore examples/zephyr/http_client/VERSION
+```
+
+## Run Test
+
+Set required environment variables:
+
+```bash
+export GOLIOTH_API_URL="https://api.golioth.io"
+export GOLIOTH_API_KEY="your_project_api_key"
+```
+
+Then run one of the following test options from the repository root
+(`pouch`):
+
+### Run with Firmware Update Test
+```bash
+west twister -vv -W -T examples/zephyr/http_client                       \
+        --device-testing --device-serial /dev/ttyACM0                    \
+        --west-flash="--dev-id=001063461944"                             \
+        -p frdm_rw612                                                    \
+        --pytest-args="--generate-certs"                                 \
+        --pytest-args="--fw-update-bin=/tmp/frdm_rw612_update_2.0.0.bin" \
+        --pytest-args="--fw-update-ver=2.0.0"
+```
+
+### Run without Firmware Update Test
+```bash
+west twister -vv -W -T examples/zephyr/http_client    \
+        --device-testing --device-serial /dev/ttyACM0 \
+        --west-flash="--dev-id=001063461944"          \
+        -p frdm_rw612                                 \
+        --pytest-args="--generate-certs"              \
+        --pytest-args="--ota-mode=disabled"
+```

--- a/examples/zephyr/http_client/pytest/README.md
+++ b/examples/zephyr/http_client/pytest/README.md
@@ -1,0 +1,85 @@
+# Zephry HTTP Client Pytest
+
+This directory contains local pytest-based HIL tests for the
+`examples/zephyr/http_client` sample.
+
+## Prerequisites
+
+1. Activate ESP-IDF environment:
+
+```bash
+. /path/to/esp-idf/export.sh
+```
+
+2. Install pinned Python dependencies into the active Python env:
+
+```bash
+uv pip install -r requirements-ci-zephyr.txt --require-hashes
+```
+
+3. Install cloud tooling used by the test:
+
+```bash
+uv pip install "golioth@git+https://github.com/golioth/python-golioth-tools@v0.8.1"
+```
+
+## Build Update Firmware
+
+Note: if you prefer to skip the fw_update test you can ignore this
+section and simple add the following to the twister command in place of
+fw_update specific flags:
+
+```
+--pytest-args="--ota-mode=disabled"
+```
+
+While twister will build and flash the device firmware, to test
+fw_update you must build the update binary your self and supply the
+binary and version pytest args when calling twister.
+
+First, you must update the version number in the VERSION file:
+```
+# Update to your preferred version, like 2.0.0
+nano examples/zephyr/http_client/VERSION
+```
+
+The sample.yml sets the package name, you must use the same value. For
+instance, the frdm_rw612 package name is set to
+`hil_ota_frdm_rw612_http_client`. Here's an example for building and
+staging the firmware:
+
+```
+# Build the update with specialized configuration
+west build -p -b frdm_rw612 --sysbuild examples/zephyr/http_client --     \
+  -DCONFIG_EXAMPLE_HTTP_CLIENT_SYNC_PERIOD_S=10                           \
+  -DCONFIG_GOLIOTH_OTA_MAX_PACKAGE_NAME_LEN=64                            \
+  -DCONFIG_GOLIOTH_OTA_MAX_VERSION_LEN=64                                 \
+  -DCONFIG_EXAMPLE_FW_UPDATE_COMPONENT=\"hil_ota_frdm_rw612_http_client\"
+
+# Copy the signed binary to a known location
+cp build/http_client/zephyr/zephyr.signed.bin /tmp/frdm_rw612_update_2.0.0.bin
+
+# Restore the VERSION file so defaults are used by twister
+git restore examples/zephyr/http_client/VERSION
+```
+
+## Run Test
+
+Set required environment variables:
+
+```bash
+export GOLIOTH_API_URL="https://api.golioth.io"
+export GOLIOTH_API_KEY="your_project_api_key"
+```
+
+Then run from the repository root (`pouch`):
+
+```bash
+west twister -vv -W -T examples/zephyr/http_client                       \
+        --device-testing --device-serial /dev/ttyACM0                    \
+        --west-flash="--dev-id=001063461944"                             \
+        -p frdm_rw612                                                    \
+        --pytest-args="--generate-certs"                                 \
+        --pytest-args="--fw-update-bin=/tmp/frdm_rw612_update_2.0.0.bin" \
+        --pytest-args="--fw-update-ver=2.0.0"
+```

--- a/examples/zephyr/http_client/pytest/json-sensor-path-to-lightdb-stream.txt
+++ b/examples/zephyr/http_client/pytest/json-sensor-path-to-lightdb-stream.txt
@@ -1,0 +1,8 @@
+filter:
+  path: "/sensor"
+  content_type: application/json
+steps:
+  - name: send-to-lightdb-stream
+    destination:
+      type: lightdb-stream
+      version: v1

--- a/examples/zephyr/http_client/pytest/test_ota.py
+++ b/examples/zephyr/http_client/pytest/test_ota.py
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2026 Golioth, Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-from pytest_pouch.zephyr_ota_tests import *  # noqa: F403

--- a/examples/zephyr/http_client/pytest/test_sample.py
+++ b/examples/zephyr/http_client/pytest/test_sample.py
@@ -6,3 +6,4 @@
 
 from pytest_pouch.zephyr_settings_tests import *  # noqa: F403
 from pytest_pouch.zephyr_stream_tests import *  # noqa: F403
+from pytest_pouch.zephyr_ota_tests import *  # noqa: F403

--- a/examples/zephyr/http_client/sample.yaml
+++ b/examples/zephyr/http_client/sample.yaml
@@ -9,19 +9,8 @@ tests:
       pytest_dut_scope: module
       pytest_root:
         - pytest/test_sample.py
-    platform_allow:
-      - native_sim
-      - native_sim/native/64
-    extra_configs:
-      - CONFIG_FILE_SYSTEM_NSIM_MOUNT=y
-      - 'CONFIG_NATIVE_EXTRA_CMDLINE_ARGS="-volume=./creds:/creds"'
-      - 'CONFIG_EXAMPLE_CREDENTIALS_DIR="/creds"'
-      - CONFIG_EXAMPLE_HTTP_CLIENT_SYNC_PERIOD_S=2
-  pouch.http_client.ota:
-    harness_config:
-      pytest_dut_scope: module
-      pytest_root:
-        - pytest/test_ota.py
+      pytest_args:
+        - --ota-mode=dummy
     platform_allow:
       - native_sim
       - native_sim/native/64

--- a/examples/zephyr/http_client/sample.yaml
+++ b/examples/zephyr/http_client/sample.yaml
@@ -27,7 +27,7 @@ tests:
       pytest_dut_scope: module
       pytest_root:
         - pytest/test_sample.py
-    timeout: 600
+    timeout: 960
     sysbuild: true
     extra_configs:
       - CONFIG_EXAMPLE_HTTP_CLIENT_SYNC_PERIOD_S=10

--- a/examples/zephyr/http_client/sample.yaml
+++ b/examples/zephyr/http_client/sample.yaml
@@ -27,7 +27,12 @@ tests:
       pytest_dut_scope: module
       pytest_root:
         - pytest/test_sample.py
+    timeout: 600
+    sysbuild: true
     extra_configs:
       - CONFIG_EXAMPLE_HTTP_CLIENT_SYNC_PERIOD_S=10
+      - CONFIG_GOLIOTH_OTA_MAX_PACKAGE_NAME_LEN=64
+      - CONFIG_GOLIOTH_OTA_MAX_VERSION_LEN=64
+      - 'platform:frdm_rw612/rw612:CONFIG_EXAMPLE_FW_UPDATE_COMPONENT="hil_ota_frdm_rw612_http_client"'
     platform_allow:
       - frdm_rw612

--- a/scripts/pytest-pouch/pytest_pouch/esp_idf_harness.py
+++ b/scripts/pytest-pouch/pytest_pouch/esp_idf_harness.py
@@ -13,7 +13,9 @@ Usage notes:
 """
 
 import os
+import re
 import secrets
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -71,6 +73,67 @@ def _device_name_from_cert_cn(cert_der: bytes | None = None) -> str | None:
         return cn or None
     except Exception:
         return None
+
+
+def _read_sdkconfig_value(sdkconfig_path: Path, key: str) -> str | None:
+    """Read a string Kconfig value from an ESP-IDF build's ``sdkconfig``."""
+    if not sdkconfig_path.exists():
+        return None
+    pattern = re.compile(rf'^{re.escape(key)}="([^"]*)"$', re.MULTILINE)
+    match = pattern.search(sdkconfig_path.read_text())
+    return match.group(1) if match else None
+
+
+@pytest.fixture(scope="module")
+def fw_update_bin(request: pytest.FixtureRequest) -> Path | None:
+    """Resolve OTA update binary path from ESP-IDF build context.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-bin``) takes precedence when provided.
+    """
+    bin_cli = request.config.getoption("--fw-update-bin")
+    if bin_cli:
+        return Path(bin_cli)
+    app_path = request.config.getoption("--app-path")
+    target = request.config.getoption("--target")
+    if not app_path or not target:
+        return None
+    sample_name = Path(app_path).name
+    return Path(app_path) / "build" / f"{sample_name}_{target}_fwupdate.bin"
+
+
+@pytest.fixture(scope="module")
+def fw_update_version(request: pytest.FixtureRequest) -> str | None:
+    """Resolve OTA update version from ESP-IDF build context.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-ver``) takes precedence when provided.
+    """
+    ver_cli = request.config.getoption("--fw-update-ver")
+    if ver_cli:
+        return ver_cli
+    return (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        .strip()
+        .decode()
+    )
+
+
+@pytest.fixture(scope="module")
+def fw_update_package(request: pytest.FixtureRequest) -> str | None:
+    """Resolve OTA package name from ESP-IDF build context.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-pkg-name``) takes precedence when provided.
+    """
+    pkg_cli = request.config.getoption("--fw-update-pkg-name")
+    if pkg_cli:
+        return pkg_cli
+    app_path = request.config.getoption("--app-path")
+    if not app_path:
+        return None
+    sdkconfig = Path(app_path) / "build" / "sdkconfig.orig"
+    return _read_sdkconfig_value(sdkconfig, "CONFIG_EXAMPLE_FW_UPDATE_COMPONENT")
 
 
 @pytest.fixture(scope="module")

--- a/scripts/pytest-pouch/pytest_pouch/esp_idf_sample_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/esp_idf_sample_tests.py
@@ -347,6 +347,7 @@ async def test_led_setting_downlink(connected_cloud_session):
     print(f"Device received LED setting {int(next_led)} after {elapsed:.1f}s")
 
 
+@pytest.mark.ota_mode("firmware")
 async def test_ota_firmware_update(
     connected_cloud_session,
     ota_update,

--- a/scripts/pytest-pouch/pytest_pouch/gateway_provision.py
+++ b/scripts/pytest-pouch/pytest_pouch/gateway_provision.py
@@ -39,10 +39,7 @@ def gateway_log_path(request):
 
 @pytest.fixture(scope="module")
 def gateway_serial_port(request):
-    port = request.config.getoption("--gateway-port")
-    if not port:
-        pytest.fail("--gateway-port not set")
-    return port
+    return request.config.getoption("--gateway-port")
 
 
 @pytest.fixture(scope="module")
@@ -241,6 +238,10 @@ def _wait_for_gateway_ready(status_queue: queue.Queue[object], log_path: Path) -
 def provisioned_gateway(
     gateway_serial_port, gateway_creds_dir, gateway_creds, gateway_log_path
 ):
+    if not gateway_serial_port:
+        logging.info("No gateway port configured; skipping gateway provisioning")
+        yield
+        return
     logging.info("Uploading gateway credentials via smpmgr")
 
     for local_name, remote_path in [

--- a/scripts/pytest-pouch/pytest_pouch/gateway_provision.py
+++ b/scripts/pytest-pouch/pytest_pouch/gateway_provision.py
@@ -39,10 +39,7 @@ def gateway_log_path(request):
 
 @pytest.fixture(scope="module")
 def gateway_serial_port(request):
-    port = request.config.getoption("--gateway-port")
-    if not port:
-        pytest.fail("--gateway-port not set")
-    return port
+    return request.config.getoption("--gateway-port")
 
 
 @pytest.fixture(scope="module")
@@ -238,10 +235,17 @@ def _wait_for_gateway_ready(status_queue: queue.Queue[object], log_path: Path) -
 
 
 @pytest.fixture(scope="module", autouse=True)
-def provisioned_gateway(
-    gateway_serial_port, gateway_creds_dir, gateway_creds, gateway_log_path
-):
+def provisioned_gateway(request, gateway_serial_port):
+    if not gateway_serial_port:
+        logging.info("No gateway port configured; skipping gateway provisioning")
+        yield
+        return
+
     logging.info("Uploading gateway credentials via smpmgr")
+
+    request.getfixturevalue("gateway_creds")  # Need to generate the gateway credentials
+    creds_dir = request.getfixturevalue("gateway_creds_dir")
+    log_path = request.getfixturevalue("gateway_log_path")
 
     for local_name, remote_path in [
         ("crt.der", "/lfs1/credentials/crt.der"),
@@ -254,7 +258,7 @@ def provisioned_gateway(
                 gateway_serial_port,
                 "file",
                 "upload",
-                str(gateway_creds_dir / local_name),
+                str(creds_dir / local_name),
                 remote_path,
             ],
             check=True,
@@ -273,13 +277,13 @@ def provisioned_gateway(
         check=True,
     )
 
-    logging.info("Starting gateway serial capture to %s", gateway_log_path)
+    logging.info("Starting gateway serial capture to %s", log_path)
 
-    with _capture_gateway_output(gateway_serial_port, gateway_log_path) as status_queue:
+    with _capture_gateway_output(gateway_serial_port, log_path) as status_queue:
         logging.info(
             "Waiting for gateway ready pattern: %s",
             _GATEWAY_READY_PATTERN.decode(),
         )
-        _wait_for_gateway_ready(status_queue, gateway_log_path)
+        _wait_for_gateway_ready(status_queue, log_path)
         logging.info("Gateway provisioned and ready")
         yield

--- a/scripts/pytest-pouch/pytest_pouch/ota_harness.py
+++ b/scripts/pytest-pouch/pytest_pouch/ota_harness.py
@@ -23,33 +23,50 @@ def artifacts_to_cleanup() -> list:
     return []
 
 
-@pytest.fixture(scope="module", autouse=True)
-def check_ota_conflict(request: pytest.FixtureRequest):
-    if request.config.getoption("--fw-update-bin") and request.config.getoption(
-        "--ota-dummy-binary"
-    ):
-        pytest.fail("--fw-update-bin and --ota-dummy-binary are mutually exclusive")
+@pytest.fixture(scope="module")
+def ota_mode(request: pytest.FixtureRequest) -> str:
+    """Selected OTA mode (``dummy``, ``firmware``, or ``disabled``)."""
+    return request.config.getoption("--ota-mode")
 
 
 @pytest.fixture(scope="module")
-def fw_update_ver(request: pytest.FixtureRequest) -> str:
-    version = request.config.getoption("--fw-update-ver")
-    if not version:
-        if request.config.getoption("--ota-dummy-binary"):
-            return "dummy_ver"
-        else:
-            pytest.fail("--fw-update-ver not provided")
-    return version
+def fw_update_ver(request: pytest.FixtureRequest, ota_mode: str) -> str:
+    if ota_mode == "dummy":
+        return "dummy_ver"
+    cli = request.config.getoption("--fw-update-ver")
+    if cli:
+        return cli
+    try:
+        ver = request.getfixturevalue("fw_update_version")
+        if ver is not None:
+            return ver
+    except pytest.FixtureLookupError:
+        pass
+    pytest.fail(
+        "Firmware update version not provided. Pass --fw-update-ver via "
+        "--pytest-args, use --ota-mode=dummy, or load a harness plugin that "
+        "defines the fw_update_version fixture."
+    )
 
 
 @pytest.fixture(scope="module")
-def pouch_ota_package(request: pytest.FixtureRequest) -> str:
-    package = request.config.getoption("--fw-update-pkg-name")
-    if not package:
-        if request.config.getoption("--ota-dummy-binary"):
-            return "ci_ota_fw"
-        pytest.fail("--fw-update-pkg-name not provided")
-    return package
+def pouch_ota_package(request: pytest.FixtureRequest, ota_mode: str) -> str:
+    if ota_mode == "dummy":
+        return "ci_ota_fw"
+    cli = request.config.getoption("--fw-update-pkg-name")
+    if cli:
+        return cli
+    try:
+        pkg = request.getfixturevalue("fw_update_package")
+        if pkg is not None:
+            return pkg
+    except pytest.FixtureLookupError:
+        pass
+    pytest.fail(
+        "OTA package name not provided. Pass --fw-update-pkg-name via "
+        "--pytest-args, use --ota-mode=dummy, or load a harness plugin that "
+        "defines the fw_update_package fixture."
+    )
 
 
 @pytest.fixture(scope="module")
@@ -89,50 +106,9 @@ async def ota_update(
     artifacts_to_cleanup,
     tmp_path_factory,
     fw_update_ver,
+    ota_mode: str,
 ) -> str:
-    fw_bin_path = request.config.getoption("--fw-update-bin")
-
-    if fw_bin_path:
-        fw_bin = Path(fw_bin_path)
-
-        existing_artifacts = await project.artifacts.get_all()
-        matching = [
-            a
-            for a in existing_artifacts
-            if a.package == pouch_ota_package and a.version == fw_update_ver
-        ]
-
-        if matching:
-            artifact = matching[0]
-            logging.info(
-                "Found existing artifact (id=%s) for package=%s, version=%s — skipping upload",
-                artifact.id,
-                pouch_ota_package,
-                fw_update_ver,
-            )
-            artifacts_to_cleanup.append(artifact.id)
-        else:
-            logging.info(
-                "Uploading OTA artifact: %s, version=%s, package=%s",
-                fw_bin,
-                fw_update_ver,
-                pouch_ota_package,
-            )
-            artifact = await project.artifacts.upload(
-                path=fw_bin,
-                version=fw_update_ver,
-                package=pouch_ota_package,
-            )
-            artifacts_to_cleanup.append(artifact.id)
-
-        logging.info("Creating deployment on cohort '%s'", ota_cohort.name)
-        await ota_cohort.deployments.create(
-            f"ota-test-{device.name}-{test_id}",
-            [artifact.id],
-        )
-
-        yield fw_update_ver
-    elif request.config.getoption("--ota-dummy-binary"):
+    if ota_mode == "dummy":
         import hashlib
         import os
 
@@ -165,5 +141,57 @@ async def ota_update(
         )
 
         yield expected_sha256
+        return
+
+    fw_bin_cli = request.config.getoption("--fw-update-bin")
+    if fw_bin_cli:
+        fw_bin = Path(fw_bin_cli)
     else:
-        pytest.fail("either --fw-update-bin or --ota-dummy-binary must be provided")
+        try:
+            fw_bin = request.getfixturevalue("fw_update_bin")
+        except pytest.FixtureLookupError:
+            fw_bin = None
+        if fw_bin is None:
+            pytest.fail(
+                "Firmware update binary not provided. Pass --fw-update-bin via "
+                "--pytest-args, use --ota-mode=dummy, or load a harness plugin "
+                "that defines the fw_update_bin fixture."
+            )
+
+    existing_artifacts = await project.artifacts.get_all()
+    matching = [
+        a
+        for a in existing_artifacts
+        if a.package == pouch_ota_package and a.version == fw_update_ver
+    ]
+
+    if matching:
+        artifact = matching[0]
+        logging.info(
+            "Found existing artifact (id=%s) for package=%s, version=%s — skipping upload",
+            artifact.id,
+            pouch_ota_package,
+            fw_update_ver,
+        )
+        artifacts_to_cleanup.append(artifact.id)
+    else:
+        logging.info(
+            "Uploading OTA artifact: %s, version=%s, package=%s",
+            fw_bin,
+            fw_update_ver,
+            pouch_ota_package,
+        )
+        artifact = await project.artifacts.upload(
+            path=fw_bin,
+            version=fw_update_ver,
+            package=pouch_ota_package,
+        )
+        artifacts_to_cleanup.append(artifact.id)
+
+    logging.info("Creating deployment on cohort '%s'", ota_cohort.name)
+    await ota_cohort.deployments.create(
+        f"ota-test-{device.name}-{test_id}",
+        [artifact.id],
+    )
+
+    yield fw_update_ver

--- a/scripts/pytest-pouch/pytest_pouch/plugin.py
+++ b/scripts/pytest-pouch/pytest_pouch/plugin.py
@@ -47,11 +47,46 @@ def pytest_addoption(parser):
         help="OTA package name for the firmware update artifact (required for OTA tests)",
     )
     parser.addoption(
-        "--ota-dummy-binary",
-        action="store_true",
-        default=False,
-        help="Generate a dummy OTA binary for SHA256 verification",
+        "--ota-mode",
+        choices=("dummy", "firmware", "disabled"),
+        default="firmware",
+        help=(
+            "OTA test mode: 'firmware' (default; real update binary), "
+            "'dummy' (random bytes, SHA256 verification), or 'disabled' "
+            "(deselect all OTA-marked tests)."
+        ),
     )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "ota_mode(mode): restrict the test to a specific OTA mode "
+        "('dummy' or 'firmware'); respected when --ota-mode is 'dummy' or "
+        "'firmware'. When --ota-mode=disabled, all OTA-marked tests are "
+        "deselected.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    selected = config.getoption("--ota-mode")
+    keep: list = []
+    drop: list = []
+    for item in items:
+        marker = item.get_closest_marker("ota_mode")
+        if selected == "disabled":
+            if marker is None:
+                keep.append(item)
+            else:
+                drop.append(item)
+        else:
+            if marker is None or marker.args[0] == selected:
+                keep.append(item)
+            else:
+                drop.append(item)
+    if drop:
+        config.hook.pytest_deselected(items=drop)
+    items[:] = keep
 
 
 @pytest.fixture(scope="session")

--- a/scripts/pytest-pouch/pytest_pouch/plugin.py
+++ b/scripts/pytest-pouch/pytest_pouch/plugin.py
@@ -10,6 +10,15 @@ from pathlib import Path
 
 import pytest
 
+_OTA_MODES = {
+    "firmware": "default; real update binary",
+    "dummy": "random bytes, SHA256 verification",
+    "disabled": "deselect all OTA-marked tests",
+}
+_OTA_MODES_DEFAULT = "firmware"
+_OTA_MARKER_VALUES = frozenset(_OTA_MODES) - {"disabled"}
+_OTA_MODES_VALID_STR = ", ".join(repr(m) for m in sorted(_OTA_MARKER_VALUES))
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -46,12 +55,63 @@ def pytest_addoption(parser):
         type=str,
         help="OTA package name for the firmware update artifact (required for OTA tests)",
     )
-    parser.addoption(
-        "--ota-dummy-binary",
-        action="store_true",
-        default=False,
-        help="Generate a dummy OTA binary for SHA256 verification",
+
+    mode_values_str = ", ".join(
+        f"'{mode}' ({desc})" for mode, desc in _OTA_MODES.items()
     )
+    parser.addoption(
+        "--ota-mode",
+        choices=tuple(_OTA_MODES),
+        default=_OTA_MODES_DEFAULT,
+        help=f"OTA test mode: {mode_values_str}",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "ota_mode(mode): restrict the test to a specific OTA mode "
+        f"({_OTA_MODES_VALID_STR}); respected when --ota-mode is one of "
+        f"({_OTA_MODES_VALID_STR}). When --ota-mode=disabled, all "
+        "OTA-marked tests are deselected.",
+    )
+
+
+def _ota_mode_extract_and_validate(item) -> str | None:
+    marker = item.get_closest_marker("ota_mode")
+    if marker is None:
+        return None
+    if len(marker.args) != 1:
+        raise pytest.UsageError(
+            f"Invalid ota_mode marker for {item.nodeid}: "
+            f"expected exactly one argument, got {len(marker.args)}"
+        )
+    if len(marker.kwargs) != 0:
+        raise pytest.UsageError(
+            f"Invalid ota_mode marker for {item.nodeid}: "
+            f"expected zero kwargs, got {len(marker.kwargs)}"
+        )
+    if marker.args[0] not in _OTA_MARKER_VALUES:
+        raise pytest.UsageError(
+            f"Invalid ota_mode marker for {item.nodeid}: "
+            f"'{marker.args[0]!r}' not a valid option ({_OTA_MODES_VALID_STR})"
+        )
+    return marker.args[0]
+
+
+def pytest_collection_modifyitems(config, items):
+    selected = config.getoption("--ota-mode")
+    keep: list = []
+    drop: list = []
+    for item in items:
+        mode = _ota_mode_extract_and_validate(item)
+        if mode is None or mode == selected:
+            keep.append(item)
+        else:
+            drop.append(item)
+    if drop:
+        config.hook.pytest_deselected(items=drop)
+    items[:] = keep
 
 
 @pytest.fixture(scope="session")

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_harness.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_harness.py
@@ -5,8 +5,10 @@
 #
 
 import logging
+import re
 import subprocess
 import time
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +18,76 @@ _SIMULATOR_PLATFORMS = {
     "native_sim/native/64",
     "nrf52_bsim/native",
 }
+
+
+def _read_kconfig_value(config_path: Path, key: str) -> str | None:
+    """Read a string Kconfig value from a Zephyr build's ``.config``."""
+    if not config_path.exists():
+        return None
+    pattern = re.compile(rf'^{re.escape(key)}="([^"]*)"$', re.MULTILINE)
+    match = pattern.search(config_path.read_text())
+    return match.group(1) if match else None
+
+
+def _twister_out_dir(device_object) -> Path:
+    """Find the Twister output directory containing this test build."""
+    build_dir = Path(device_object.device_config.build_dir)
+    for candidate in (build_dir, *build_dir.parents):
+        if (candidate / "testplan.json").is_file():
+            return candidate
+    pytest.fail(f"Could not locate Twister output directory above {build_dir}")
+
+
+def _fw_update_bins_root(device_object) -> Path:
+    """Compute the fw_update_bins extraction root for the current test's build."""
+    return _twister_out_dir(device_object) / "fw_update_bins"
+
+
+@pytest.fixture(scope="module")
+def fw_update_bin(request, device_object) -> Path | None:
+    """Resolve OTA update binary path from the twister build context.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-bin``) takes precedence when provided.
+    """
+    bin_cli = request.config.getoption("--fw-update-bin")
+    if bin_cli:
+        return Path(bin_cli)
+    twister_root = _twister_out_dir(device_object)
+    original_bin = (
+        device_object.device_config.app_build_dir / "zephyr" / "zephyr.signed.bin"
+    )
+    return _fw_update_bins_root(device_object) / original_bin.relative_to(twister_root)
+
+
+@pytest.fixture(scope="module")
+def fw_update_version(request, device_object) -> str | None:
+    """Resolve OTA update version from the twister build context.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-ver``) takes precedence when provided.
+    """
+    ver_cli = request.config.getoption("--fw-update-ver")
+    if ver_cli:
+        return ver_cli
+    version_path = _fw_update_bins_root(device_object) / "update-ver-num.txt"
+    if version_path.exists():
+        return version_path.read_text().strip()
+    return None
+
+
+@pytest.fixture(scope="module")
+def fw_update_package(request, device_object) -> str | None:
+    """Resolve OTA package name from the twister build's ``.config``.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-pkg-name``) takes precedence when provided.
+    """
+    pkg_cli = request.config.getoption("--fw-update-pkg-name")
+    if pkg_cli:
+        return pkg_cli
+    config_path = device_object.device_config.app_build_dir / "zephyr" / ".config"
+    return _read_kconfig_value(config_path, "CONFIG_EXAMPLE_FW_UPDATE_COMPONENT")
 
 
 def _upload_credentials(serial_port, creds_dir):

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_harness.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_harness.py
@@ -5,8 +5,10 @@
 #
 
 import logging
+import re
 import subprocess
 import time
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +18,79 @@ _SIMULATOR_PLATFORMS = {
     "native_sim/native/64",
     "nrf52_bsim/native",
 }
+
+
+def _read_kconfig_value(config_path: Path, key: str) -> str | None:
+    """Read a string Kconfig value from a Zephyr build's ``.config``."""
+    if not config_path.exists():
+        return None
+    pattern = re.compile(rf'^{re.escape(key)}="([^"]*)"$', re.MULTILINE)
+    match = pattern.search(config_path.read_text())
+    return match.group(1) if match else None
+
+
+def _fw_update_bins_root(device_object) -> Path:
+    """Compute the fw_update_bins extraction root for the current test's build."""
+    app_build_dir = device_object.device_config.app_build_dir
+    parts = app_build_dir.parts
+    try:
+        idx = parts.index("twister-out")
+    except ValueError:
+        pytest.fail(f"Expected 'twister-out' in build path: {app_build_dir}")
+    return Path(*parts[:idx], "twister-out", "fw_update_bins")
+
+
+@pytest.fixture(scope="module")
+def fw_update_bin(request, device_object) -> Path | None:
+    """Resolve OTA update binary path from the twister build context.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-bin``) takes precedence when provided.
+    """
+    bin_cli = request.config.getoption("--fw-update-bin")
+    if bin_cli:
+        return Path(bin_cli)
+    parts = device_object.device_config.app_build_dir.parts
+    try:
+        idx = parts.index("twister-out")
+    except ValueError:
+        return None
+    root = _fw_update_bins_root(device_object)
+    original_bin = (
+        device_object.device_config.app_build_dir / "zephyr" / "zephyr.signed.bin"
+    )
+    rel = Path(*original_bin.parts[idx + 1 :])
+    return root / rel
+
+
+@pytest.fixture(scope="module")
+def fw_update_version(request, device_object) -> str | None:
+    """Resolve OTA update version from the twister build context.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-ver``) takes precedence when provided.
+    """
+    ver_cli = request.config.getoption("--fw-update-ver")
+    if ver_cli:
+        return ver_cli
+    version_path = _fw_update_bins_root(device_object) / "update-ver-num.txt"
+    if version_path.exists():
+        return version_path.read_text().strip()
+    return None
+
+
+@pytest.fixture(scope="module")
+def fw_update_package(request, device_object) -> str | None:
+    """Resolve OTA package name from the twister build's ``.config``.
+
+    Overrides the default in ``ota_harness``. CLI override
+    (``--fw-update-pkg-name``) takes precedence when provided.
+    """
+    pkg_cli = request.config.getoption("--fw-update-pkg-name")
+    if pkg_cli:
+        return pkg_cli
+    config_path = device_object.device_config.app_build_dir / "zephyr" / ".config"
+    return _read_kconfig_value(config_path, "CONFIG_EXAMPLE_FW_UPDATE_COMPONENT")
 
 
 def _upload_credentials(serial_port, creds_dir):

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_ota_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_ota_tests.py
@@ -12,6 +12,10 @@ from twister_harness.device.device_adapter import DeviceAdapter
 
 pytestmark = pytest.mark.anyio
 
+OTA_DOWNLINK_TIMEOUT_S = 120.0
+OTA_DOWNLOAD_TIMEOUT_S = 180.0
+OTA_REBOOT_TIMEOUT_S = 180.0
+
 
 @pytest.mark.ota_mode("dummy")
 async def test_ota_sha256(dut: DeviceAdapter, ota_update):
@@ -19,7 +23,7 @@ async def test_ota_sha256(dut: DeviceAdapter, ota_update):
 
     logging.info("Waiting for OTA download, expected SHA256=%s", expected_sha256)
     lines = dut.readlines_until(
-        regex=r"OTA computed SHA256: [0-9a-f]{64}", timeout=180.0
+        regex=r"OTA computed SHA256: [0-9a-f]{64}", timeout=OTA_DOWNLOAD_TIMEOUT_S
     )
 
     actual_sha256 = None
@@ -36,4 +40,35 @@ async def test_ota_sha256(dut: DeviceAdapter, ota_update):
 
     assert actual_sha256 == expected_sha256, (
         f"SHA256 mismatch: device={actual_sha256}, expected={expected_sha256}"
+    )
+
+
+@pytest.mark.ota_mode("firmware")
+async def test_ota_firmware_update(
+    dut: DeviceAdapter,
+    ota_update,
+    fw_update_ver,
+):
+    dut.readlines_until(
+        regex=".*Receiving Downlink entry on path.*", timeout=OTA_DOWNLINK_TIMEOUT_S
+    )
+
+    dut.readlines_until(
+        regex=".*fw_update: Rebooting to apply upgrade",
+        timeout=OTA_DOWNLOAD_TIMEOUT_S,
+    )
+
+    dut.readlines_until(
+        regex=rf".*Image version: v{re.escape(fw_update_ver)}",
+        timeout=OTA_REBOOT_TIMEOUT_S,
+    )
+
+    dut.readlines_until(
+        regex=".*Credentials loaded.*",
+        timeout=OTA_DOWNLINK_TIMEOUT_S,
+    )
+
+    dut.readlines_until(
+        regex=r".*Received LED setting: [0-1]",
+        timeout=OTA_DOWNLINK_TIMEOUT_S,
     )

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_ota_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_ota_tests.py
@@ -13,6 +13,7 @@ from twister_harness.device.device_adapter import DeviceAdapter
 pytestmark = pytest.mark.anyio
 
 
+@pytest.mark.ota_mode("dummy")
 async def test_ota_sha256(dut: DeviceAdapter, ota_update):
     expected_sha256 = ota_update
 

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_ota_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_ota_tests.py
@@ -12,6 +12,7 @@ from twister_harness.device.device_adapter import DeviceAdapter
 
 pytestmark = pytest.mark.anyio
 
+OTA_DEFAULT_TIMEOUT_S = 60.0
 OTA_DOWNLINK_TIMEOUT_S = 120.0
 OTA_DOWNLOAD_TIMEOUT_S = 180.0
 OTA_REBOOT_TIMEOUT_S = 180.0
@@ -65,10 +66,10 @@ async def test_ota_firmware_update(
 
     dut.readlines_until(
         regex=".*Credentials loaded.*",
-        timeout=OTA_DOWNLINK_TIMEOUT_S,
+        timeout=OTA_DEFAULT_TIMEOUT_S,
     )
 
     dut.readlines_until(
         regex=r".*Received LED setting: [0-1]",
-        timeout=OTA_DOWNLINK_TIMEOUT_S,
+        timeout=OTA_DEFAULT_TIMEOUT_S,
     )

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_settings_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_settings_tests.py
@@ -35,11 +35,11 @@ async def setup(project, device, creds):
 
 
 async def test_setting_project(dut: DeviceAdapter):
-    dut.readlines_until(regex="Received LED setting: 0", timeout=120.0)
+    dut.readlines_until(regex="Received LED setting: 0", timeout=60.0)
 
 
 async def test_setting_device(device, dut: DeviceAdapter):
     logging.info("Set device-level setting")
     await device.settings.set("LED", True)
 
-    dut.readlines_until(regex="Received LED setting: 1", timeout=120.0)
+    dut.readlines_until(regex="Received LED setting: 1", timeout=60.0)

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_stream_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_stream_tests.py
@@ -8,6 +8,7 @@ import datetime
 
 import anyio
 import pytest
+from twister_harness.device.device_adapter import DeviceAdapter
 
 pytestmark = pytest.mark.anyio
 
@@ -19,7 +20,7 @@ def _iso8601_utc(timestamp: datetime.datetime) -> str:
     return timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-async def test_sensor_stream_uplink(device):
+async def test_sensor_stream_uplink(device, dut: DeviceAdapter):
     start_time = datetime.datetime.now(datetime.UTC)
 
     latest_payload = None

--- a/scripts/pytest-pouch/pytest_pouch/zephyr_stream_tests.py
+++ b/scripts/pytest-pouch/pytest_pouch/zephyr_stream_tests.py
@@ -11,7 +11,7 @@ import pytest
 
 pytestmark = pytest.mark.anyio
 
-_STREAM_POLL_ATTEMPTS = 24
+_STREAM_POLL_ATTEMPTS = 12
 _STREAM_POLL_DELAY_S = 5.0
 
 


### PR DESCRIPTION
Adds a fw_update test to the Zephyr HIL run. Currently frdm_rw612 on http_client is the only supported target but the implementation has been designed to scale.

1. Refactor pytest fw_update flags, removing --ota-dummy-binary in favor of `--ota-mode=[firmware | dummy | disabled]`
2. Update ESP-IDF harness and tests to use new flag approach
3. Add fw_update test to zephyr_ota_tests.py; pytest.mark.ota_mode is used to select between tests
4. Add workflow for fw_update HIL test
    1. Cloud update bin collision (component name and version) is avoided by leveraging the harness to generate a per-sample name.
    2. Use the short hash to generate a imgtool compatible version number
    3. Replace the VERSION files and rerun twister build step too generate update binaries
5. Use -vv instead of -v for better twister CI clarity
6. Revise pytest documentation for ESP-IDF to reflect repo changes and fw_update

resolves https://github.com/golioth/firmware-issue-tracker/issues/1060