### PR TITLE
Fix uplink session key memory leak

### DIFF
--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -19,9 +19,16 @@ static struct session uplink;
 
 int saead_uplink_session_start(psa_algorithm_t algorithm, psa_key_id_t private_key)
 {
+    if (pouch_atomic_test_and_set_bit(&uplink.flags, SESSION_ACTIVE))
+    {
+        POUCH_LOG_WRN("Already in a session");
+        return -EBUSY;
+    }
+
     struct pubkey pubkey;
 
-    uplink.flags = POUCH_ATOMIC_INIT(0);
+    pouch_atomic_clear_bit(&uplink.flags, SESSION_HAS_POUCH);
+    pouch_atomic_clear_bit(&uplink.flags, SESSION_VALID);
 
     // Sequential IDs require replay protection, which isn't supported yet:
     uplink.id.type = SESSION_ID_TYPE_RANDOM;
@@ -30,6 +37,7 @@ int saead_uplink_session_start(psa_algorithm_t algorithm, psa_key_id_t private_k
     if (err)
     {
         POUCH_LOG_ERR("Session ID generation failed (err: %d)", err);
+        pouch_atomic_clear_bit(&uplink.flags, SESSION_ACTIVE);
         return err;
     }
 
@@ -44,13 +52,13 @@ int saead_uplink_session_start(psa_algorithm_t algorithm, psa_key_id_t private_k
     if (PSA_KEY_ID_NULL == uplink.key)
     {
         POUCH_LOG_ERR("Session key generation failed");
+        pouch_atomic_clear_bit(&uplink.flags, SESSION_ACTIVE);
         return -ENOENT;
     }
 
     uplink.algorithm = algorithm;
     uplink.pouch.id = 0;
     pouch_atomic_set_bit(&uplink.flags, SESSION_VALID);
-    pouch_atomic_set_bit(&uplink.flags, SESSION_ACTIVE);
 
     return 0;
 }

--- a/src/uplink.c
+++ b/src/uplink.c
@@ -195,6 +195,7 @@ struct pouch_uplink *pouch_uplink_start(void)
     if (err)
     {
         pouch_atomic_clear_bit(uplink.flags, SESSION_ACTIVE);
+        crypto_session_end();
         return NULL;
     }
 
@@ -203,6 +204,7 @@ struct pouch_uplink *pouch_uplink_start(void)
     if (!uplink.header)
     {
         pouch_atomic_clear_bit(uplink.flags, SESSION_ACTIVE);
+        crypto_session_end();
         return NULL;
     }
 


### PR DESCRIPTION
When we start the uplink session, we run a few setup functions in a row that may fail, but we don't free the session key if the setup fails after starting the session.

Starts checking and setting the `SESSION_ACTIVE` flag in the saead session, to avoid silently dropping the psa key slot by starting a new session before cleaning up the last one.