### PR TITLE
ci: capture and upload BLE gateway logs during HIL tests

### DIFF
--- a/.github/workflows/test-esp-idf-hil.yml
+++ b/.github/workflows/test-esp-idf-hil.yml
@@ -173,7 +173,10 @@ jobs:
       - name: Clean stale run assets
         run: |
           rm -rf "$SAMPLE_DIR/build"
-          rm -f "$UNITY_REPORT_NAME" "pytest-${{ matrix.name }}-hil.log"
+          rm -f \
+            "$UNITY_REPORT_NAME" \
+            "pytest-${{ matrix.name }}-hil.log" \
+            "gateway-${{ matrix.name }}.log"
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -259,12 +262,17 @@ jobs:
             WIFI_ARGS="--wifi-ssid $WIFI_SSID --wifi-psk $WIFI_PSK"
           fi
 
-          GATEWAY_PORT_ARG=""
+          GATEWAY_ARGS=()
           if [ "$SAMPLE_NAME" == "ble_gatt" ]; then
             GW_PORT_VAR=CI_FRDM_RW612_PORT
-            if [ -n "${!GW_PORT_VAR}" ]; then
-              GATEWAY_PORT_ARG="--gateway-port ${!GW_PORT_VAR}"
+            if [ -z "${!GW_PORT_VAR}" ]; then
+              echo "Runner environment variable '$GW_PORT_VAR' is not set"
+              exit 1
             fi
+            GATEWAY_ARGS=(
+              --gateway-port "${!GW_PORT_VAR}"
+              --gateway-log-file "gateway-${SAMPLE_NAME}.log"
+            )
           fi
 
           pytest -vv -rs -s                  \
@@ -282,7 +290,7 @@ jobs:
             --api-url "$GOLIOTH_API_URL"     \
             --api-key "$GOLIOTH_API_KEY"     \
             $WIFI_ARGS                       \
-            $GATEWAY_PORT_ARG                \
+            "${GATEWAY_ARGS[@]}"             \
             --generate-certs                 \
             --junit-xml "$UNITY_REPORT_NAME" \
             "$SAMPLE_DIR/pytest/test_sample.py" | tee pytest-${{ matrix.name }}-hil.log
@@ -309,6 +317,7 @@ jobs:
           path: |
             pytest-${{ matrix.name }}-hil.log
             ${{ env.UNITY_REPORT_NAME }}
+            gateway-${{ matrix.name }}.log
 
       - name: Erase flash
         if: always()

--- a/requirements-ci-esp-idf.in
+++ b/requirements-ci-esp-idf.in
@@ -5,6 +5,7 @@ pyparsing>=3.1.0,<3.3
 rich<16
 anyio>=4.0.0,<5
 smpmgr>=0.18.0
+pyserial
 
 # Workaround for anyio dependency:
 # https://github.com/agronholm/anyio/blob/2370032396438b0279bacb3ff2f5c4ae2886f0d0/pyproject.toml#L32

--- a/requirements-ci-esp-idf.txt
+++ b/requirements-ci-esp-idf.txt
@@ -631,6 +631,7 @@ pyserial==3.5 \
     --hash=sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb \
     --hash=sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0
     # via
+    #   -r requirements-ci-esp-idf.in
     #   esptool
     #   pytest-embedded-serial
     #   smpclient

--- a/scripts/pytest-pouch/pyproject.toml
+++ b/scripts/pytest-pouch/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
     "pytest",
     "anyio[trio]",
+    "pyserial",
 ]
 classifiers = [
     "Framework :: Pytest",

--- a/scripts/pytest-pouch/pytest_pouch/gateway_provision.py
+++ b/scripts/pytest-pouch/pytest_pouch/gateway_provision.py
@@ -5,11 +5,17 @@
 #
 
 import logging
+import queue
 import secrets
 import subprocess
-import time
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO
 
 import pytest
+import serial
 
 
 def pytest_addoption(parser):
@@ -18,6 +24,17 @@ def pytest_addoption(parser):
         type=str,
         help="Serial port for gateway provisioning",
     )
+    parser.addoption(
+        "--gateway-log-file",
+        type=Path,
+        default=Path("gateway.log"),
+        help="Path for captured gateway serial output",
+    )
+
+
+@pytest.fixture(scope="module")
+def gateway_log_path(request):
+    return request.config.getoption("--gateway-log-file").resolve()
 
 
 @pytest.fixture(scope="module")
@@ -114,8 +131,116 @@ def gateway_creds(creds, creds_dir, gateway_creds_dir, gateway_cloud_device, pro
     )
 
 
