### PR TITLE
examples: linux: rpmsg gateway (Go broker for Pouch Serial)

### DIFF
--- a/examples/linux/rpmsg_gateway/README.md
+++ b/examples/linux/rpmsg_gateway/README.md
@@ -1,0 +1,106 @@
+# Pouch rpmsg Gateway
+
+The Linux half of Pouch on an MPU+MCU SoC. The MCU runs Zephyr and the Pouch
+device stack (see `examples/zephyr/rpmsg_device`); this daemon runs on the
+application processor, brokers the MCU's sync sessions to a Pouch-compatible
+server, and speaks the Pouch Serial protocol over an rpmsg endpoint.
+
+```
+┌──────────── Linux (Cortex-A) ─────────────┐   ┌──── Zephyr (Cortex-M) ────┐
+│  cloud ◀── HTTPS ── pouch-rpmsg-gateway   │   │  app + Pouch device stack │
+│                          │                │   │            │              │
+│                          └─ /dev/rpmsgN ──┼───┼─▶ rpmsg transport adapter │
+└───────────────────────────────────────────┘   └───────────────────────────┘
+              virtio vrings in shared memory (rpmsg)
+```
+
+The MCU keeps its own cloud identity: the session is encrypted end to end
+between it and the cloud, so this process forwards ciphertext and never holds a
+device key. It authenticates upstream with its **own** certificate, which is a
+separate identity from the device's.
+
+## Building
+
+```sh
+go build ./cmd/pouch-rpmsg-gateway
+
+# or for the target, which needs no cgo:
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" \
+    -o pouch-rpmsg-gateway ./cmd/pouch-rpmsg-gateway
+```
+
+## Running
+
+Load and start the MCU firmware first, then attach:
+
+```sh
+rproc=$(grep -l '^imx-rproc$' /sys/class/remoteproc/*/name | xargs dirname)
+cp zephyr.elf /lib/firmware/
+echo zephyr.elf > $rproc/firmware
+echo start > $rproc/state
+
+pouch-rpmsg-gateway \
+    -device /dev/rpmsg0 \
+    -cloud https://gw.golioth.io \
+    -cert gateway.crt.der -key gateway.key.der
+```
+
+`-once` runs a single session and exits, which is the easiest way to see what is
+happening; `-v` adds per-channel logging. Certificates may be DER or PEM.
+
+The device announces its endpoint through the rpmsg name service. With the
+default name `rpmsg-raw` the kernel's `rpmsg_char` driver binds it and it shows
+up as `/dev/rpmsgN` with no `RPMSG_CREATE_EPT_IOCTL` needed.
+
+## What a session does
+
+The broker drives a fixed verb sequence, skipping whatever is already done:
+
+| Channel | Direction | Purpose |
+|---------|-----------|---------|
+| 0 INFO | device → gateway | what the device already holds |
+| 1 SERVER_CERT | gateway → device | the server chain, so the device can trust the cloud |
+| 2 DEVICE_CERT | device → gateway | the device's leaf, forwarded to `/.g/device-cert` |
+| 3 DOWNLINK | gateway → device | the cloud's reply |
+| 4 UPLINK | device → gateway | the outbound pouch, posted to `/.g/pouch` |
+
+INFO carries a flags byte and the serial of the server certificate the device
+holds. If that serial matches the chain we would push, the SERVER_CERT phase is
+skipped; if the flags say the cloud already has the device's certificate, so is
+DEVICE_CERT.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `internal/serial` | The Pouch Serial protocol: header codec, channel state machine, broker verb loop |
+| `internal/link` | Frame I/O over an rpmsg character device |
+| `internal/cloud` | The `/.g/*` HTTP contract and upstream mTLS |
+| `internal/gateway` | Session wiring: endpoints, provisioning decisions, the pump |
+| `cmd/pouch-rpmsg-gateway` | The daemon |
+
+`internal/serial` is a port of `src/transport/serial/` from this repo. Its tests
+drive a device built from the same state machine, mirroring
+`tests/pouch/serial/exchange`, and the header vectors are bytes captured from a
+real device so the two implementations are pinned to each other rather than only
+to themselves.
+
+## Notes for anyone writing another gateway
+
+Two things here are not obvious and cost real debugging time:
+
+- **Write to the rpmsg device with blocking writes.** `internal/link` uses raw
+  file descriptors rather than `*os.File` on purpose. Go registers pollable
+  descriptors with its netpoller and makes them non-blocking, and
+  `virtio_rpmsg_poll()` reports the endpoint writable only when a TX buffer is
+  already free — it never enables the tx-complete callback, because only the
+  blocking `write(2)` path calls `rpmsg_upref_sleepers()`. A non-blocking writer
+  that drains the ring then waits for a wakeup that cannot arrive. This bites any
+  runtime that makes descriptors non-blocking by default (Go, Node, async Rust).
+
+- **The downlink cannot be fetched until the uplink is complete.** Both
+  directions open in the same phase, so the device usually prompts for its
+  downlink before it has finished sending the uplink. There is nothing to post
+  at that point, and an empty body is not a valid pouch — the server answers
+  400. The downlink sender reports `MoreData` with zero bytes until the uplink
+  transfer closes, which re-arms the channel without putting a frame on the wire.

