### PR TITLE
Change CI to run on `pull_request_target`

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
With the "Require approval for all external contributors" flag set for the repo, and the token permissions being set to `content: read` and `actions: write`, I believe this should be perfectly safe for us, and allows fork PRs to run CI - automatically for us and upon approval for external contributors.