### PR TITLE
Downlink replay protection rework

### DIFF
--- a/src/saead/downlink.c
+++ b/src/saead/downlink.c
@@ -20,6 +20,8 @@ POUCH_LOG_REGISTER(saead_downlink, CONFIG_POUCH_COMMON_LOG_LEVEL);
 static struct session downlink;
 static struct
 {
+    // Whether we have received a valid sequence number from the server
+    bool has_seqnum;
     /**
      * Highest sequence number we've seen the server create a session with.
      * If replay protection isn't enabled, we can still use this to ensure that the server hasn't
@@ -28,6 +30,7 @@ static struct
      * replay attacks.
      */
     uint64_t seqnum;
+
     /**
      * Highest pouch ID we've seen the server send in the current session. Is only updated once
      * at least one block of the pouch is decrypted.
@@ -36,26 +39,34 @@ static struct
 } server;
 
 /** Check that this session is a valid follow up to the previous downlink session */
-static bool is_valid_downlink(const struct session_id *id, psa_algorithm_t algorithm)
+static bool is_valid_downlink(const struct session_id *id,
+                              uint8_t max_block_size_log,
+                              psa_algorithm_t algorithm)
 {
-    if (!pouch_atomic_test_bit(&downlink.flags, SESSION_VALID))
+    if (id->initiator == POUCH_ROLE_DEVICE)
     {
-        // No previous session to invalidate the incoming session
+        if (id->type != SESSION_ID_TYPE_SEQUENTIAL)
+        {
+            // The server can only use our session if it's a sequential session ID
+            POUCH_LOG_ERR("Session reuse failed: ID not sequential");
+            return false;
+        }
+
+        if (!saead_uplink_session_matches(id, max_block_size_log, algorithm))
+        {
+            // The server claims to use our uplink's session, but it doesn't match
+            POUCH_LOG_ERR("Session reuse failed: No match");
+            return false;
+        }
+
         return true;
     }
 
-    if (session_id_is_equal(&downlink.id, id) && downlink.algorithm != algorithm)
+    // server initiated, sequential ID:
+    if (id->type == SESSION_ID_TYPE_SEQUENTIAL)
     {
-        // Session ID is unchanged, parameters must be identical
-        POUCH_LOG_ERR("Algorithm doesn't match");
-        return false;
-    }
-
-    if (id->initiator == POUCH_ROLE_SERVER)
-    {
-        // This was initiated by the server. If it's sequential, we can validate the sequence
-        // number.
-        if (id->type == SESSION_ID_TYPE_SEQUENTIAL && id->value.sequential.seqnum <= server.seqnum)
+        // seqnum must be increasing:
+        if (server.has_seqnum && id->value.sequential.seqnum <= server.seqnum)
         {
             POUCH_LOG_ERR("Old seqnum: %" PRIu64 " (was %" PRIu64 ")",
                           id->value.sequential.seqnum,
@@ -74,7 +85,21 @@ int saead_downlink_session_start(const struct session_id *id,
 {
     psa_key_id_t session_key;
 
-    if (!is_valid_downlink(id, algorithm))
+    int match = session_match(&downlink, id, max_block_size_log, algorithm);
+    if (match < 0)
+    {
+        POUCH_LOG_ERR("Session parameter changed");
+        return -EBADMSG;
+    }
+
+    if (match && pouch_atomic_test_bit(&downlink.flags, SESSION_ACTIVE))
+    {
+        // This is the current session. We already have a session key, and shouldn't
+        // recalculate or reset anything.
+        return 0;
+    }
+
+    if (!is_valid_downlink(id, max_block_size_log, algorithm))
     {
         POUCH_LOG_ERR("Invalid downlink");
         return -EBADMSG;
@@ -82,20 +107,6 @@ int saead_downlink_session_start(const struct session_id *id,
 
     if (id->initiator == POUCH_ROLE_DEVICE)
     {
-        if (id->type != SESSION_ID_TYPE_SEQUENTIAL)
-        {
-            // The server can only use our session if it's a sequential session ID
-            POUCH_LOG_ERR("Session reuse failed: ID not sequential");
-            return -EBADMSG;
-        }
-
-        if (!saead_uplink_session_matches(id, max_block_size_log, algorithm))
-        {
-            // The server claims to use our uplink's session, but it doesn't match
-            POUCH_LOG_ERR("Session reuse failed: No match");
-            return -EBADMSG;
-        }
-
         // We can make a copy of the uplink session's key instead of deriving it again:
         session_key = saead_uplink_session_key_copy(DOWNLINK_KEY_USAGE);
     }
@@ -121,6 +132,7 @@ int saead_downlink_session_start(const struct session_id *id,
 
     downlink.flags = POUCH_ATOMIC_INIT(0);
     downlink.pouch.id = 0;
+    downlink.max_block_size_log = max_block_size_log;
     downlink.algorithm = algorithm;
     downlink.key = session_key;
     downlink.id = *id;
@@ -170,10 +182,12 @@ int saead_downlink_block_decrypt(const struct pouch_buf *block, struct pouch_buf
     pouch_atomic_set_bit(&downlink.flags, SESSION_HAS_POUCH);
     // We can also update our replay protection:
     server.pouch_id = downlink.pouch.id;
+
     if (downlink.id.initiator == POUCH_ROLE_SERVER
         && downlink.id.type == SESSION_ID_TYPE_SEQUENTIAL)
     {
         server.seqnum = downlink.id.value.sequential.seqnum;
+        server.has_seqnum = true;
     }
 
     return 0;

--- a/src/saead/session.c
+++ b/src/saead/session.c
@@ -335,3 +335,30 @@ int session_decrypt_block(struct session *session,
 
     return 0;
 }
+
+int session_match(const struct session *session,
+                  const struct session_id *id,
+                  uint8_t max_block_size_log,
+                  psa_algorithm_t algorithm)
+{
+    if (!pouch_atomic_test_bit(&session->flags, SESSION_VALID))
+    {
+        // session ID and parameters are unset.
+        return 0;
+    }
+
+    if (!session_id_is_equal(id, &session->id))
+    {
+        // not the same session
+        return 0;
+    }
+
+    if (max_block_size_log != session->max_block_size_log || session->algorithm != algorithm)
+    {
+        // parameters have changed.
+        return -EINVAL;
+    }
+
+    // everything matches
+    return 1;
+}

--- a/src/saead/session.h
+++ b/src/saead/session.h
@@ -57,6 +57,7 @@ struct session
     pouch_atomic_t flags;
     psa_algorithm_t algorithm;
     psa_key_id_t key;
+    uint8_t max_block_size_log;
     struct
     {
         pouch_id_t id;
@@ -84,6 +85,18 @@ psa_key_id_t session_key_generate(const struct session_id *id,
 
 /** End the given session, deleting the session key. */
 void session_end(struct session *session);
+
+/**
+ * Check if the given parameters matches the session.
+ *
+ * @return 0 if the session ID does not match the session.
+ * @return 1 if everything matches
+ * @return -EINVAL if the ID matches, but not the parameters.
+ */
+int session_match(const struct session *session,
+                  const struct session_id *id,
+                  uint8_t max_block_size_log,
+                  psa_algorithm_t algorithm);
 
 int session_pouch_start(struct session *session, pouch_id_t pouch_id);
 

--- a/src/saead/uplink.c
+++ b/src/saead/uplink.c
@@ -58,6 +58,7 @@ int saead_uplink_session_start(psa_algorithm_t algorithm, psa_key_id_t private_k
 
     uplink.algorithm = algorithm;
     uplink.pouch.id = 0;
+    uplink.max_block_size_log = MAX_BLOCK_PAYLOAD_SIZE_LOG;
     pouch_atomic_set_bit(&uplink.flags, SESSION_VALID);
 
     return 0;
@@ -135,9 +136,7 @@ bool saead_uplink_session_matches(const struct session_id *id,
                                   uint8_t max_block_size_log,
                                   psa_algorithm_t algorithm)
 {
-    return pouch_atomic_test_bit(&uplink.flags, SESSION_VALID)
-        && session_id_is_equal(id, &uplink.id) && max_block_size_log == MAX_BLOCK_PAYLOAD_SIZE_LOG
-        && uplink.algorithm == algorithm;
+    return session_match(&uplink, id, max_block_size_log, algorithm) == 1;
 }
 
 psa_key_id_t saead_uplink_session_key_copy(psa_key_usage_t usage)

--- a/tests/pouch/downlink_session/CMakeLists.txt
+++ b/tests/pouch/downlink_session/CMakeLists.txt
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(downlink_session_test)
+
+# This suite exercises src/saead/downlink.c and src/saead/session.c with
+# real PSA crypto (ECDH + AEAD), so we can't use CONFIG_POUCH_ENCRYPTION_MOCK.
+# Rather than pulling in the whole pouch library (which would need a real
+# device/server X.509 certificate chain via src/cert.c just to reach the
+# session code), we compile only the sources under test plus test doubles
+# for their few dependencies outside the saead module.
+target_sources(app PRIVATE
+  src/downlink_session.c
+  ${ZEPHYR_POUCH_MODULE_DIR}/src/saead/downlink.c
+  ${ZEPHYR_POUCH_MODULE_DIR}/src/saead/session.c
+  ${ZEPHYR_POUCH_MODULE_DIR}/src/buf.c
+)
+
+target_include_directories(app PRIVATE
+  ${ZEPHYR_POUCH_MODULE_DIR}/include
+  ${ZEPHYR_POUCH_MODULE_DIR}/port/include
+  ${ZEPHYR_POUCH_MODULE_DIR}/src
+  ${ZEPHYR_BINARY_DIR}/include/generated/include
+)
+
+# Provide the macros that the bypassed POUCH Kconfig tree would normally
+# generate (see src/Kconfig and the module log config).
+target_compile_definitions(app PRIVATE
+  CONFIG_POUCH_COMMON_LOG_LEVEL=3
+  CONFIG_POUCH_AUTH_TAG_LEN=16
+  CONFIG_POUCH_BLOCK_SIZE=512
+)
+
+# src/saead/uplink.h (pulled in transitively by src/saead/downlink.c) needs
+# the zcbor-generated cddl/header_types.h for struct saead_info. We don't
+# need the generated codec itself (header_decode.c/header_encode.c) since
+# we never touch the pouch header layer here, just the type definitions.
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated)
+file(MAKE_DIRECTORY ${gen_dir})
+
+add_custom_command(
+  OUTPUT
+    ${gen_dir}/header_decode.c
+    ${gen_dir}/header_encode.c
+    ${gen_dir}/include/cddl/header_types.h
+  COMMAND
+    zcbor code -c ${ZEPHYR_POUCH_MODULE_DIR}/src/header.cddl -t pouch_header -sde
+      --include-prefix cddl/ --oc header.c --oh include/cddl/header.h
+  DEPENDS ${ZEPHYR_POUCH_MODULE_DIR}/src/header.cddl
+  WORKING_DIRECTORY ${gen_dir})
+
+add_custom_target(downlink_session_generate_headers
+  DEPENDS ${gen_dir}/include/cddl/header_types.h)
+add_dependencies(app downlink_session_generate_headers)

--- a/tests/pouch/downlink_session/prj.conf
+++ b/tests/pouch/downlink_session/prj.conf
@@ -1,0 +1,29 @@
+CONFIG_ZTEST=y
+CONFIG_LOG=y
+
+# src/saead/uplink.h needs the zcbor-generated cddl/header_types.h, which
+# in turn needs zcbor's own runtime headers.
+CONFIG_ZCBOR=y
+CONFIG_ZCBOR_CANONICAL=y
+
+# Real PSA crypto (ECDH key agreement + AEAD), matching what
+# POUCH_ENCRYPTION_SAEAD would select if we pulled in the full POUCH
+# Kconfig tree.
+CONFIG_MBEDTLS=y
+CONFIG_MBEDTLS_PSA_CRYPTO_C=y
+CONFIG_PSA_CRYPTO=y
+CONFIG_MBEDTLS_BASE64_C=y
+
+CONFIG_PSA_WANT_ALG_ECDH=y
+CONFIG_PSA_WANT_ALG_HKDF=y
+CONFIG_PSA_WANT_ALG_SHA_256=y
+CONFIG_PSA_WANT_ECC_SECP_R1_256=y
+CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE=y
+CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT=y
+CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY=y
+CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305=y
+CONFIG_PSA_WANT_KEY_TYPE_CHACHA20=y
+
+# Needed by the test fixture to generate the device/server EC keypairs
+# (production devices are provisioned with their key some other way).
+CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE=y

--- a/tests/pouch/downlink_session/src/downlink_session.c
+++ b/tests/pouch/downlink_session/src/downlink_session.c
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tests for src/saead/downlink.c's session handling: receiving multiple
+ * pouches within a single downlink session without needlessly regenerating
+ * the session key, and rejecting session/pouch IDs that don't form a valid
+ * continuation of a previous session.
+ *
+ * This links the saead downlink/session code directly, with real PSA
+ * crypto (ECDH + AEAD), rather than going through the full pouch library
+ * (CONFIG_POUCH_ENCRYPTION_MOCK bypasses the code under test entirely, and
+ * the non-mock path needs a real device/server X.509 certificate chain
+ * just to reach it). Its few dependencies outside the saead module -
+ * src/cert.c and the uplink-session-reuse half of src/saead/uplink.c - are
+ * replaced with test doubles below.
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <psa/crypto.h>
+
+#include "block.h"
+#include "buf.h"
+#include "cert.h"
+#include "pouch.h"
+#include "saead/downlink.h"
+#include "saead/session.h"
+#include "saead/uplink.h"
+
+#define TEST_ALGORITHM PSA_ALG_CHACHA20_POLY1305
+#define TEST_BLOCK_SIZE_LOG 9
+#define NONCE_LEN 12
+
+/*
+ * All sessions in this suite are server-initiated, so downlink.c's
+ * uplink-session reuse path (for device-initiated sessions) is never
+ * taken. These only need to exist to satisfy the linker.
+ */
+bool saead_uplink_session_matches(const struct session_id *id,
+                                  uint8_t max_block_size_log,
+                                  psa_algorithm_t algorithm)
+{
+    ARG_UNUSED(id);
+    ARG_UNUSED(max_block_size_log);
+    ARG_UNUSED(algorithm);
+    return false;
+}
+
+psa_key_id_t saead_uplink_session_key_copy(psa_key_usage_t usage)
+{
+    ARG_UNUSED(usage);
+    return PSA_KEY_ID_NULL;
+}
+
+/*
+ * session.c's only dependency on block.c. block.c itself isn't linked in
+ * here, as it drags in the blockbuf pool (and its Kconfig) for
+ * block_alloc()/block_free(), neither of which is needed to exercise the
+ * session code.
+ */
+void block_size_write(struct pouch_buf *block, uint16_t size)
+{
+    pouch_put_be16(size, buf_claim(block, sizeof(uint16_t)));
+}
+
+/*
+ * Test double for cert_server_key_get(): stands in for a server
+ * certificate the device would normally have already validated. Counting
+ * calls lets tests prove the session key was (or wasn't) re-derived,
+ * without relying on psa_key_id_t values happening to differ.
+ */
+static struct pubkey server_pubkey;
+static int cert_server_key_get_calls;
+
+void cert_server_key_get(struct pubkey *out)
+{
+    cert_server_key_get_calls++;
+    *out = server_pubkey;
+}
+
+static psa_key_id_t device_privkey;
+static psa_key_id_t server_privkey;
+static struct pubkey device_pubkey;
+
+static psa_key_id_t generate_p256_keypair(struct pubkey *pubkey_out)
+{
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+
+    psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+    psa_set_key_bits(&attr, 256);
+    psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_algorithm(&attr, PSA_ALG_ECDH);
+
+    psa_key_id_t key = PSA_KEY_ID_NULL;
+    psa_status_t status = psa_generate_key(&attr, &key);
+    zassert_equal(status, PSA_SUCCESS, "keypair generation failed: %d", (int) status);
+
+    pubkey_out->len = 0;
+    status =
+        psa_export_public_key(key, pubkey_out->data, sizeof(pubkey_out->data), &pubkey_out->len);
+    zassert_equal(status, PSA_SUCCESS, "public key export failed: %d", (int) status);
+
+    return key;
+}
+
+static void *suite_setup(void)
+{
+    zassert_equal(psa_crypto_init(), PSA_SUCCESS, "psa_crypto_init failed");
+
+    /* A device keypair (used as saead_downlink_session_start()'s
+     * private_key) and a "server" keypair. cert_server_key_get() above
+     * always hands back the server's public key, as if the device had
+     * already received and validated the server's certificate. */
+    device_privkey = generate_p256_keypair(&device_pubkey);
+    server_privkey = generate_p256_keypair(&server_pubkey);
+
+    return NULL;
+}
+
+ZTEST_SUITE(downlink_session, NULL, suite_setup, NULL, NULL, NULL);
+
+/*
+ * A minimal mirror of session_encrypt_block() (src/saead/session.c) for the
+ * *server* side of a downlink session: same block framing, nonce format and
+ * AD chaining, but with the sender role in the nonce set to
+ * POUCH_ROLE_SERVER rather than the POUCH_ROLE_DEVICE that
+ * session_encrypt_block() hardcodes (it's only ever used to encrypt the
+ * device's own uplink). There's no gateway-side SAEAD implementation in
+ * this repo to reuse instead - the real server that would build these
+ * blocks lives in the cloud.
+ */
+struct fake_server_session
+{
+    psa_key_id_t key;
+    psa_algorithm_t algorithm;
+    uint16_t pouch_id;
+    uint32_t block_index;
+    uint8_t ad[AUTH_TAG_LEN];
+};
+
+static void fake_server_session_start(struct fake_server_session *s,
+                                      psa_key_id_t key,
+                                      psa_algorithm_t algorithm,
+                                      uint16_t pouch_id)
+{
+    s->key = key;
+    s->algorithm = algorithm;
+    s->pouch_id = pouch_id;
+    s->block_index = 0;
+}
+
+static struct pouch_buf *fake_server_encrypt_block(struct fake_server_session *s,
+                                                   const uint8_t *plaintext,
+                                                   size_t plaintext_len)
+{
+    size_t encrypted_len = plaintext_len + AUTH_TAG_LEN;
+    struct pouch_buf *encrypted = buf_alloc(sizeof(uint16_t) + encrypted_len);
+
+    zassert_not_null(encrypted, "buf_alloc failed");
+
+    uint8_t nonce[NONCE_LEN];
+    pouch_put_be16(s->pouch_id, &nonce[0]);
+    pouch_put_be16(s->block_index, &nonce[2]);
+    nonce[4] = POUCH_ROLE_SERVER;
+    memset(&nonce[5], 0, sizeof(nonce) - 5);
+
+    block_size_write(encrypted, encrypted_len);
+    uint8_t *ciphertext = buf_claim(encrypted, encrypted_len);
+    size_t ciphertext_len;
+
+    psa_status_t status = psa_aead_encrypt(s->key,
+                                           s->algorithm,
+                                           nonce,
+                                           sizeof(nonce),
+                                           s->ad,
+                                           s->block_index > 0 ? sizeof(s->ad) : 0,
+                                           plaintext,
+                                           plaintext_len,
+                                           ciphertext,
+                                           encrypted_len,
+                                           &ciphertext_len);
+    zassert_equal(status, PSA_SUCCESS, "encrypt failed: %d", (int) status);
+    zassert_equal(ciphertext_len, encrypted_len, "unexpected ciphertext length");
+
+    memcpy(s->ad, &ciphertext[plaintext_len], AUTH_TAG_LEN);
+    s->block_index++;
+
+    return encrypted;
+}
+
+static void make_session_id(struct session_id *id, uint64_t seqnum)
+{
+    memset(id, 0, sizeof(*id));
+    id->type = SESSION_ID_TYPE_SEQUENTIAL;
+    id->initiator = POUCH_ROLE_SERVER;
+    memset(id->value.sequential.tag, 0xA5, sizeof(id->value.sequential.tag));
+    id->value.sequential.seqnum = seqnum;
+}
+
+/*
+ * Derive the session key the *server* side of the session would compute
+ * for the given session ID, mirroring what saead_downlink_session_start()
+ * derives on the device side. ECDH is symmetric, and both sides feed
+ * identical id/algorithm/max_block_size_log info into the HKDF, so the two
+ * derivations produce the same raw key material - each side just ends up
+ * with its own psa_key_id_t for it, carrying the usage it actually needs.
+ */
+static psa_key_id_t derive_server_key(const struct session_id *id)
+{
+    psa_key_id_t key = session_key_generate(id,
+                                            TEST_ALGORITHM,
+                                            TEST_BLOCK_SIZE_LOG,
+                                            server_privkey,
+                                            &device_pubkey,
+                                            PSA_KEY_USAGE_ENCRYPT);
+    zassert_not_equal(key, PSA_KEY_ID_NULL, "server-side key derivation failed");
+    return key;
+}
+
+/* Round-trip one single-block pouch through the device's downlink session
+ * and check the decrypted payload matches. */
+static void receive_pouch(pouch_id_t pouch_id,
+                          struct fake_server_session *server,
+                          const char *payload)
+{
+    int err = saead_downlink_pouch_start(pouch_id);
+    zassert_ok(err, "pouch_start(%u) failed: %d", pouch_id, err);
+
+    struct pouch_buf *encrypted =
+        fake_server_encrypt_block(server, (const uint8_t *) payload, strlen(payload));
+
+    struct pouch_buf *decrypted = saead_downlink_block_buf_alloc();
+    zassert_not_null(decrypted, "block buf alloc failed");
+
+    err = saead_downlink_block_decrypt(encrypted, decrypted);
+    zassert_ok(err, "block decrypt failed: %d", err);
+
+    struct pouch_bufview view;
+    pouch_bufview_init(&view, decrypted);
+    uint16_t len;
+    zassert_ok(pouch_bufview_read_be16(&view, &len), "reading decrypted length failed");
+    zassert_equal(len, strlen(payload), "decrypted length mismatch");
+    zassert_mem_equal(pouch_bufview_read(&view, len), payload, len, "decrypted payload mismatch");
+
+    buf_free(encrypted);
+    buf_free(decrypted);
+}
+
+ZTEST(downlink_session, test_downlink_session_lifecycle)
+{
+    struct session_id id;
+    struct fake_server_session server;
+    int err;
+
+    /*
+     * --- Multiple pouches in a single downlink session ---
+     *
+     * crypto_downlink_start() calls saead_downlink_session_start() once per
+     * *pouch*, not once per session: the session parameters are repeated in
+     * every pouch's header. The first pouch establishes the session; later
+     * pouches with the same session ID and parameters must reuse it rather
+     * than re-deriving the key (an ECDH + HKDF operation) every time.
+     */
+    make_session_id(&id, 1);
+    cert_server_key_get_calls = 0;
+
+    err = saead_downlink_session_start(&id, TEST_ALGORITHM, TEST_BLOCK_SIZE_LOG, device_privkey);
+    zassert_ok(err, "session_start failed: %d", err);
+    zassert_equal(cert_server_key_get_calls, 1, "expected exactly one key derivation");
+
+    psa_key_id_t server_key = derive_server_key(&id);
+    fake_server_session_start(&server, server_key, TEST_ALGORITHM, 1);
+    receive_pouch(1, &server, "hello from pouch one");
+
+    /* Second pouch, same session: its header repeats the same session ID
+     * and parameters. */
+    err = saead_downlink_session_start(&id, TEST_ALGORITHM, TEST_BLOCK_SIZE_LOG, device_privkey);
+    zassert_ok(err, "session_start (2nd pouch) failed: %d", err);
+    zassert_equal(cert_server_key_get_calls,
+                  1,
+                  "session key must not be regenerated while the session is active");
+
+    fake_server_session_start(&server, server_key, TEST_ALGORITHM, 2);
+    receive_pouch(2, &server, "hello from pouch two, a bit longer");
+
+    /*
+     * --- Session parameters are validated ---
+     *
+     * Once the session has decrypted at least one block it's "valid", and
+     * the same session ID can no longer be reused with different
+     * parameters.
+     */
+    err =
+        saead_downlink_session_start(&id, TEST_ALGORITHM, TEST_BLOCK_SIZE_LOG + 1, device_privkey);
+    zassert_equal(err, -EBADMSG, "changed max_block_size_log should be rejected, got %d", err);
+
+    err = saead_downlink_session_start(&id, PSA_ALG_GCM, TEST_BLOCK_SIZE_LOG, device_privkey);
+    zassert_equal(err, -EBADMSG, "changed algorithm should be rejected, got %d", err);
+
+    /* The rejected attempts must not have disturbed the still-active
+     * session, nor caused a key re-derivation: it resumes normally. */
+    zassert_equal(cert_server_key_get_calls, 1, "rejected attempts must not derive a new key");
+    err = saead_downlink_session_start(&id, TEST_ALGORITHM, TEST_BLOCK_SIZE_LOG, device_privkey);
+    zassert_ok(err, "resuming the original session failed: %d", err);
+
+    fake_server_session_start(&server, server_key, TEST_ALGORITHM, 3);
+    receive_pouch(3, &server, "still the same session");
+
+    saead_downlink_session_end();
+
+    /*
+     * --- Non-increasing session IDs are rejected ---
+     *
+     * A new sequential session must have a strictly higher sequence number
+     * than any session the server has previously started with the device,
+     * even across a session boundary (this device-wide high-water mark is
+     * the replay guard for sessions the device didn't itself initiate).
+     */
+    struct session_id replay_id;
+
+    make_session_id(&replay_id, 1);
+    err = saead_downlink_session_start(&replay_id,
+                                       TEST_ALGORITHM,
+                                       TEST_BLOCK_SIZE_LOG,
+                                       device_privkey);
+    zassert_equal(err, -EBADMSG, "reused seqnum should be rejected, got %d", err);
+
+    make_session_id(&replay_id, 0);
+    err = saead_downlink_session_start(&replay_id,
+                                       TEST_ALGORITHM,
+                                       TEST_BLOCK_SIZE_LOG,
+                                       device_privkey);
+    zassert_equal(err, -EBADMSG, "decreasing seqnum should be rejected, got %d", err);
+
+    make_session_id(&id, 2);
+    err = saead_downlink_session_start(&id, TEST_ALGORITHM, TEST_BLOCK_SIZE_LOG, device_privkey);
+    zassert_ok(err, "increasing seqnum should be accepted: %d", err);
+
+    server_key = derive_server_key(&id);
+    fake_server_session_start(&server, server_key, TEST_ALGORITHM, 4);
+    receive_pouch(4, &server, "first pouch of the new session");
+
+    /*
+     * --- Non-increasing pouch IDs are rejected ---
+     *
+     * Within a session (and across sessions, since the guard is a
+     * device-wide high-water mark), pouch IDs must keep increasing.
+     */
+    err = saead_downlink_pouch_start(4);
+    zassert_equal(err, -EBADMSG, "replaying the current pouch ID should be rejected, got %d", err);
+
+    err = saead_downlink_pouch_start(2);
+    zassert_equal(err, -EBADMSG, "replaying an older pouch ID should be rejected, got %d", err);
+
+    /* A third pouch in this same session: same key derivation guard as
+     * before applies. */
+    err = saead_downlink_session_start(&id, TEST_ALGORITHM, TEST_BLOCK_SIZE_LOG, device_privkey);
+    zassert_ok(err, "session_start (3rd pouch) failed: %d", err);
+    zassert_equal(cert_server_key_get_calls, 2, "session key must not be regenerated again");
+
+    fake_server_session_start(&server, server_key, TEST_ALGORITHM, 5);
+    receive_pouch(5, &server, "a later pouch in the new session");
+
+    saead_downlink_session_end();
+}

--- a/tests/pouch/downlink_session/testcase.yaml
+++ b/tests/pouch/downlink_session/testcase.yaml
@@ -1,0 +1,9 @@
+tests:
+  pouch.downlink_session:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+    tags: test_framework


### PR DESCRIPTION
As reported in https://github.com/golioth/pouch/pull/314, the downlink replay protection can be disarmed by
pushing an invalid downlink session, as the SESSION_VALID flag gets cleared
at the start of each session, which disables the `is_valid_downlink` check.

The fix https://github.com/golioth/pouch/pull/314 only addresses the invalid sequence number decrement. This bug
also disables replay protection for sessions that follow a session with
only corrupted pouches, though which has to be addressed separately. We
also reinitialize the session for every received pouch, which resets the
session pouch ID, preventing the pouch ID replay check from working
correctly.

This patch addresses the core issue that causes the bug addressed in https://github.com/golioth/pouch/pull/314,
and is intended to supersede https://github.com/golioth/pouch/pull/314. It additionally adds a check for the
block size log parameter, and adds a `server.has_seqnum` flag that replaces
the validation check for `server.seqnum` the `SESSION_VALID` flag
previously covered.

> [!NOTE]
> As replay protection is not implemented on the server side, the
> session replay protection defect does not affect any active deployments,
> but all the while this code exists in this repo, it needs to be correct.

Adds a quick test that verifies the ruleset.