--- a/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
+++ b/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
@@ -34,6 +34,8 @@ func main() {
 		insecure = flag.Bool("insecure", false, "skip upstream TLS verification (testing only)")
 		firmware = flag.Bool("firmware", false, "accept MCU-mediated firmware relay")
 		fwDir    = flag.String("firmware-dir", "", "install verified images here (implies -firmware)")
+		rproc    = flag.String("remoteproc", "",
+			"remoteproc node to apply firmware through, e.g. /sys/class/remoteproc/remoteproc1")
 		fwReject = flag.Bool("firmware-reject", false,
 			"report a hash failure for images that verify, to exercise the device's retry path")
 		verbose = flag.Bool("v", false, "debug logging")
@@ -76,8 +78,14 @@ func main() {
 	}
 
 	gw := gateway.New(l, c, link.MaxFrame, log)
+	var fwOpts *gateway.FirmwareOptions
 
-	if *firmware || *fwDir != "" || *fwReject {
+	// applied is set when an image lands on disk. The core is restarted after
+	// the session ends, not during it: the device is owed its apply verdict
+	// first, and restarting mid-session would take the link down under it.
+	var applied string
+
+	if *firmware || *fwDir != "" || *fwReject || *rproc != "" {
 		opts := &gateway.FirmwareOptions{ForceReject: *fwReject}
 		if *fwDir != "" {
 			dir := *fwDir
@@ -89,11 +97,13 @@ func main() {
 				if err := os.WriteFile(path, image, 0o644); err != nil {
 					return err
 				}
+				applied = path
 				log.Info("firmware installed", "path", path, "bytes", len(image))
 				return nil
 			}
 		}
 		gw.Firmware = opts
+		fwOpts = opts
 	}
 	log.Info("gateway started", "device", *dev, "cloud", *server, "mtls", *certPath != "")
 
@@ -105,6 +115,26 @@ func main() {
 			log.Info("session complete", "elapsed", time.Since(start))
 		}
 
+		if applied != "" && *rproc != "" {
+			if err := applyViaRemoteproc(log, *rproc, applied); err != nil {
+				log.Error("apply through remoteproc", "err", err)
+			}
+			applied = ""
+			// The core dropped its rpmsg endpoint on the way down and brings a
+			// new one up on the way back, so the link has to be reopened.
+			_ = l.Close()
+			time.Sleep(3 * time.Second)
+			nl, err := link.Open(*dev)
+			if err != nil {
+				log.Error("reopen rpmsg endpoint after restart", "err", err)
+				return
+			}
+			l = nl
+			gw = gateway.New(l, c, link.MaxFrame, log)
+			gw.Firmware = fwOpts
+			log.Info("reattached after firmware apply", "device", *dev)
+		}
+
 		if *once {
 			return
 		}
@@ -114,4 +144,36 @@ func main() {
 		case <-time.After(*interval):
 		}
 	}
+}
+
+// applyViaRemoteproc installs an image as the core's firmware and restarts it.
+// This is the "host-side apply" half of an MCU-mediated update: the core has no
+// flash of its own, so applying means putting the file where remoteproc loads
+// from and cycling the core.
+func applyViaRemoteproc(log *slog.Logger, node, image string) error {
+	name := filepath.Base(image)
+	dst := filepath.Join("/lib/firmware", name)
+
+	if dst != image {
+		data, err := os.ReadFile(image)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return err
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(node, "state"), []byte("stop"), 0o644); err != nil {
+		return fmt.Errorf("stop: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(node, "firmware"), []byte(name), 0o644); err != nil {
+		return fmt.Errorf("select firmware: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(node, "state"), []byte("start"), 0o644); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	log.Info("core restarted on the new image", "firmware", name, "node", node)
+	return nil
 }

--- a/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
+++ b/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
@@ -9,9 +9,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -30,7 +32,11 @@ func main() {
 		certPath = flag.String("cert", "", "gateway certificate for upstream mTLS (DER or PEM)")
 		keyPath  = flag.String("key", "", "gateway private key for upstream mTLS (DER or PEM)")
 		insecure = flag.Bool("insecure", false, "skip upstream TLS verification (testing only)")
-		verbose  = flag.Bool("v", false, "debug logging")
+		firmware = flag.Bool("firmware", false, "accept MCU-mediated firmware relay")
+		fwDir    = flag.String("firmware-dir", "", "install verified images here (implies -firmware)")
+		fwReject = flag.Bool("firmware-reject", false,
+			"report a hash failure for images that verify, to exercise the device's retry path")
+		verbose = flag.Bool("v", false, "debug logging")
 	)
 	flag.Parse()
 
@@ -70,6 +76,25 @@ func main() {
 	}
 
 	gw := gateway.New(l, c, link.MaxFrame, log)
+
+	if *firmware || *fwDir != "" || *fwReject {
+		opts := &gateway.FirmwareOptions{ForceReject: *fwReject}
+		if *fwDir != "" {
+			dir := *fwDir
+			opts.Apply = func(pkg, version string, image []byte) error {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					return err
+				}
+				path := filepath.Join(dir, fmt.Sprintf("%s-%s.elf", pkg, version))
+				if err := os.WriteFile(path, image, 0o644); err != nil {
+					return err
+				}
+				log.Info("firmware installed", "path", path, "bytes", len(image))
+				return nil
+			}
+		}
+		gw.Firmware = opts
+	}
 	log.Info("gateway started", "device", *dev, "cloud", *server, "mtls", *certPath != "")
 
 	for {

--- a/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
+++ b/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -57,6 +58,18 @@ func main() {
 		os.Exit(1)
 	}
 	defer func() { _ = l.Close() }()
+
+	// A session spends most of its life waiting for the device to say
+	// something. Closing the link is what breaks that wait, so a signal has to
+	// reach the descriptor - cancelling the context alone would leave the
+	// process sitting in poll(2) until it was killed outright.
+	closeOnCancel := func(l *link.RPMsg) {
+		go func() {
+			<-ctx.Done()
+			_ = l.Close()
+		}()
+	}
+	closeOnCancel(l)
 
 	// The gateway authenticates upstream with its own certificate. It is a
 	// separate identity from the device's: the device's key never leaves the
@@ -109,9 +122,13 @@ func main() {
 
 	for {
 		start := time.Now()
-		if err := gw.RunSession(ctx); err != nil {
+		switch err := gw.RunSession(ctx); {
+		case errors.Is(err, link.ErrClosed) || ctx.Err() != nil:
+			log.Info("shutting down")
+			return
+		case err != nil:
 			log.Error("session failed", "err", err, "elapsed", time.Since(start))
-		} else {
+		default:
 			log.Info("session complete", "elapsed", time.Since(start))
 		}
 
@@ -130,6 +147,7 @@ func main() {
 				return
 			}
 			l = nl
+			closeOnCancel(l)
 			gw = gateway.New(l, c, link.MaxFrame, log)
 			gw.Firmware = fwOpts
 			log.Info("reattached after firmware apply", "device", *dev)

--- a/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
+++ b/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
@@ -1,0 +1,92 @@
+// Command pouch-rpmsg-gateway brokers Pouch sessions between a Zephyr device on
+// an MCU core and a Pouch-compatible cloud, over rpmsg.
+//
+// The MCU is the authenticated Pouch endpoint: it holds its own certificate and
+// the session is encrypted end to end, so this process forwards ciphertext and
+// never sees plaintext or a key.
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/golioth/pouch/examples/linux/rpmsg_gateway/internal/cloud"
+	"github.com/golioth/pouch/examples/linux/rpmsg_gateway/internal/gateway"
+	"github.com/golioth/pouch/examples/linux/rpmsg_gateway/internal/link"
+)
+
+func main() {
+	var (
+		dev      = flag.String("device", "/dev/rpmsg0", "rpmsg endpoint to attach to")
+		server   = flag.String("cloud", "https://gw.golioth.io", "Pouch server base URL")
+		interval = flag.Duration("interval", 30*time.Second, "delay between sync sessions")
+		once     = flag.Bool("once", false, "run a single session and exit")
+		timeout  = flag.Duration("timeout", 60*time.Second, "cloud request timeout")
+		certPath = flag.String("cert", "", "gateway certificate for upstream mTLS (DER or PEM)")
+		keyPath  = flag.String("key", "", "gateway private key for upstream mTLS (DER or PEM)")
+		insecure = flag.Bool("insecure", false, "skip upstream TLS verification (testing only)")
+		verbose  = flag.Bool("v", false, "debug logging")
+	)
+	flag.Parse()
+
+	level := slog.LevelInfo
+	if *verbose {
+		level = slog.LevelDebug
+	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	l, err := link.Open(*dev)
+	if err != nil {
+		log.Error("open rpmsg endpoint", "err", err)
+		os.Exit(1)
+	}
+	defer func() { _ = l.Close() }()
+
+	// The gateway authenticates upstream with its own certificate. It is a
+	// separate identity from the device's: the device's key never leaves the
+	// MCU, and the pouches passing through here stay encrypted end to end.
+	var c *cloud.Client
+	switch {
+	case *certPath != "" && *keyPath != "":
+		cert, err := cloud.LoadKeyPair(*certPath, *keyPath)
+		if err != nil {
+			log.Error("load gateway credentials", "err", err)
+			os.Exit(1)
+		}
+		c = cloud.NewMTLS(*server, *timeout, cert, *insecure)
+	case *certPath != "" || *keyPath != "":
+		log.Error("-cert and -key must be given together")
+		os.Exit(1)
+	default:
+		c = cloud.New(*server, *timeout)
+	}
+
+	gw := gateway.New(l, c, link.MaxFrame, log)
+	log.Info("gateway started", "device", *dev, "cloud", *server, "mtls", *certPath != "")
+
+	for {
+		start := time.Now()
+		if err := gw.RunSession(ctx); err != nil {
+			log.Error("session failed", "err", err, "elapsed", time.Since(start))
+		} else {
+			log.Info("session complete", "elapsed", time.Since(start))
+		}
+
+		if *once {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(*interval):
+		}
+	}
+}

--- a/examples/linux/rpmsg_gateway/go.mod
+++ b/examples/linux/rpmsg_gateway/go.mod
@@ -2,6 +2,9 @@ module github.com/golioth/pouch/examples/linux/rpmsg_gateway
 
 go 1.25.0
 
-require github.com/fxamacker/cbor/v2 v2.9.0
+require (
+	github.com/fxamacker/cbor/v2 v2.9.0
+	golang.org/x/sys v0.33.0
+)
 
 require github.com/x448/float16 v0.8.4 // indirect

--- a/examples/linux/rpmsg_gateway/go.mod
+++ b/examples/linux/rpmsg_gateway/go.mod
@@ -1,0 +1,7 @@
+module github.com/golioth/pouch/examples/linux/rpmsg_gateway
+
+go 1.25.0
+
+require github.com/fxamacker/cbor/v2 v2.9.0
+
+require github.com/x448/float16 v0.8.4 // indirect

--- a/examples/linux/rpmsg_gateway/go.sum
+++ b/examples/linux/rpmsg_gateway/go.sum
@@ -1,0 +1,4 @@
+github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
+github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=

--- a/examples/linux/rpmsg_gateway/go.sum
+++ b/examples/linux/rpmsg_gateway/go.sum
@@ -2,3 +2,5 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/examples/linux/rpmsg_gateway/internal/cloud/client.go
+++ b/examples/linux/rpmsg_gateway/internal/cloud/client.go
@@ -1,0 +1,92 @@
+// Package cloud speaks the Pouch gateway HTTP contract.
+//
+//	GET  <Address>/.g/server-cert  -> the server certificate chain to push down
+//	POST <Address>/.g/device-cert  <- the device's leaf certificate
+//	POST <Address>/.g/pouch        <- an uplink pouch; the body back is the downlink
+//
+// Pouches are opaque here. The session is encrypted end to end between the
+// device and the cloud, so the gateway forwards ciphertext and never holds a key.
+package cloud
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	PathServerCert = "/.g/server-cert"
+	PathDeviceCert = "/.g/device-cert"
+	PathPouch      = "/.g/pouch"
+
+	maxResponseBytes = 8 << 20
+)
+
+// Client talks to one Pouch-compatible server.
+type Client struct {
+	Address string
+	HTTP    *http.Client
+}
+
+// New returns a client for address, e.g. "https://gw.golioth.io".
+func New(address string, timeout time.Duration) *Client {
+	return &Client{
+		Address: address,
+		HTTP:    &http.Client{Timeout: timeout},
+	}
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	u, err := url.JoinPath(c.Address, path)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: build url: %w", method, path, err)
+	}
+
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, r)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/octet-stream")
+	}
+
+	client := c.HTTP
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, bytes.TrimSpace(b))
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+}
+
+// ServerCert fetches the certificate chain to provision onto the device.
+func (c *Client) ServerCert(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, PathServerCert, nil)
+}
+
+// RegisterDevice hands the device's leaf certificate to the cloud.
+func (c *Client) RegisterDevice(ctx context.Context, cert []byte) error {
+	_, err := c.do(ctx, http.MethodPost, PathDeviceCert, cert)
+	return err
+}
+
+// Forward posts an uplink pouch and returns the downlink to hand back.
+func (c *Client) Forward(ctx context.Context, uplink []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, PathPouch, uplink)
+}