+_GATEWAY_READY_PATTERN = b"Scanning successfully started"
+_GATEWAY_READY = object()
+_GATEWAY_READY_TIMEOUT_S = 120.0
+_GATEWAY_BAUDRATE = 115_200
+_GATEWAY_READ_TIMEOUT_S = 0.5
+_GATEWAY_READER_JOIN_TIMEOUT_S = 5.0
+_GATEWAY_LOG_TAIL_BYTES = 200
+
+
+def _read_gateway_output(
+    gateway_serial: serial.Serial,
+    log_file: BinaryIO,
+    stop_event: threading.Event,
+    status_queue: queue.Queue[object],
+):
+    overlap = b""
+    ready = False
+
+    try:
+        while not stop_event.is_set():
+            data = gateway_serial.read(4096)
+            if not data:
+                continue
+
+            log_file.write(data)
+
+            if ready:
+                continue
+
+            marker_window = overlap + data
+            if _GATEWAY_READY_PATTERN in marker_window:
+                ready = True
+                status_queue.put(_GATEWAY_READY)
+                continue
+
+            overlap = marker_window[-(len(_GATEWAY_READY_PATTERN) - 1) :]
+    except Exception as error:
+        if stop_event.is_set():
+            return
+        if ready:
+            logging.exception("Gateway serial capture stopped")
+        else:
+            status_queue.put(error)
+
+
+@contextmanager
+def _capture_gateway_output(
+    serial_port: str, log_path: Path
+) -> Iterator[queue.Queue[object]]:
+    stop_event = threading.Event()
+    status_queue: queue.Queue[object] = queue.Queue()
+
+    with (
+        log_path.open("wb", buffering=0) as log_file,
+        serial.Serial(
+            serial_port,
+            baudrate=_GATEWAY_BAUDRATE,
+            timeout=_GATEWAY_READ_TIMEOUT_S,
+        ) as gateway_serial,
+    ):
+        reader = threading.Thread(
+            name="gateway-log-reader",
+            target=_read_gateway_output,
+            args=(gateway_serial, log_file, stop_event, status_queue),
+            daemon=True,
+        )
+        reader.start()
+
+        try:
+            yield status_queue
+        finally:
+            stop_event.set()
+            reader.join(timeout=_GATEWAY_READER_JOIN_TIMEOUT_S)
+            if reader.is_alive():
+                logging.error(
+                    "Gateway serial reader did not stop within %.1fs",
+                    _GATEWAY_READER_JOIN_TIMEOUT_S,
+                )
+
+
+def _gateway_log_tail(log_path: Path) -> str:
+    with log_path.open("rb") as log_file:
+        log_file.seek(0, 2)
+        log_file.seek(max(0, log_file.tell() - _GATEWAY_LOG_TAIL_BYTES))
+        return log_file.read(_GATEWAY_LOG_TAIL_BYTES).decode(errors="replace")
+
+
+def _wait_for_gateway_ready(status_queue: queue.Queue[object], log_path: Path) -> None:
+    try:
+        status = status_queue.get(timeout=_GATEWAY_READY_TIMEOUT_S)
+    except queue.Empty:
+        pytest.fail(
+            f"Gateway failed to start scanning within {_GATEWAY_READY_TIMEOUT_S:g}s. "
+            f"Last captured output: {_gateway_log_tail(log_path)}\n"
+            f"Full gateway log: {log_path}"
+        )
+
+    if status is _GATEWAY_READY:
+        return
+    if isinstance(status, Exception):
+        raise RuntimeError(
+            f"Gateway serial capture failed before readiness; output is in {log_path}"
+        ) from status
+    raise RuntimeError(f"Unexpected gateway capture status: {status!r}")
+
+
 @pytest.fixture(scope="module", autouse=True)
-def provisioned_gateway(gateway_serial_port, gateway_creds_dir, gateway_creds):
+def provisioned_gateway(
+    gateway_serial_port, gateway_creds_dir, gateway_creds, gateway_log_path
+):
     logging.info("Uploading gateway credentials via smpmgr")
 
     for local_name, remote_path in [
@@ -148,7 +273,13 @@ def provisioned_gateway(gateway_serial_port, gateway_creds_dir, gateway_creds):
         check=True,
     )
 
-    logging.info("Waiting for gateway to reboot")
-    time.sleep(30)
+    logging.info("Starting gateway serial capture to %s", gateway_log_path)
 
-    yield
+    with _capture_gateway_output(gateway_serial_port, gateway_log_path) as status_queue:
+        logging.info(
+            "Waiting for gateway ready pattern: %s",
+            _GATEWAY_READY_PATTERN.decode(),
+        )
+        _wait_for_gateway_ready(status_queue, gateway_log_path)
+        logging.info("Gateway provisioned and ready")
+        yield


### PR DESCRIPTION
This is an alternative implementation to #323. It addresses the same flaky BLE HIL failures by:

1. Capturing raw gateway serial output for the complete pytest module and uploading it as `gateway-ble_gatt.log`
2. Waiting for `Scanning successfully started` before yielding the gateway fixture, which occurs only after initial cloud setup succeeds
3. Cleaning stale gateway logs before each run so failures cannot upload output from an earlier self-hosted runner job

Unlike #323, readiness is detected directly from incoming bytes instead of polling and decoding a growing log file. Reader failures are propagated to the fixture, split markers are handled across serial reads, timeout diagnostics are bounded to the final 200 bytes, and a context manager owns serial, file, and thread cleanup.

The workflow passes an explicit matrix-specific log path, preserves argument boundaries with a Bash array, and declares `pyserial` directly. Runtime behavior is validated by the existing ESP-IDF BLE HIL job.