### PR TITLE
ci: add grouped Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - /
+      - /.github/actions/safe-upload-artifacts
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-root:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /scripts/pytest-pouch
+    schedule:
+      interval: weekly
+    groups:
+      pytest-pouch:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
Automate weekly dependency maintenance for workflows, the nested composite
action, root Python requirements, pytest-pouch, and pre-commit while
keeping unrelated dependency families in separate pull requests.

Group each scope to limit update noise. Root Python updates may need their
uv-generated lock files repaired before merge. Leave the zcbor Git
submodule and unsupported firmware manifests manually managed.