--- a/examples/linux/rpmsg_gateway/internal/cloud/tls.go
+++ b/examples/linux/rpmsg_gateway/internal/cloud/tls.go
@@ -1,0 +1,85 @@
+package cloud
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// LoadKeyPair reads a certificate and private key for upstream mTLS. Both DER
+// and PEM encodings are accepted, since Golioth's PKI tooling hands out either.
+func LoadKeyPair(certPath, keyPath string) (tls.Certificate, error) {
+	certBytes, err := os.ReadFile(certPath)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("read certificate: %w", err)
+	}
+	keyBytes, err := os.ReadFile(keyPath)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("read key: %w", err)
+	}
+
+	certDER, err := toDER(certBytes)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("certificate: %w", err)
+	}
+	keyDER, err := toDER(keyBytes)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("key: %w", err)
+	}
+
+	key, err := parsePrivateKey(keyDER)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	if _, err := x509.ParseCertificate(certDER); err != nil {
+		return tls.Certificate{}, fmt.Errorf("parse certificate: %w", err)
+	}
+
+	return tls.Certificate{Certificate: [][]byte{certDER}, PrivateKey: key}, nil
+}
+
+// toDER returns the DER body, unwrapping a PEM block if there is one.
+func toDER(b []byte) ([]byte, error) {
+	if block, _ := pem.Decode(b); block != nil {
+		return block.Bytes, nil
+	}
+	if len(b) == 0 {
+		return nil, fmt.Errorf("empty file")
+	}
+	return b, nil
+}
+
+func parsePrivateKey(der []byte) (any, error) {
+	if k, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParseECPrivateKey(der); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return k, nil
+	}
+	return nil, fmt.Errorf("parse key: not PKCS#8, SEC1 or PKCS#1")
+}
+
+// NewMTLS returns a client that presents cert to the server.
+func NewMTLS(address string, timeout time.Duration, cert tls.Certificate, insecure bool) *Client {
+	return &Client{
+		Address: address,
+		HTTP: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion:         tls.VersionTLS12,
+					Certificates:       []tls.Certificate{cert},
+					InsecureSkipVerify: insecure,
+				},
+			},
+		},
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/gateway/firmware.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/firmware.go
@@ -1,0 +1,118 @@
+package gateway
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+)
+
+// The firmware chunk header, as src/transport/endpoints/device/fw.c writes it.
+//
+//	magic    u32le "PFW2"
+//	size     u32le  total image size
+//	offset   u32le  absolute offset this chunk starts at
+//	sha256   [32]   digest of the whole image
+//	ver_len  u8
+//	pkg_len  u8
+//	version  [ver_len]
+//	package  [pkg_len]
+//
+// A relay is chunked because the image arrives from the cloud over several
+// sessions: each chunk carries whatever was buffered at that moment, stamped
+// with where it belongs.
+const (
+	fwHdrFixedLen = 46
+	fwMagic       = 0x32574650 // "PFW2" little endian
+)
+
+// FwStatus is the verdict the host reports after trying to apply an image.
+type FwStatus uint8
+
+const (
+	FwStatusOK       FwStatus = 0 // verified and installed
+	FwStatusHashFail FwStatus = 1 // SHA-256 mismatch, nothing installed
+	FwStatusError    FwStatus = 2 // install or I/O error
+)
+
+func (s FwStatus) String() string {
+	switch s {
+	case FwStatusOK:
+		return "ok"
+	case FwStatusHashFail:
+		return "hash-fail"
+	case FwStatusError:
+		return "error"
+	}
+	return fmt.Sprintf("unknown(%d)", uint8(s))
+}
+
+type fwChunk struct {
+	size    uint32
+	offset  uint32
+	sha256  [32]byte
+	version string
+	pkg     string
+	data    []byte
+}
+
+func parseFwChunk(b []byte) (*fwChunk, error) {
+	if len(b) < fwHdrFixedLen {
+		return nil, fmt.Errorf("firmware chunk of %d bytes is shorter than its header", len(b))
+	}
+	if magic := binary.LittleEndian.Uint32(b[0:4]); magic != fwMagic {
+		return nil, fmt.Errorf("bad firmware chunk magic 0x%08x", magic)
+	}
+
+	c := &fwChunk{
+		size:   binary.LittleEndian.Uint32(b[4:8]),
+		offset: binary.LittleEndian.Uint32(b[8:12]),
+	}
+	copy(c.sha256[:], b[12:44])
+
+	verLen, pkgLen := int(b[44]), int(b[45])
+	end := fwHdrFixedLen + verLen + pkgLen
+	if len(b) < end {
+		return nil, fmt.Errorf("firmware chunk truncated in its name fields")
+	}
+	c.version = string(b[fwHdrFixedLen : fwHdrFixedLen+verLen])
+	c.pkg = string(b[fwHdrFixedLen+verLen : end])
+	c.data = b[end:]
+	return c, nil
+}
+
+// fwRelay assembles an image from the chunks the device streams across
+// sessions, and reports what the host made of it.
+type fwRelay struct {
+	pkg     string
+	version string
+	size    uint32
+	digest  [32]byte
+	image   []byte
+}
+
+// push adds a chunk. It returns true once the image is complete.
+func (r *fwRelay) push(c *fwChunk) (bool, error) {
+	if r.size == 0 || r.version != c.version {
+		// A new image: either the first one, or the device moved on to another.
+		*r = fwRelay{pkg: c.pkg, version: c.version, size: c.size, digest: c.sha256}
+	}
+	if c.offset != uint32(len(r.image)) {
+		return false, fmt.Errorf("firmware chunk at offset %d, expected %d",
+			c.offset, len(r.image))
+	}
+	r.image = append(r.image, c.data...)
+	return uint32(len(r.image)) >= r.size, nil
+}
+
+// verdict checks the assembled image against the digest from the manifest.
+func (r *fwRelay) verdict() FwStatus {
+	if uint32(len(r.image)) != r.size {
+		return FwStatusError
+	}
+	if sha256.Sum256(r.image) != r.digest {
+		return FwStatusHashFail
+	}
+	return FwStatusOK
+}
+
+func (r *fwRelay) reset() { *r = fwRelay{} }

--- a/examples/linux/rpmsg_gateway/internal/gateway/session.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/session.go
@@ -48,11 +48,28 @@ type Gateway struct {
 
 	maxFrame int
 
+	// Firmware carries MCU-mediated updates when set. relay persists across
+	// sessions because the image arrives a chunk at a time.
+	Firmware *FirmwareOptions
+	relay    fwRelay
+
 	// serverCert is fetched once and reused across sessions.
 	certOnce sync.Once
 	cert     []byte
 	certSNR  []byte
 	certErr  error
+}
+
+// FirmwareOptions enables MCU-mediated firmware relay. A core loaded by
+// remoteproc has no flash of its own, so it downloads its own image through
+// Pouch OTA and streams the plaintext here for the host to verify and apply.
+type FirmwareOptions struct {
+	// Apply installs a verified image. Leaving it nil verifies and discards,
+	// which is what a bring-up run wants.
+	Apply func(pkg, version string, image []byte) error
+	// ForceReject reports a hash failure for an image that actually verified.
+	// It exists to exercise the device's retry path on demand.
+	ForceReject bool
 }
 
 // New returns a gateway that brokers between link and cloud.
@@ -97,6 +114,7 @@ func (g *Gateway) RunSession(ctx context.Context) error {
 		deviceCert []byte
 		uplink     []byte
 		downlink   []byte
+		fwVerdict  FwStatus
 	)
 
 	ep := serial.Endpoints{}
@@ -179,6 +197,64 @@ func (g *Gateway) RunSession(ctx context.Context) error {
 			return downlink, nil
 		},
 		fail: func(err error) { sessErr = fmt.Errorf("forward uplink: %w", err) },
+	}
+
+	if g.Firmware != nil {
+		ep.Fw = &serial.BufReceiver{Done: func(data []byte, ok bool) {
+			// An empty transfer is the normal answer: it means the device has
+			// no image in flight.
+			if !ok || len(data) == 0 {
+				return
+			}
+			chunk, err := parseFwChunk(data)
+			if err != nil {
+				g.log.Error("firmware relay", "err", err)
+				g.relay.reset()
+				return
+			}
+			complete, err := g.relay.push(chunk)
+			if err != nil {
+				g.log.Error("firmware relay", "err", err)
+				g.relay.reset()
+				return
+			}
+			g.log.Info("firmware chunk",
+				"package", chunk.pkg, "version", chunk.version,
+				"offset", chunk.offset, "bytes", len(chunk.data),
+				"have", len(g.relay.image), "of", g.relay.size)
+
+			if !complete {
+				return
+			}
+
+			fwVerdict = g.relay.verdict()
+			if fwVerdict == FwStatusOK && g.Firmware.ForceReject {
+				g.log.Warn("image verified, reporting a hash failure anyway " +
+					"to exercise the device's retry path")
+				fwVerdict = FwStatusHashFail
+			}
+			if fwVerdict == FwStatusOK && g.Firmware.Apply != nil {
+				if err := g.Firmware.Apply(g.relay.pkg, g.relay.version, g.relay.image); err != nil {
+					g.log.Error("apply firmware", "err", err)
+					fwVerdict = FwStatusError
+				}
+			}
+			g.log.Info("firmware image complete",
+				"package", g.relay.pkg, "version", g.relay.version,
+				"bytes", len(g.relay.image), "verdict", fwVerdict)
+
+			g.relay.reset()
+			broker.SendFwStatus()
+		}}
+
+		ep.FwStatus = &serial.BufSender{
+			Data: func() []byte { return []byte{byte(fwVerdict)} },
+			Done: func(ok bool) {
+				if ok {
+					g.log.Info("apply verdict delivered", "verdict", fwVerdict)
+				}
+			},
+		}
 	}
 
 	broker = serial.NewBroker(ep, g.log,

--- a/examples/linux/rpmsg_gateway/internal/gateway/session.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/session.go
@@ -1,0 +1,298 @@
+// Package gateway runs Pouch sync sessions between a device on a frame link and
+// a Pouch-compatible cloud.
+package gateway
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/fxamacker/cbor/v2"
+
+	"github.com/golioth/pouch/examples/linux/rpmsg_gateway/internal/serial"
+)
+
+// infoFlagDeviceProvisioned is set by the device once the cloud holds its
+// certificate. The remaining seven bits are unused - the natural place for a
+// future capability exchange.
+const infoFlagDeviceProvisioned = 1 << 0
+
+// deviceInfo is the CBOR map the device sends on the INFO channel.
+type deviceInfo struct {
+	Flags         uint8  `cbor:"flags"`
+	ServerCertSNR []byte `cbor:"server_cert_snr"`
+}
+
+// Link is a frame-oriented transport to the device.
+type Link interface {
+	ReadFrame() ([]byte, error)
+	WriteFrame(frame []byte) error
+	Close() error
+}
+
+// Cloud is the Pouch server contract.
+type Cloud interface {
+	ServerCert(ctx context.Context) ([]byte, error)
+	RegisterDevice(ctx context.Context, cert []byte) error
+	Forward(ctx context.Context, uplink []byte) ([]byte, error)
+}
+
+// Gateway brokers sessions for one device.
+type Gateway struct {
+	link  Link
+	cloud Cloud
+	log   *slog.Logger
+
+	maxFrame int
+
+	// serverCert is fetched once and reused across sessions.
+	certOnce sync.Once
+	cert     []byte
+	certSNR  []byte
+	certErr  error
+}
+
+// New returns a gateway that brokers between link and cloud.
+func New(link Link, cloud Cloud, maxFrame int, log *slog.Logger) *Gateway {
+	return &Gateway{link: link, cloud: cloud, maxFrame: maxFrame, log: log}
+}
+
+// serverCert fetches the chain to provision, and the serial number the device
+// reports back once it holds it.
+func (g *Gateway) serverCert(ctx context.Context) ([]byte, []byte, error) {
+	g.certOnce.Do(func() {
+		g.cert, g.certErr = g.cloud.ServerCert(ctx)
+		if g.certErr != nil {
+			return
+		}
+		// The device echoes the serial of the certificate it holds, which is how
+		// the broker decides whether provisioning can be skipped next time. The
+		// chain may hold several; the device reports the first, matching
+		// mbedtls_x509_crt_parse().
+		leaf, err := firstCertificate(g.cert)
+		if err != nil {
+			g.log.Warn("cannot derive the server certificate serial, "+
+				"so the chain will be pushed every session", "err", err)
+		} else {
+			g.certSNR = derSerial(leaf)
+		}
+	})
+	return g.cert, g.certSNR, g.certErr
+}
+
+// RunSession brokers one complete sync and returns when it finishes.
+func (g *Gateway) RunSession(ctx context.Context) error {
+	cert, certSNR, err := g.serverCert(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch server certificate: %w", err)
+	}
+
+	var (
+		sessErr    error
+		finished   bool
+		uplinkDone bool
+		deviceCert []byte
+		uplink     []byte
+		downlink   []byte
+	)
+
+	ep := serial.Endpoints{}
+	var broker *serial.Broker
+
+	// INFO: the device tells us what it already has.
+	ep.Info = &serial.BufReceiver{Done: func(data []byte, ok bool) {
+		if !ok {
+			return
+		}
+		var info deviceInfo
+		if err := cbor.Unmarshal(data, &info); err != nil {
+			sessErr = fmt.Errorf("decode device info: %w", err)
+			return
+		}
+		node := broker.Node()
+		node.ServerCertProvisioned = len(certSNR) > 0 &&
+			string(info.ServerCertSNR) == string(certSNR)
+		node.DeviceCertProvisioned = info.Flags&infoFlagDeviceProvisioned != 0
+
+		g.log.Info("device info",
+			"flags", info.Flags,
+			"server_cert_provisioned", node.ServerCertProvisioned,
+			"device_cert_provisioned", node.DeviceCertProvisioned)
+	}}
+
+	// SERVER_CERT: push the chain so the device can authenticate the cloud.
+	ep.ServerCert = &serial.BufSender{
+		Data: func() []byte { return cert },
+		Done: func(ok bool) {
+			if ok {
+				broker.Node().ServerCertProvisioned = true
+				g.log.Info("server certificate provisioned", "bytes", len(cert))
+			}
+		},
+	}
+
+	// DEVICE_CERT: collect the device's leaf and register it with the cloud.
+	ep.DeviceCert = &serial.BufReceiver{Done: func(data []byte, ok bool) {
+		if !ok {
+			return
+		}
+		deviceCert = append([]byte(nil), data...)
+		if err := g.cloud.RegisterDevice(ctx, deviceCert); err != nil {
+			sessErr = fmt.Errorf("register device: %w", err)
+			return
+		}
+		broker.Node().DeviceCertProvisioned = true
+		g.log.Info("device certificate registered", "bytes", len(deviceCert))
+	}}
+
+	// UPLINK: collect the outbound pouch and post it; the reply is the downlink.
+	ep.Uplink = &serial.BufReceiver{Done: func(data []byte, ok bool) {
+		if !ok {
+			return
+		}
+		uplink = append([]byte(nil), data...)
+		uplinkDone = true
+		g.log.Info("uplink collected", "bytes", len(uplink))
+	}}
+
+	// DOWNLINK: post the uplink and hand back what the cloud returns.
+	//
+	// Both directions are opened in the same phase, so the device usually
+	// prompts for its downlink before it has finished sending the uplink. There
+	// is nothing to post yet at that point - and an empty body is not a valid
+	// pouch, the server rejects it with 400 - so the sender reports "not ready"
+	// until the uplink transfer closes. Zero bytes with MoreData re-arms the
+	// channel without putting a frame on the wire, which is exactly what that
+	// result is for.
+	ep.Downlink = &deferredSender{
+		ready: func() bool { return uplinkDone },
+		fetch: func() ([]byte, error) {
+			resp, err := g.cloud.Forward(ctx, uplink)
+			if err != nil {
+				return nil, err
+			}
+			downlink = resp
+			g.log.Info("downlink received", "bytes", len(downlink))
+			return downlink, nil
+		},
+		fail: func(err error) { sessErr = fmt.Errorf("forward uplink: %w", err) },
+	}
+
+	broker = serial.NewBroker(ep, g.log,
+		func(ok bool) {
+			finished = true
+			if !ok && sessErr == nil {
+				sessErr = fmt.Errorf("session ended in error")
+			}
+		},
+		func() {},
+	)
+
+	broker.Start()
+
+	// Pump: drain everything the broker wants to say, then block for a frame.
+	for !finished {
+		for {
+			frame := broker.FrameGet(g.maxFrame)
+			if frame == nil {
+				break
+			}
+			if err := g.link.WriteFrame(frame); err != nil {
+				return err
+			}
+		}
+		if finished {
+			break
+		}
+
+		frame, err := g.link.ReadFrame()
+		if err != nil {
+			return err
+		}
+		if err := broker.Recv(frame); err != nil {
+			// A frame the broker rejects is not fatal to the link; log it and
+			// keep going so a stray frame cannot end the session.
+			g.log.Warn("dropped frame", "err", err)
+		}
+	}
+
+	return sessErr
+}
+
+// derSerial returns the serial number as DER encodes its content octets, which
+// is the form the device reports. A positive integer whose top bit is set gains
+// a leading zero byte, and Go's big.Int does not carry it.
+func derSerial(c *x509.Certificate) []byte {
+	b := c.SerialNumber.Bytes()
+	if len(b) > 0 && b[0]&0x80 != 0 {
+		return append([]byte{0x00}, b...)
+	}
+	return b
+}
+
+// deferredSender serves a payload that is not available when the transfer
+// opens. It reports MoreData with no bytes until ready() is true, which re-arms
+// the channel without emitting a frame.
+type deferredSender struct {
+	ready func() bool
+	fetch func() ([]byte, error)
+	fail  func(error)
+
+	data    []byte
+	off     int
+	fetched bool
+}
+
+func (s *deferredSender) Start() error {
+	s.data, s.off, s.fetched = nil, 0, false
+	return nil
+}
+
+func (s *deferredSender) Send(max int) ([]byte, serial.Result) {
+	if !s.fetched {
+		if !s.ready() {
+			return nil, serial.MoreData
+		}
+		data, err := s.fetch()
+		if err != nil {
+			if s.fail != nil {
+				s.fail(err)
+			}
+			return nil, serial.SendError
+		}
+		s.data, s.fetched = data, true
+	}
+
+	n := min(len(s.data)-s.off, max)
+	chunk := s.data[s.off : s.off+n]
+	s.off += n
+	if s.off >= len(s.data) {
+		return chunk, serial.NoMoreData
+	}
+	return chunk, serial.MoreData
+}
+
+func (s *deferredSender) End(bool) {}
+
+// firstCertificate returns the leading certificate of a chain, which the server
+// may hand over as PEM or as concatenated DER.
+func firstCertificate(chain []byte) (*x509.Certificate, error) {
+	if block, _ := pem.Decode(chain); block != nil {
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("first PEM block is %q, not CERTIFICATE", block.Type)
+		}
+		return x509.ParseCertificate(block.Bytes)
+	}
+
+	certs, err := x509.ParseCertificates(chain)
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates in chain")
+	}
+	return certs[0], nil
+}

--- a/examples/linux/rpmsg_gateway/internal/link/rpmsg.go
+++ b/examples/linux/rpmsg_gateway/internal/link/rpmsg.go
@@ -5,13 +5,21 @@
 package link
 
 import (
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // MaxFrame is the largest frame an rpmsg buffer can carry. The kernel's default
 // buffer is 512 bytes, of which 16 are the rpmsg header.
 const MaxFrame = 496
+
+// ErrClosed is returned by ReadFrame once Close has been called.
+var ErrClosed = errors.New("link: closed")
 
 // RPMsg is a frame-oriented link over /dev/rpmsgN.
 //
@@ -24,9 +32,24 @@ const MaxFrame = 496
 // drains the ring, which is routine when streaming, then waits for a wakeup
 // that structurally cannot arrive. Keeping the descriptor blocking and out of
 // the poller is the fix.
+//
+// Reads still wait in poll(2) rather than in read(2), so that Close can
+// interrupt an idle reader. That does not reintroduce the problem above: the
+// descriptor stays in blocking mode, writes are untouched, and we only ever ask
+// poll about readability. POLLIN comes from the endpoint's receive queue and is
+// reliable; POLLOUT is the half of virtio_rpmsg_poll() that cannot be trusted,
+// and is never consulted.
 type RPMsg struct {
 	fd   int
 	path string
+
+	// wake is a self-pipe used to break a blocked reader out of poll(2).
+	// Closing the device descriptor would not do it: on Linux, close(2) does
+	// not reliably wake a thread already waiting on that descriptor.
+	wakeR, wakeW int
+
+	closed    atomic.Bool
+	closeOnce sync.Once
 }
 
 // Open attaches to an rpmsg endpoint, e.g. /dev/rpmsg0.
@@ -35,18 +58,57 @@ func Open(path string) (*RPMsg, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
-	return &RPMsg{fd: fd, path: path}, nil
+
+	var p [2]int
+	if err := syscall.Pipe2(p[:], syscall.O_CLOEXEC); err != nil {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("open %s: wake pipe: %w", path, err)
+	}
+
+	return &RPMsg{fd: fd, path: path, wakeR: p[0], wakeW: p[1]}, nil
 }
 
-// ReadFrame blocks until a frame arrives and returns it.
+// ReadFrame waits for a frame and returns it. It returns ErrClosed if Close is
+// called while it is waiting.
 func (r *RPMsg) ReadFrame() ([]byte, error) {
 	buf := make([]byte, MaxFrame)
 	for {
+		if r.closed.Load() {
+			return nil, ErrClosed
+		}
+
+		fds := []unix.PollFd{
+			{Fd: int32(r.fd), Events: unix.POLLIN},
+			{Fd: int32(r.wakeR), Events: unix.POLLIN},
+		}
+		if _, err := unix.Poll(fds, -1); err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			return nil, fmt.Errorf("poll %s: %w", r.path, err)
+		}
+
+		// Check for shutdown before touching the descriptor: Close may have
+		// closed it between poll returning and here.
+		if r.closed.Load() || fds[1].Revents != 0 {
+			return nil, ErrClosed
+		}
+
+		if fds[0].Revents&(unix.POLLERR|unix.POLLHUP|unix.POLLNVAL) != 0 {
+			return nil, fmt.Errorf("read %s: endpoint went away", r.path)
+		}
+		if fds[0].Revents&unix.POLLIN == 0 {
+			continue
+		}
+
 		n, err := syscall.Read(r.fd, buf)
 		if err == syscall.EINTR {
 			continue
 		}
 		if err != nil {
+			if r.closed.Load() {
+				return nil, ErrClosed
+			}
 			return nil, fmt.Errorf("read %s: %w", r.path, err)
 		}
 		if n == 0 {
@@ -81,5 +143,19 @@ func (r *RPMsg) WriteFrame(frame []byte) error {
 	}
 }
 
-// Close releases the endpoint.
-func (r *RPMsg) Close() error { return syscall.Close(r.fd) }
+// Close releases the endpoint and wakes a reader blocked in ReadFrame. It is
+// safe to call concurrently with ReadFrame, and safe to call more than once.
+func (r *RPMsg) Close() error {
+	var err error
+	r.closeOnce.Do(func() {
+		r.closed.Store(true)
+
+		// Wake the reader before releasing anything it might be waiting on.
+		_, _ = syscall.Write(r.wakeW, []byte{0})
+
+		err = syscall.Close(r.fd)
+		_ = syscall.Close(r.wakeW)
+		_ = syscall.Close(r.wakeR)
+	})
+	return err
+}

--- a/examples/linux/rpmsg_gateway/internal/link/rpmsg.go
+++ b/examples/linux/rpmsg_gateway/internal/link/rpmsg.go
@@ -1,0 +1,85 @@
+// Package link carries Pouch Serial frames over an rpmsg character device.
+//
+// One rpmsg message is exactly one frame, so there is no framing to do here:
+// a read returns a whole frame and a write sends one.
+package link
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// MaxFrame is the largest frame an rpmsg buffer can carry. The kernel's default
+// buffer is 512 bytes, of which 16 are the rpmsg header.
+const MaxFrame = 496
+
+// RPMsg is a frame-oriented link over /dev/rpmsgN.
+//
+// It deliberately uses raw file descriptors rather than *os.File. Go's runtime
+// registers pollable descriptors with the netpoller and switches them to
+// non-blocking, which is fatal here: virtio_rpmsg_poll() reports the endpoint
+// writable only when a TX buffer is already free, and never enables the
+// tx-complete callback - only the blocking write(2) path calls
+// rpmsg_upref_sleepers(), which is what arms it. A non-blocking writer that
+// drains the ring, which is routine when streaming, then waits for a wakeup
+// that structurally cannot arrive. Keeping the descriptor blocking and out of
+// the poller is the fix.
+type RPMsg struct {
+	fd   int
+	path string
+}
+
+// Open attaches to an rpmsg endpoint, e.g. /dev/rpmsg0.
+func Open(path string) (*RPMsg, error) {
+	fd, err := syscall.Open(path, syscall.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	return &RPMsg{fd: fd, path: path}, nil
+}
+
+// ReadFrame blocks until a frame arrives and returns it.
+func (r *RPMsg) ReadFrame() ([]byte, error) {
+	buf := make([]byte, MaxFrame)
+	for {
+		n, err := syscall.Read(r.fd, buf)
+		if err == syscall.EINTR {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", r.path, err)
+		}
+		if n == 0 {
+			continue
+		}
+		return buf[:n], nil
+	}
+}
+
+// WriteFrame sends one frame. The write blocks until the peer frees a buffer.
+func (r *RPMsg) WriteFrame(frame []byte) error {
+	if len(frame) == 0 {
+		return fmt.Errorf("write %s: empty frame", r.path)
+	}
+	if len(frame) > MaxFrame {
+		return fmt.Errorf("write %s: frame of %d bytes exceeds %d", r.path, len(frame), MaxFrame)
+	}
+	for {
+		n, err := syscall.Write(r.fd, frame)
+		if err == syscall.EINTR {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("write %s: %w", r.path, err)
+		}
+		if n != len(frame) {
+			// rpmsg is message-oriented; a short write would mean a truncated
+			// frame on the wire, which the peer cannot recover from.
+			return fmt.Errorf("write %s: short write, %d of %d bytes", r.path, n, len(frame))
+		}
+		return nil
+	}
+}
+
+// Close releases the endpoint.
+func (r *RPMsg) Close() error { return syscall.Close(r.fd) }

--- a/examples/linux/rpmsg_gateway/internal/link/rpmsg_test.go
+++ b/examples/linux/rpmsg_gateway/internal/link/rpmsg_test.go
@@ -1,0 +1,105 @@
+package link
+
+import (
+	"errors"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// A FIFO stands in for the rpmsg character device: both are message-ish
+// descriptors that block a reader when empty, which is the property under test.
+func fifo(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "rpmsg")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	return path
+}
+
+// Close must break a reader out of its wait. Before this was fixed the reader
+// sat in read(2) with nothing to interrupt it, so SIGTERM did nothing, the
+// process only died to SIGKILL, and the stale instance kept /dev/rpmsg0 open -
+// the next start then failed with "device or resource busy".
+func TestCloseInterruptsBlockedRead(t *testing.T) {
+	l, err := Open(fifo(t))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := l.ReadFrame()
+		result <- err
+	}()
+
+	// Let the reader reach its wait before pulling the rug.
+	time.Sleep(100 * time.Millisecond)
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("ReadFrame returned %v, want ErrClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadFrame still blocked two seconds after Close")
+	}
+}
+
+func TestReadAfterCloseReturnsErrClosed(t *testing.T) {
+	l, err := Open(fifo(t))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := l.ReadFrame(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("ReadFrame returned %v, want ErrClosed", err)
+	}
+}
+
+// Close runs on the shutdown path and again on the firmware-restart path, so it
+// has to tolerate being called twice.
+func TestCloseIsIdempotent(t *testing.T) {
+	l, err := Open(fifo(t))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+}
+
+// A frame written while the reader is waiting still arrives intact.
+func TestReadFrameDeliversData(t *testing.T) {
+	path := fifo(t)
+	l, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	want := []byte{0xb0, 0x01, 0x02, 0x03}
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = l.WriteFrame(want)
+	}()
+
+	got, err := l.ReadFrame()
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("ReadFrame = % x, want % x", got, want)
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/serial/broker.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/broker.go
@@ -1,0 +1,173 @@
+package serial
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// Node carries what the broker learns about the device across one session.
+type Node struct {
+	// ServerCertProvisioned is true once the device holds the same server
+	// certificate we would push, so the SERVER_CERT step can be skipped.
+	ServerCertProvisioned bool
+	// DeviceCertProvisioned is true once the device reports that the cloud has
+	// its certificate, so the DEVICE_CERT step can be skipped.
+	DeviceCertProvisioned bool
+}
+
+// Endpoints supplies the five channel implementations. Info, DeviceCert and
+// Uplink are things the device sends us; ServerCert and Downlink are things we
+// send it.
+type Endpoints struct {
+	Info       Receiver
+	ServerCert Sender
+	DeviceCert Receiver
+	Downlink   Sender
+	Uplink     Receiver
+}
+
+// Broker drives one Pouch Serial session against a single device.
+//
+// It is a pure state machine: it never touches the link itself. Feed it frames
+// with Recv and drain them with FrameGet. All methods must be called from one
+// goroutine.
+type Broker struct {
+	channels [ChannelCount]channel
+	node     Node
+	log      *slog.Logger
+
+	infoRead     bool
+	syncStarted  bool
+	uplinkDone   bool
+	downlinkDone bool
+
+	// done reports the end of a session.
+	done func(success bool)
+	// wake signals that the broker has a frame ready to send.
+	wake func()
+}
+
+// NewBroker wires the endpoints into a session. done is called once per
+// session; wake is called whenever a frame becomes available.
+func NewBroker(ep Endpoints, log *slog.Logger, done func(bool), wake func()) *Broker {
+	b := &Broker{log: log, done: done, wake: wake}
+
+	b.channels[ChInfo] = channel{id: ChInfo, receiver: ep.Info}
+	b.channels[ChServerCert] = channel{id: ChServerCert, sender: ep.ServerCert}
+	b.channels[ChDeviceCert] = channel{id: ChDeviceCert, receiver: ep.DeviceCert}
+	b.channels[ChDownlink] = channel{id: ChDownlink, sender: ep.Downlink}
+	b.channels[ChUplink] = channel{id: ChUplink, receiver: ep.Uplink}
+
+	for i := range b.channels {
+		b.channels[i].closed = b.channelClosed
+	}
+	return b
+}
+
+// Node exposes the provisioning state the INFO endpoint fills in.
+func (b *Broker) Node() *Node { return &b.node }
+
+// Start begins a session.
+func (b *Broker) Start() {
+	b.infoRead = false
+	b.syncStarted = false
+	b.uplinkDone = false
+	b.downlinkDone = false
+	b.next()
+}
+
+// next advances the verb sequence: read the device's info, provision whichever
+// certificates are missing, then exchange pouches.
+func (b *Broker) next() {
+	switch {
+	case !b.infoRead:
+		b.infoRead = true
+		b.channels[ChInfo].ready()
+
+	case !b.node.ServerCertProvisioned:
+		b.channels[ChServerCert].ready()
+
+	case !b.node.DeviceCertProvisioned:
+		b.channels[ChDeviceCert].ready()
+
+	case !b.syncStarted:
+		b.syncStarted = true
+		// Both directions are collected in the same phase.
+		b.channels[ChUplink].ready()
+		b.channels[ChDownlink].ready()
+
+	case b.uplinkDone && b.downlinkDone:
+		if b.done != nil {
+			b.done(true)
+		}
+		return
+
+	default:
+		return
+	}
+
+	if b.wake != nil {
+		b.wake()
+	}
+}
+
+func (b *Broker) channelClosed(ch Channel, success bool) {
+	if !success {
+		b.infoRead = false
+		b.syncStarted = false
+		b.uplinkDone = false
+		b.downlinkDone = false
+		if b.done != nil {
+			b.done(false)
+		}
+		return
+	}
+
+	b.log.Debug("channel completed", "channel", ch)
+
+	switch ch {
+	case ChUplink:
+		b.uplinkDone = true
+	case ChDownlink:
+		b.downlinkDone = true
+	}
+
+	b.next()
+}
+
+// Recv feeds one received frame into the session.
+func (b *Broker) Recv(frame []byte) error {
+	if len(frame) == 0 {
+		return fmt.Errorf("serial: empty frame")
+	}
+
+	h, err := DecodeHeader(frame[0])
+	if err != nil {
+		return fmt.Errorf("serial: header 0x%02x (len %d): %w", frame[0], len(frame), err)
+	}
+	if h.Channel >= ChannelCount {
+		return fmt.Errorf("serial: unknown channel %d", h.Channel)
+	}
+
+	return b.channels[h.Channel].recv(h, frame[HeaderLen:])
+}
+
+// FrameGet returns the next frame to transmit, or nil when there is nothing to
+// send. Channels are served round-robin so no one channel can starve another.
+func (b *Broker) FrameGet(maxLen int) []byte {
+	for i := range b.channels {
+		if f := b.channels[i].frameGet(maxLen); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+// NotifyUplink re-arms the uplink channel, for a caller that has learned the
+// device has more to say.
+func (b *Broker) NotifyUplink() {
+	b.channels[ChUplink].ready()
+	if b.wake != nil {
+		b.wake()
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/serial/broker.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/broker.go
@@ -24,6 +24,12 @@ type Endpoints struct {
 	DeviceCert Receiver
 	Downlink   Sender
 	Uplink     Receiver
+
+	// Fw and FwStatus carry MCU-mediated firmware updates. Both are optional:
+	// leaving them nil leaves the channels unconfigured, which is what a
+	// gateway that does not apply firmware wants.
+	Fw       Receiver
+	FwStatus Sender
 }
 
 // Broker drives one Pouch Serial session against a single device.
@@ -40,6 +46,11 @@ type Broker struct {
 	syncStarted  bool
 	uplinkDone   bool
 	downlinkDone bool
+	fwDone       bool
+
+	// fwStatusPending is set when a verdict is waiting to go out, and cleared
+	// once it has been delivered. The session does not end while it is set.
+	fwStatusPending bool
 
 	// done reports the end of a session.
 	done func(success bool)
@@ -57,6 +68,8 @@ func NewBroker(ep Endpoints, log *slog.Logger, done func(bool), wake func()) *Br
 	b.channels[ChDeviceCert] = channel{id: ChDeviceCert, receiver: ep.DeviceCert}
 	b.channels[ChDownlink] = channel{id: ChDownlink, sender: ep.Downlink}
 	b.channels[ChUplink] = channel{id: ChUplink, receiver: ep.Uplink}
+	b.channels[ChFwStatus] = channel{id: ChFwStatus, sender: ep.FwStatus}
+	b.channels[ChFw] = channel{id: ChFw, receiver: ep.Fw}
 
 	for i := range b.channels {
 		b.channels[i].closed = b.channelClosed
@@ -73,6 +86,8 @@ func (b *Broker) Start() {
 	b.syncStarted = false
 	b.uplinkDone = false
 	b.downlinkDone = false
+	b.fwDone = b.channels[ChFw].receiver == nil
+	b.fwStatusPending = false
 	b.next()
 }
 
@@ -92,11 +107,21 @@ func (b *Broker) next() {
 
 	case !b.syncStarted:
 		b.syncStarted = true
-		// Both directions are collected in the same phase.
+		// Both pouch directions are collected in the same phase, and so is the
+		// firmware channel: the relay is fed by the very downlink it runs
+		// alongside, so collecting it afterwards would deadlock a device whose
+		// buffer fills mid-transfer.
 		b.channels[ChUplink].ready()
 		b.channels[ChDownlink].ready()
+		if b.channels[ChFw].receiver != nil {
+			b.channels[ChFw].ready()
+		}
 
-	case b.uplinkDone && b.downlinkDone:
+	// A verdict became available after the firmware transfer closed.
+	case b.fwStatusPending && !b.channels[ChFwStatus].pending && !b.channels[ChFwStatus].open:
+		b.channels[ChFwStatus].ready()
+
+	case b.uplinkDone && b.downlinkDone && b.fwDone && !b.fwStatusPending:
 		if b.done != nil {
 			b.done(true)
 		}
@@ -117,6 +142,8 @@ func (b *Broker) channelClosed(ch Channel, success bool) {
 		b.syncStarted = false
 		b.uplinkDone = false
 		b.downlinkDone = false
+		b.fwDone = false
+		b.fwStatusPending = false
 		if b.done != nil {
 			b.done(false)
 		}
@@ -130,6 +157,10 @@ func (b *Broker) channelClosed(ch Channel, success bool) {
 		b.uplinkDone = true
 	case ChDownlink:
 		b.downlinkDone = true
+	case ChFw:
+		b.fwDone = true
+	case ChFwStatus:
+		b.fwStatusPending = false
 	}
 
 	b.next()
@@ -161,6 +192,15 @@ func (b *Broker) FrameGet(maxLen int) []byte {
 		}
 	}
 	return nil
+}
+
+// SendFwStatus asks the broker to deliver a firmware apply verdict before the
+// session ends. Call it from the firmware channel's End, while the transfer
+// that produced the image is closing.
+func (b *Broker) SendFwStatus() {
+	if b.channels[ChFwStatus].sender != nil {
+		b.fwStatusPending = true
+	}
 }
 
 // NotifyUplink re-arms the uplink channel, for a caller that has learned the

--- a/examples/linux/rpmsg_gateway/internal/serial/channel.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/channel.go
@@ -1,0 +1,242 @@
+package serial
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Result is what a Sender reports about the data it just produced.
+type Result int
+
+const (
+	// MoreData means the endpoint expects to be called again. Returning it with
+	// zero bytes means "nothing ready yet", not "finished".
+	MoreData Result = iota
+	// NoMoreData means the transfer is complete; the frame carrying it is LAST.
+	NoMoreData
+	// SendError abandons the transfer.
+	SendError
+)
+
+// ErrNoEndpoint is reported for a frame on a channel this build knows by id but
+// has no endpoint for.
+var ErrNoEndpoint = errors.New("serial: channel has no endpoint")
+
+// Sender produces bytes for a channel this side transmits on.
+type Sender interface {
+	// Start opens a transfer. A non-nil error aborts the channel.
+	Start() error
+	// Send returns up to max bytes. Returning zero bytes with MoreData means
+	// the data is not ready yet and the channel should be polled again.
+	Send(max int) ([]byte, Result)
+	// End reports how the transfer finished. Optional: implementations that
+	// have nothing to tear down may leave it a no-op.
+	End(success bool)
+}
+
+// Receiver consumes bytes for a channel this side receives on.
+type Receiver interface {
+	Start() error
+	Recv(p []byte) error
+	End(success bool)
+}
+
+// channel is one endpoint's state machine. Only one side of sender/receiver is
+// ever set; which one determines whether the channel prompts or is prompted.
+type channel struct {
+	id       Channel
+	sender   Sender
+	receiver Receiver
+
+	open      bool
+	firstFrag bool
+	pending   bool
+	errored   bool
+
+	// closed is invoked after a transfer finishes, successfully or not.
+	closed func(ch Channel, success bool)
+}
+
+func (c *channel) configured() bool { return c.sender != nil || c.receiver != nil }
+
+// ready marks the channel as having something to say on the next frameGet.
+func (c *channel) ready() { c.pending = true }
+
+func (c *channel) start() error {
+	if c.sender != nil {
+		return c.sender.Start()
+	}
+	return c.receiver.Start()
+}
+
+func (c *channel) end(success bool) {
+	if c.sender != nil {
+		c.sender.End(success)
+		return
+	}
+	c.receiver.End(success)
+}
+
+// close ends an open transfer. Closing an already-closed channel is a no-op, so
+// the error paths can call it freely.
+func (c *channel) close(success bool) {
+	if !c.open {
+		return
+	}
+	c.open = false
+
+	if !success {
+		c.errored = true
+	}
+
+	c.end(success)
+
+	if c.closed != nil {
+		c.closed(c.id, success)
+	}
+
+	// A failed transfer still owes the peer an error frame.
+	if !success {
+		c.ready()
+	}
+}
+
+func (c *channel) recv(h Header, payload []byte) error {
+	if !c.configured() {
+		// The peer is using an optional feature this build does not implement.
+		// Ignore it rather than dereferencing a missing endpoint.
+		return ErrNoEndpoint
+	}
+	if h.IsData {
+		return c.handleData(h, payload)
+	}
+	return c.handleAck(h.Err)
+}
+
+func (c *channel) handleAck(err bool) error {
+	if err {
+		c.close(false)
+		return nil
+	}
+
+	// Receiver channels do not open on an ACK - they open when the first DATA
+	// frame arrives. Answer with an ACK so the remote sender may proceed.
+	if c.sender == nil {
+		c.ready()
+		return nil
+	}
+
+	if !c.open {
+		c.open = true
+		if err := c.sender.Start(); err != nil {
+			c.errored = true
+			c.close(false)
+			return nil
+		}
+		c.firstFrag = true
+		c.ready()
+	}
+	return nil
+}
+
+func (c *channel) handleData(h Header, payload []byte) error {
+	if h.Err {
+		c.close(false)
+		return nil
+	}
+
+	if !c.open {
+		if !h.First {
+			c.close(false)
+			return fmt.Errorf("serial: ch %d: data without FIRST", c.id)
+		}
+		c.open = true
+		if err := c.start(); err != nil {
+			c.open = false
+			c.errored = true
+			c.ready() // nack
+			return err
+		}
+		c.firstFrag = true
+	} else if h.First {
+		c.close(false)
+		return fmt.Errorf("serial: ch %d: unexpected FIRST on an open transfer", c.id)
+	}
+
+	if len(payload) > 0 {
+		if c.receiver == nil {
+			c.close(false)
+			return fmt.Errorf("serial: ch %d: data on a send-only channel", c.id)
+		}
+		if err := c.receiver.Recv(payload); err != nil {
+			c.close(false)
+			return err
+		}
+	}
+
+	if h.Last {
+		c.close(true)
+	}
+	return nil
+}
+
+// frameGet returns the next frame this channel wants to send, or nil if it has
+// nothing pending. maxLen bounds the whole frame, header included.
+func (c *channel) frameGet(maxLen int) []byte {
+	if maxLen <= HeaderLen || !c.configured() {
+		return nil
+	}
+	if !c.pending {
+		return nil
+	}
+	c.pending = false
+
+	// Receiver channel: all it ever emits is an ACK.
+	if c.sender == nil {
+		errored := c.errored
+		c.errored = false
+		return []byte{Header{Channel: c.id, Err: errored}.Encode()}
+	}
+
+	if c.errored {
+		c.errored = false
+		first := c.firstFrag
+		c.firstFrag = false
+		c.open = false
+		return []byte{Header{
+			IsData: true, Err: true, First: first, Last: true, Channel: c.id,
+		}.Encode()}
+	}
+
+	if !c.open {
+		// Prompt the peer to open the transfer by ACKing back.
+		return []byte{Header{Channel: c.id}.Encode()}
+	}
+
+	data, result := c.sender.Send(maxLen - HeaderLen)
+	if len(data) == 0 && result == MoreData {
+		// Nothing ready yet. Do not send an empty frame; re-arm so the channel
+		// is polled again, because nothing else will.
+		c.ready()
+		return nil
+	}
+
+	failed := result == SendError
+	last := result == NoMoreData || failed
+
+	first := c.firstFrag
+	c.firstFrag = false
+
+	frame := make([]byte, 0, HeaderLen+len(data))
+	frame = append(frame, Header{
+		IsData: true, Err: failed, First: first, Last: last, Channel: c.id,
+	}.Encode())
+	frame = append(frame, data...)
+
+	if last {
+		c.close(!failed)
+	} else {
+		c.ready()
+	}
+	return frame
+}

--- a/examples/linux/rpmsg_gateway/internal/serial/endpoints.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/endpoints.go
@@ -1,0 +1,68 @@
+package serial
+
+import "bytes"
+
+// BufReceiver collects a whole transfer in memory and hands it to Done when the
+// channel closes. Done runs before the broker advances to the next verb, so it
+// is the place to update provisioning state.
+type BufReceiver struct {
+	buf  bytes.Buffer
+	Done func(data []byte, success bool)
+}
+
+func (r *BufReceiver) Start() error {
+	r.buf.Reset()
+	return nil
+}
+
+func (r *BufReceiver) Recv(p []byte) error {
+	r.buf.Write(p)
+	return nil
+}
+
+func (r *BufReceiver) End(success bool) {
+	if r.Done != nil {
+		r.Done(r.buf.Bytes(), success)
+	}
+}
+
+// Bytes returns what has been collected so far.
+func (r *BufReceiver) Bytes() []byte { return r.buf.Bytes() }
+
+// BufSender serves a byte slice, fragmenting it to whatever the link allows.
+// Data is called once per transfer, at Start.
+type BufSender struct {
+	Data func() []byte
+	Done func(success bool)
+
+	data []byte
+	off  int
+}
+
+func (s *BufSender) Start() error {
+	if s.Data != nil {
+		s.data = s.Data()
+	}
+	s.off = 0
+	return nil
+}
+
+func (s *BufSender) Send(max int) ([]byte, Result) {
+	n := len(s.data) - s.off
+	if n > max {
+		n = max
+	}
+	chunk := s.data[s.off : s.off+n]
+	s.off += n
+
+	if s.off >= len(s.data) {
+		return chunk, NoMoreData
+	}
+	return chunk, MoreData
+}
+
+func (s *BufSender) End(success bool) {
+	if s.Done != nil {
+		s.Done(success)
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/serial/exchange_test.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/exchange_test.go
@@ -1,0 +1,213 @@
+package serial
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// The device half, built from the same channel state machine as the broker.
+// Mirroring tests/pouch/serial/exchange in the Pouch tree: driving both ends
+// through each other is what proves the two agree on the wire, since a
+// disagreement stops the exchange converging.
+type device struct {
+	channels [ChannelCount]channel
+}
+
+func newDevice(info, deviceCert, uplink []byte, serverCert, downlink *bytes.Buffer) *device {
+	d := &device{}
+	d.channels[ChInfo] = channel{id: ChInfo, sender: &BufSender{Data: func() []byte { return info }}}
+	d.channels[ChServerCert] = channel{id: ChServerCert, receiver: &collector{buf: serverCert}}
+	d.channels[ChDeviceCert] = channel{id: ChDeviceCert, sender: &BufSender{Data: func() []byte { return deviceCert }}}
+	d.channels[ChDownlink] = channel{id: ChDownlink, receiver: &collector{buf: downlink}}
+	d.channels[ChUplink] = channel{id: ChUplink, sender: &BufSender{Data: func() []byte { return uplink }}}
+	return d
+}
+
+func (d *device) recv(frame []byte) error {
+	h, err := DecodeHeader(frame[0])
+	if err != nil {
+		return err
+	}
+	return d.channels[h.Channel].recv(h, frame[HeaderLen:])
+}
+
+func (d *device) frameGet(max int) []byte {
+	for i := range d.channels {
+		if f := d.channels[i].frameGet(max); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+type collector struct{ buf *bytes.Buffer }
+
+func (c *collector) Start() error        { c.buf.Reset(); return nil }
+func (c *collector) Recv(p []byte) error { c.buf.Write(p); return nil }
+func (c *collector) End(success bool)    {}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// pump runs frames between the two halves until neither has anything to say.
+func pump(t *testing.T, b *Broker, d *device, maxFrame int) int {
+	t.Helper()
+	const maxIter = 500
+	iter := 0
+	for ; iter < maxIter; iter++ {
+		if f := b.FrameGet(maxFrame); f != nil {
+			if err := d.recv(f); err != nil {
+				t.Fatalf("device rejected frame 0x%02x: %v", f[0], err)
+			}
+			continue
+		}
+		if f := d.frameGet(maxFrame); f != nil {
+			if err := b.Recv(f); err != nil {
+				t.Fatalf("broker rejected frame 0x%02x: %v", f[0], err)
+			}
+			continue
+		}
+		break
+	}
+	if iter == maxIter {
+		t.Fatalf("exchange did not converge in %d iterations", maxIter)
+	}
+	return iter
+}
+
+func TestFullExchange(t *testing.T) {
+	var (
+		infoPayload       = []byte("device-info-stub")
+		deviceCertPayload = []byte("device-certificate-data")
+		uplinkPayload     = []byte("uplink-payload")
+		serverCertPayload = []byte("server-certificate-data")
+		downlinkPayload   = []byte("downlink-payload")
+	)
+
+	var gotServerCert, gotDownlink bytes.Buffer
+	dev := newDevice(infoPayload, deviceCertPayload, uplinkPayload, &gotServerCert, &gotDownlink)
+
+	var gotInfo, gotDeviceCert, gotUplink []byte
+	var sessionOK, finished bool
+
+	var b *Broker
+	ep := Endpoints{
+		Info: &BufReceiver{Done: func(d []byte, ok bool) {
+			gotInfo = append([]byte(nil), d...)
+			// The device in this test is unprovisioned, so both certificate
+			// phases must run.
+			b.Node().ServerCertProvisioned = false
+			b.Node().DeviceCertProvisioned = false
+		}},
+		ServerCert: &BufSender{Data: func() []byte { return serverCertPayload },
+			Done: func(ok bool) { b.Node().ServerCertProvisioned = ok }},
+		DeviceCert: &BufReceiver{Done: func(d []byte, ok bool) {
+			gotDeviceCert = append([]byte(nil), d...)
+			b.Node().DeviceCertProvisioned = ok
+		}},
+		Downlink: &BufSender{Data: func() []byte { return downlinkPayload }},
+		Uplink: &BufReceiver{Done: func(d []byte, ok bool) {
+			gotUplink = append([]byte(nil), d...)
+		}},
+	}
+
+	b = NewBroker(ep, discardLogger(), func(ok bool) { finished, sessionOK = true, ok }, func() {})
+	b.Start()
+
+	pump(t, b, dev, 64)
+
+	if !finished || !sessionOK {
+		t.Fatalf("session did not complete successfully (finished=%v ok=%v)", finished, sessionOK)
+	}
+
+	// Device -> broker.
+	if !bytes.Equal(gotInfo, infoPayload) {
+		t.Errorf("info = %q, want %q", gotInfo, infoPayload)
+	}
+	if !bytes.Equal(gotDeviceCert, deviceCertPayload) {
+		t.Errorf("device cert = %q, want %q", gotDeviceCert, deviceCertPayload)
+	}
+	if !bytes.Equal(gotUplink, uplinkPayload) {
+		t.Errorf("uplink = %q, want %q", gotUplink, uplinkPayload)
+	}
+
+	// Broker -> device.
+	if !bytes.Equal(gotServerCert.Bytes(), serverCertPayload) {
+		t.Errorf("server cert = %q, want %q", gotServerCert.Bytes(), serverCertPayload)
+	}
+	if !bytes.Equal(gotDownlink.Bytes(), downlinkPayload) {
+		t.Errorf("downlink = %q, want %q", gotDownlink.Bytes(), downlinkPayload)
+	}
+}
+
+// A payload larger than one frame must be fragmented and reassembled.
+func TestExchangeFragments(t *testing.T) {
+	big := bytes.Repeat([]byte("0123456789abcdef"), 40) // 640 bytes
+
+	var gotServerCert, gotDownlink bytes.Buffer
+	dev := newDevice([]byte("i"), []byte("c"), big, &gotServerCert, &gotDownlink)
+
+	var gotUplink []byte
+	var finished, ok bool
+	var b *Broker
+	b = NewBroker(Endpoints{
+		Info:       &BufReceiver{},
+		ServerCert: &BufSender{Data: func() []byte { return []byte("sc") }, Done: func(ok bool) { b.Node().ServerCertProvisioned = ok }},
+		DeviceCert: &BufReceiver{Done: func(_ []byte, o bool) { b.Node().DeviceCertProvisioned = o }},
+		Downlink:   &BufSender{Data: func() []byte { return big }},
+		Uplink:     &BufReceiver{Done: func(d []byte, _ bool) { gotUplink = append([]byte(nil), d...) }},
+	}, discardLogger(), func(o bool) { finished, ok = true, o }, func() {})
+	b.Start()
+
+	pump(t, b, dev, 32) // 31 payload bytes per frame forces fragmentation
+
+	if !finished || !ok {
+		t.Fatalf("session did not complete (finished=%v ok=%v)", finished, ok)
+	}
+	if !bytes.Equal(gotUplink, big) {
+		t.Errorf("uplink round trip failed: got %d bytes, want %d", len(gotUplink), len(big))
+	}
+	if !bytes.Equal(gotDownlink.Bytes(), big) {
+		t.Errorf("downlink round trip failed: got %d bytes, want %d", gotDownlink.Len(), len(big))
+	}
+}
+
+// A provisioned device must skip both certificate phases.
+func TestProvisionedDeviceSkipsCertPhases(t *testing.T) {
+	var gotServerCert, gotDownlink bytes.Buffer
+	dev := newDevice([]byte("i"), []byte("c"), []byte("u"), &gotServerCert, &gotDownlink)
+
+	serverCertSent := false
+	deviceCertRead := false
+	var finished bool
+	var b *Broker
+	b = NewBroker(Endpoints{
+		Info: &BufReceiver{Done: func(_ []byte, _ bool) {
+			b.Node().ServerCertProvisioned = true
+			b.Node().DeviceCertProvisioned = true
+		}},
+		ServerCert: &BufSender{Data: func() []byte { serverCertSent = true; return []byte("sc") }},
+		DeviceCert: &BufReceiver{Done: func(_ []byte, _ bool) { deviceCertRead = true }},
+		Downlink:   &BufSender{Data: func() []byte { return []byte("d") }},
+		Uplink:     &BufReceiver{},
+	}, discardLogger(), func(bool) { finished = true }, func() {})
+	b.Start()
+
+	pump(t, b, dev, 64)
+
+	if !finished {
+		t.Fatal("session did not complete")
+	}
+	if serverCertSent {
+		t.Error("server certificate was pushed to an already-provisioned device")
+	}
+	if deviceCertRead {
+		t.Error("device certificate was collected from an already-provisioned device")
+	}
+	if gotServerCert.Len() != 0 {
+		t.Errorf("device received %d server-cert bytes, want none", gotServerCert.Len())
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/serial/packet.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/packet.go
@@ -20,9 +20,15 @@ const (
 	ChDeviceCert Channel = 2 // device -> broker: device leaf certificate
 	ChDownlink   Channel = 3 // broker -> device: inbound pouches
 	ChUplink     Channel = 4 // device -> broker: outbound pouches
+	ChFwStatus   Channel = 5 // broker -> device: firmware apply verdict
+	ChFw         Channel = 6 // device -> broker: firmware image relay
 
-	ChannelCount Channel = 5
+	ChannelCount Channel = 7
 )
+
+// Direction is encoded in the parity of the channel id: odd ids run
+// broker -> device, even ids device -> broker.
+func (c Channel) BrokerToDevice() bool { return c&1 == 1 }
 
 // HeaderLen is the size of the frame header in bytes.
 const HeaderLen = 1

--- a/examples/linux/rpmsg_gateway/internal/serial/packet.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/packet.go
@@ -1,0 +1,99 @@
+// Package serial implements the broker half of the Pouch Serial protocol.
+//
+// The wire format is a one-byte header followed by an optional payload. Frame
+// boundaries come from the link, not from the header: over rpmsg one message is
+// exactly one frame, so there is no length prefix and no start-of-frame byte.
+//
+// This mirrors src/transport/serial/ in the Pouch tree. The device half runs on
+// the MCU; this is what the Linux side needs to talk to it.
+package serial
+
+import "errors"
+
+// Channel identifiers. These are wire constants: every build agrees on them
+// whether or not it implements the channel.
+type Channel uint8
+
+const (
+	ChInfo       Channel = 0 // device -> broker: device metadata and flags
+	ChServerCert Channel = 1 // broker -> device: server certificate chain
+	ChDeviceCert Channel = 2 // device -> broker: device leaf certificate
+	ChDownlink   Channel = 3 // broker -> device: inbound pouches
+	ChUplink     Channel = 4 // device -> broker: outbound pouches
+
+	ChannelCount Channel = 5
+)
+
+// HeaderLen is the size of the frame header in bytes.
+const HeaderLen = 1
+
+const (
+	hdrData   = 1 << 7
+	hdrErr    = 1 << 6
+	hdrFirst  = 1 << 5
+	hdrLast   = 1 << 4
+	hdrChMask = 0x0f
+
+	// FIRST and LAST are reserved in an ACK frame and must be zero.
+	hdrAckReserved = hdrFirst | hdrLast
+)
+
+// ErrMalformedHeader is returned for an ACK frame with reserved bits set.
+var ErrMalformedHeader = errors.New("serial: malformed frame header")
+
+// Header is the decoded one-byte frame header.
+//
+//	ACK frame  (bit 7 = 0): [ 0 | ERR |  0   |  0   | channel[3:0] ]
+//	Data frame (bit 7 = 1): [ 1 | ERR | FIRST| LAST | channel[3:0] ]
+type Header struct {
+	IsData bool
+	// Err marks a transfer abandoned by the sender (data frames, always with
+	// Last) or by the receiver (ACK frames).
+	Err     bool
+	First   bool
+	Last    bool
+	Channel Channel
+}
+
+// Encode renders the header as its wire byte.
+func (h Header) Encode() byte {
+	b := byte(h.Channel) & hdrChMask
+	if h.IsData {
+		b |= hdrData
+		if h.First {
+			b |= hdrFirst
+		}
+		if h.Last {
+			b |= hdrLast
+		}
+	}
+	if h.Err {
+		b |= hdrErr
+	}
+	return b
+}
+
+// DecodeHeader parses a wire header byte.
+func DecodeHeader(b byte) (Header, error) {
+	h := Header{
+		IsData:  b&hdrData != 0,
+		Err:     b&hdrErr != 0,
+		Channel: Channel(b & hdrChMask),
+	}
+
+	if h.IsData {
+		h.First = b&hdrFirst != 0
+		h.Last = b&hdrLast != 0
+		// An error always terminates the transfer, whether or not the sender
+		// bothered to set LAST.
+		if h.Err {
+			h.Last = true
+		}
+		return h, nil
+	}
+
+	if b&hdrAckReserved != 0 {
+		return Header{}, ErrMalformedHeader
+	}
+	return h, nil
+}

--- a/examples/linux/rpmsg_gateway/internal/serial/packet_test.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/packet_test.go
@@ -1,0 +1,76 @@
+package serial
+
+import "testing"
+
+// Wire vectors. The 0xb0 and 0xb2 cases are bytes captured from a real device
+// (Zephyr on an i.MX95 M7) answering an INFO and a DEVICE_CERT prompt, so they
+// pin this implementation against the C one rather than against itself.
+func TestHeaderVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		byte byte
+		hdr  Header
+	}{
+		{"ack ch0", 0x00, Header{Channel: ChInfo}},
+		{"ack ch2", 0x02, Header{Channel: ChDeviceCert}},
+		{"ack err ch4", 0x44, Header{Channel: ChUplink, Err: true}},
+		{"data first+last ch0 (from hardware)", 0xb0,
+			Header{IsData: true, First: true, Last: true, Channel: ChInfo}},
+		{"data first+last ch2 (from hardware)", 0xb2,
+			Header{IsData: true, First: true, Last: true, Channel: ChDeviceCert}},
+		{"data first ch3", 0xa3,
+			Header{IsData: true, First: true, Channel: ChDownlink}},
+		{"data mid-transfer ch4", 0x84, Header{IsData: true, Channel: ChUplink}},
+		{"data last ch1", 0x91, Header{IsData: true, Last: true, Channel: ChServerCert}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.hdr.Encode(); got != tt.byte {
+				t.Errorf("Encode() = 0x%02x, want 0x%02x", got, tt.byte)
+			}
+			got, err := DecodeHeader(tt.byte)
+			if err != nil {
+				t.Fatalf("DecodeHeader(0x%02x) failed: %v", tt.byte, err)
+			}
+			if got != tt.hdr {
+				t.Errorf("DecodeHeader(0x%02x) = %+v, want %+v", tt.byte, got, tt.hdr)
+			}
+		})
+	}
+}
+
+// FIRST and LAST are reserved in an ACK and must be rejected, matching
+// pouch_serial_header_decode().
+func TestDecodeRejectsReservedAckBits(t *testing.T) {
+	for _, b := range []byte{0x20, 0x10, 0x30} {
+		if _, err := DecodeHeader(b); err == nil {
+			t.Errorf("DecodeHeader(0x%02x) accepted a malformed ACK", b)
+		}
+	}
+}
+
+// An error on a data frame always terminates the transfer, whether or not the
+// sender set LAST.
+func TestDecodeErrImpliesLast(t *testing.T) {
+	h, err := DecodeHeader(0xc0) // DATA | ERR, no LAST
+	if err != nil {
+		t.Fatalf("DecodeHeader failed: %v", err)
+	}
+	if !h.Err || !h.Last {
+		t.Errorf("got %+v, want Err and Last both set", h)
+	}
+}
+
+func TestHeaderRoundTrip(t *testing.T) {
+	for b := 0; b < 256; b++ {
+		h, err := DecodeHeader(byte(b))
+		if err != nil {
+			continue // malformed ACKs have no round trip
+		}
+		// An ERR data frame re-encodes with LAST, which decode already implied.
+		if got := h.Encode(); got != byte(b) && !(h.IsData && h.Err) {
+			t.Errorf("round trip of 0x%02x produced 0x%02x", b, got)
+		}
+	}
+}


### PR DESCRIPTION
The Linux half of the rpmsg transport: a Go daemon that brokers Pouch sessions
between the MCU on `/dev/rpmsgN` and Golioth over mTLS. This is what made the
end-to-end hardware validation of #304 possible.

**We expect this to end up in a production gateway rather than here.** It is
proposed as an example so the rpmsg transport has a working host counterpart to
be reviewed and validated against — which is what it has already done, carrying
the end-to-end hardware runs behind #304, #350 and #351 — but a gateway that
ships is not an example, and this would be better moved than maintained in two
places.

`internal/serial` is the load-bearing part and the piece worth moving. It is the
only implementation of Pouch Serial outside the firmware tree, and any host
gateway needs one regardless once SPI (#256) lands. It transfers roughly intact:
a pure state machine that never touches the link, so it carries no assumption
about rpmsg. `cmd/` and `internal/link` are the example-shaped parts and would be
dropped or replaced.

Merging here is therefore worth treating as provisional. If the move happens
soon it may be better not to land this at all, and to take `internal/serial`
straight across. See the discussion on #274.

Stack:
1. #304 `transport/rpmsg` — device-side transport
2. **this PR** `transport/rpmsg-broker` — the Go gateway
3. `transport/rpmsg-ota` — MCU-mediated firmware relay
4. `transport/rpmsg-signed-url` — signed-URL firmware delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qt7dZyVifxnMVfSHJT1neN


