### PR TITLE
transport: serial: MCU-mediated firmware relay

### DIFF
--- a/examples/zephyr/rpmsg_device/CMakeLists.txt
+++ b/examples/zephyr/rpmsg_device/CMakeLists.txt
@@ -11,3 +11,7 @@ target_sources(app PRIVATE
   src/main.c
   src/credentials.c
 )
+
+if(CONFIG_POUCH_SERIAL_FW_RELAY)
+  target_sources(app PRIVATE src/fw_relay.c)
+endif()

--- a/examples/zephyr/rpmsg_device/Kconfig
+++ b/examples/zephyr/rpmsg_device/Kconfig
@@ -4,4 +4,13 @@
 
 mainmenu "Pouch rpmsg device example"
 
+config EXAMPLE_FW_COMPONENT
+    string "OTA component to use for firmware update"
+    depends on POUCH_SERIAL_FW_RELAY
+    default "rpmsg_device"
+    help
+      Name of the component in the OTA manifest carrying this core's firmware.
+      The image is relayed to the host, which verifies and applies it through
+      remoteproc - this core has no flash of its own.
+
 source "Kconfig.zephyr"

--- a/examples/zephyr/rpmsg_device/boards/imx95_evk_mimx9596_m7.conf
+++ b/examples/zephyr/rpmsg_device/boards/imx95_evk_mimx9596_m7.conf
@@ -55,6 +55,16 @@ CONFIG_OPENAMP_WITH_DCACHE=y
 CONFIG_POUCH_SERIAL_UART_DEVICE=n
 CONFIG_POUCH_RPMSG_RSC_DEVICE=y
 
+# MCU-mediated OTA: this core has no flash, so it relays its own image to the
+# host, which verifies and applies it through remoteproc. malloc() draws from
+# whatever RAM is left after static allocations, and the downlink
+# heap-allocates one buffer per encrypted block in flight, so a bigger relay
+# buffer shrinks the pool the downlink needs. 32 KB leaves a comfortable arena.
+CONFIG_POUCH_SERIAL_FW_RELAY=y
+CONFIG_POUCH_SERIAL_FW_BUF_SIZE=32768
+CONFIG_GOLIOTH=y
+CONFIG_GOLIOTH_OTA=y
+
 # Keep the M7 console (LPUART3) for logs.
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/examples/zephyr/rpmsg_device/src/fw_relay.c
+++ b/examples/zephyr/rpmsg_device/src/fw_relay.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * MCU-mediated firmware update.
+ *
+ * This core has no flash of its own - the host loads it through remoteproc at
+ * every boot - so it cannot apply an update itself. It is still the
+ * authenticated Pouch endpoint, so it downloads its own image through Pouch OTA
+ * and streams the plaintext out to the host over the serial firmware channel.
+ * The host verifies the SHA-256 from the manifest, installs the image next to
+ * the previous one, and restarts this core.
+ *
+ * Only a block-sized buffer of RAM is used: relaying blocks while the outgoing
+ * buffer is full, which throttles the download to the speed of the link.
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(fw_relay, LOG_LEVEL_INF);
+
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+
+#include <string.h>
+
+#include <golioth/ota.h>
+#include <pouch/transport/serial/fw.h>
+
+#include <app_version.h>
+
+#define FW_COMPONENT CONFIG_EXAMPLE_FW_COMPONENT
+
+/* pouch_serial_fw_begin() rejects names longer than this. */
+#define FW_VERSION_MAX 32
+
+/* How many times to re-offer an image the host rejects before giving up. A
+ * rejection is usually a corrupt transfer, which a retry fixes; a genuinely bad
+ * image would otherwise retry every session forever.
+ */
+#define FW_MAX_ATTEMPTS 3
+
+static bool relaying;
+
+/*
+ * The image currently being relayed. The manifest's strings only live for the
+ * duration of the manifest handler, but a rejected image has to be restarted
+ * long after that, so keep a copy.
+ */
+static struct
+{
+    char version[FW_VERSION_MAX + 1];
+    uint8_t hash[32];
+    size_t size;
+    bool valid;
+    int attempts;
+} pending;
+
+static int relay_start(void)
+{
+    int err =
+        pouch_serial_fw_begin(FW_COMPONENT, pending.version, (uint32_t) pending.size, pending.hash);
+    if (err)
+    {
+        LOG_ERR("Failed to start firmware relay: %d", err);
+        return err;
+    }
+
+    relaying = true;
+    golioth_ota_mark_for_download(FW_COMPONENT);
+    return 0;
+}
+
+/* Runs on the downlink decrypt work queue. Blocking here is deliberate: it is
+ * the backpressure that stops the cloud outrunning the serial link.
+ */
+static void fw_receive(const void *data, size_t offset, size_t len, bool is_last)
+{
+    if (!relaying)
+    {
+        return;
+    }
+
+    /* Blocking here is the backpressure that stops the cloud outrunning the
+     * link: the broker drains the firmware channel concurrently with this
+     * downlink, so waiting does make progress. It is still bounded rather than
+     * indefinite - a broker that never collects the firmware channel would
+     * otherwise wedge the session that is supposed to drain it.
+     */
+    int ret = pouch_serial_fw_write(data, len, POUCH_SECONDS(5));
+    if (ret < (int) len)
+    {
+        LOG_ERR("Firmware relay stalled at offset %zu (%d/%zu) - abandoning update",
+                offset,
+                ret,
+                len);
+        relaying = false;
+        pouch_serial_fw_abort();
+        golioth_ota_mark_idle(FW_COMPONENT);
+        return;
+    }
+
+    if (is_last)
+    {
+        LOG_INF("Relayed %zu bytes, awaiting host apply", offset + len);
+        pouch_serial_fw_end();
+        relaying = false;
+
+        /* The host verifies and restarts this core. Marking updating stops the
+         * cloud sending more component data in the meantime.
+         */
+        golioth_ota_mark_updating(FW_COMPONENT);
+    }
+}
+
+GOLIOTH_OTA_COMPONENT(fw, FW_COMPONENT, APP_VERSION_STRING, fw_receive);
+
+static void fw_manifest(const struct golioth_ota_manifest_component *components, size_t num)
+{
+    for (size_t i = 0; i < num; i++)
+    {
+        const struct golioth_ota_manifest_component *c = &components[i];
+
+        if (strcmp(c->name, FW_COMPONENT) != 0)
+        {
+            continue;
+        }
+
+        if (strcmp(c->target, APP_VERSION_STRING) == 0)
+        {
+            LOG_DBG("Already running %s", c->target);
+            continue;
+        }
+
+        LOG_INF("Update available: %s -> %s (%zu bytes)", c->current, c->target, c->size);
+
+        if (strlen(c->target) > FW_VERSION_MAX)
+        {
+            LOG_ERR("Target version %s is too long to relay", c->target);
+            continue;
+        }
+
+        strcpy(pending.version, c->target);
+        memcpy(pending.hash, c->target_hash, sizeof(pending.hash));
+        pending.size = c->size;
+        pending.attempts = 1;
+        pending.valid = true;
+
+        if (relay_start() != 0)
+        {
+            pending.valid = false;
+        }
+    }
+}
+
+GOLIOTH_OTA_MANIFEST_HANDLER(fw_manifest);
+
+/*
+ * The host's verdict on an image we relayed.
+ *
+ * This is the only place a rejection can be acted on. By the time it arrives
+ * the device has called golioth_ota_mark_updating(), which tells the cloud to
+ * stop offering the component, and the OTA manifest that would otherwise
+ * re-offer it is delivered once per connection - so a device that waits for
+ * another manifest after a rejection never retries. Re-arming the download from
+ * here is what makes a retry possible at all.
+ */
+static void fw_apply_status(enum pouch_serial_fw_status status)
+{
+    if (status == POUCH_SERIAL_FW_STATUS_OK)
+    {
+        LOG_INF("Host installed %s; awaiting restart", pending.version);
+        pending.valid = false;
+        return;
+    }
+
+    LOG_WRN("Host rejected the image (status %d)", status);
+
+    if (!pending.valid)
+    {
+        return;
+    }
+
+    if (pending.attempts >= FW_MAX_ATTEMPTS)
+    {
+        LOG_ERR("Giving up on %s after %d attempts", pending.version, pending.attempts);
+        pending.valid = false;
+        relaying = false;
+        /* Leaving the component "updating" would stop the cloud sending any
+         * component at all, not just this one.
+         */
+        golioth_ota_mark_idle(FW_COMPONENT);
+        return;
+    }
+
+    /* Nothing is in flight after a verdict, but a relay abandoned mid-image
+     * would still be active - clear it either way so begin() can restart.
+     */
+    pouch_serial_fw_abort();
+    relaying = false;
+
+    pending.attempts++;
+    LOG_INF("Retrying %s (attempt %d/%d)", pending.version, pending.attempts, FW_MAX_ATTEMPTS);
+
+    if (relay_start() != 0)
+    {
+        pending.valid = false;
+        golioth_ota_mark_idle(FW_COMPONENT);
+    }
+}
+
+static int fw_relay_init(void)
+{
+    pouch_serial_fw_status_callback_set(fw_apply_status);
+    return 0;
+}
+
+SYS_INIT(fw_relay_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/include/pouch/transport/serial/common.h
+++ b/include/pouch/transport/serial/common.h
@@ -15,6 +15,8 @@ enum pouch_serial_channel_id
     POUCH_SERIAL_CH_DEVICE_CERT, /**< Device -> Broker: device leaf certificate */
     POUCH_SERIAL_CH_DOWNLINK,    /**< Broker -> Device: inbound pouches */
     POUCH_SERIAL_CH_UPLINK,      /**< Device -> Broker: outbound pouches */
+    POUCH_SERIAL_CH_FW_STATUS,   /**< Broker -> Device: firmware apply result */
+    POUCH_SERIAL_CH_FW,          /**< Device -> Broker: firmware image relay */
 
     POUCH_SERIAL_CHANNEL_COUNT,
 };

--- a/include/pouch/transport/serial/fw.h
+++ b/include/pouch/transport/serial/fw.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <pouch/port.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @file fw.h
+ * @brief MCU-mediated firmware relay over the Pouch Serial firmware channel.
+ *
+ * On MPU+MCU parts the MCU usually has no flash of its own: it is loaded from
+ * the host filesystem at every boot (remoteproc on Linux). The MCU is still the
+ * authenticated Pouch endpoint, so it downloads its own image through Pouch OTA
+ * and streams the plaintext out to the host, which verifies and applies it.
+ *
+ * The application feeds this module from its Golioth OTA handlers; the serial
+ * firmware endpoint drains it. Only a small buffer of MCU RAM is used - the
+ * image is never resident.
+ *
+ * The image arrives from the cloud over several Pouch sessions, so the relay is
+ * chunked: each session carries whatever is buffered at that moment, tagged with
+ * its absolute offset in the image, and the host assembles them. A relay that
+ * tried to send the whole image within one session would deadlock, because the
+ * remaining bytes only arrive on the next session's downlink.
+ */
+
+/** Size of the fixed part of the firmware chunk header. */
+#define POUCH_SERIAL_FW_HDR_FIXED_LEN 46
+
+/** Magic at the head of a firmware chunk: "PFW2", little endian. */
+#define POUCH_SERIAL_FW_MAGIC 0x32574650UL
+
+/** Firmware apply result reported by the broker. */
+enum pouch_serial_fw_status
+{
+    POUCH_SERIAL_FW_STATUS_OK = 0,        /**< Verified and installed */
+    POUCH_SERIAL_FW_STATUS_HASH_FAIL = 1, /**< SHA-256 mismatch, nothing installed */
+    POUCH_SERIAL_FW_STATUS_ERROR = 2,     /**< Install or I/O error */
+};
+
+/**
+ * Announce a firmware image that is about to be relayed.
+ *
+ * Call once, from the OTA manifest handler, before any @ref pouch_serial_fw_write.
+ * The details are sent to the broker ahead of the image so it can verify what it
+ * receives.
+ *
+ * @param package  Component/package name.
+ * @param version  Target version string.
+ * @param size     Total image size in bytes.
+ * @param sha256   SHA-256 of the image, 32 bytes.
+ *
+ * @return 0 on success, -EBUSY if a relay is already in progress, -EINVAL on bad input.
+ */
+int pouch_serial_fw_begin(const char *package,
+                          const char *version,
+                          uint32_t size,
+                          const uint8_t sha256[32]);
+
+/**
+ * Relay a chunk of the firmware image.
+ *
+ * Blocks while the outgoing buffer is full, which is what applies backpressure to
+ * the OTA download - call it straight from the component receive callback.
+ *
+ * @param buf      Image bytes.
+ * @param len      Number of bytes.
+ * @param timeout  How long to wait for buffer space.
+ *
+ * @return Number of bytes accepted, or a negative error code.
+ */
+int pouch_serial_fw_write(const void *buf, size_t len, pouch_timeout_t timeout);
+
+/**
+ * Mark the firmware image complete.
+ *
+ * Call when the OTA component reports its last block. The relay finishes once the
+ * broker has drained the remaining buffered bytes.
+ */
+void pouch_serial_fw_end(void);
+
+/**
+ * Abandon the relay in progress.
+ *
+ * Discards anything buffered and returns the module to idle so a later offer of
+ * the same or another image can start cleanly.
+ */
+void pouch_serial_fw_abort(void);
+
+/**
+ * Check whether a firmware relay is currently in progress.
+ */
+bool pouch_serial_fw_active(void);
+
+/**
+ * Check whether the relay buffer is too full to accept much more.
+ *
+ * Transports use this to stop pulling firmware downlink off the wire while the
+ * relay is backed up, so the backpressure reaches the broker instead of piling
+ * up as queued blocks on the device. Without it a fast link can push an entire
+ * component faster than the relay drains, and the downlink runs the device out
+ * of memory.
+ */
+bool pouch_serial_fw_pressure(void);
+
+/**
+ * Get the last status reported by the broker.
+ *
+ * @param status  Written with the last received status.
+ * @return true if a status has been received since the last @ref pouch_serial_fw_begin.
+ */
+bool pouch_serial_fw_status_get(enum pouch_serial_fw_status *status);
+
+/**
+ * Called when the broker reports what it did with a relayed image.
+ *
+ * Invoked from the serial receive path with no relay lock held, so it may call
+ * back into this module.
+ */
+typedef void (*pouch_serial_fw_status_cb_t)(enum pouch_serial_fw_status status);
+
+/**
+ * Register a handler for the broker's apply verdict.
+ *
+ * The verdict is the only signal that an image was rejected. It has to be acted
+ * on when it arrives: a device that has called golioth_ota_mark_updating() has
+ * told the cloud to stop offering the component, and the OTA manifest is
+ * delivered once per connection, so a device waiting for another manifest to
+ * re-offer a rejected image waits forever. Re-arm from here instead.
+ *
+ * @param cb  Handler, or NULL to remove the current one.
+ */
+void pouch_serial_fw_status_callback_set(pouch_serial_fw_status_cb_t cb);

--- a/port/zephyr/transport/serial/Kconfig
+++ b/port/zephyr/transport/serial/Kconfig
@@ -21,6 +21,37 @@ config POUCH_TRANSPORT_SERIAL_DEVICE
         runs on the node device and communicates with a gateway running the
         broker implementation.
 
+menuconfig POUCH_SERIAL_FW_RELAY
+    bool "MCU-mediated firmware relay"
+    depends on POUCH_TRANSPORT_SERIAL_DEVICE
+    help
+        Relay this core's own firmware image to the broker over the Pouch
+        Serial firmware channels, for cores that remoteproc loads from the
+        host filesystem at every boot and so have no flash of their own to
+        write an update into. The core stays the authenticated Pouch endpoint:
+        it downloads its image through Pouch OTA and streams the plaintext out,
+        and the host verifies it and applies it.
+
+        Off by default. The channel ids exist unconditionally so that every
+        build agrees on the wire format, but a device that does not enable this
+        leaves them unconfigured and pays neither the relay buffer nor the code.
+
+        Requires a broker that collects the firmware channel; the in-tree
+        broker does not.
+
+if POUCH_SERIAL_FW_RELAY
+
+config POUCH_SERIAL_FW_BUF_SIZE
+    int "Firmware relay buffer size"
+    default 8192
+    help
+        Bytes of the firmware image held in RAM while relaying it to the
+        broker. The broker collects the firmware channel alongside the downlink
+        that feeds it, so this only has to cover the gap between the two - the
+        image is never resident.
+
+endif # POUCH_SERIAL_FW_RELAY
+
 menuconfig POUCH_RPMSG_RSC_DEVICE
     bool "Pouch rpmsg device transport adapter (resource table)"
     depends on POUCH_TRANSPORT_SERIAL_DEVICE
@@ -67,7 +98,19 @@ config POUCH_RPMSG_RSC_DEVICE_TX_THREAD_PRIORITY
     default 4
     help
         Must be above the management thread so the Pouch work queue keeps
-        draining what the receive callback delivers.
+        draining what the receive callback delivers, and so the firmware
+        channel keeps draining while the receive callback stalls on it.
+
+config POUCH_RPMSG_RSC_DEVICE_RX_STALL_MS
+    int "How long the receive path stalls on firmware relay pressure (ms)"
+    depends on POUCH_SERIAL_FW_RELAY
+    default 5000
+    help
+        While the firmware relay buffer is more than half full the receive
+        callback waits rather than taking more downlink off the wire, which
+        makes the host's write(2) block and pushes the backpressure back to
+        the broker. Capped so a broker that never collects the firmware
+        channel cannot wedge the link.
 
 config POUCH_RPMSG_RSC_DEVICE_TX_WAIT_MS
     int "How long to wait for a free rpmsg TX buffer (ms)"

--- a/port/zephyr/transport/serial/rpmsg_rsc_device.c
+++ b/port/zephyr/transport/serial/rpmsg_rsc_device.c
@@ -16,6 +16,9 @@
 #include <addr_translation.h>
 
 #include <pouch/transport/serial/device.h>
+#if defined(CONFIG_POUCH_SERIAL_FW_RELAY)
+#include <pouch/transport/serial/fw.h>
+#endif
 
 #include <errno.h>
 #include <stdint.h>
@@ -110,6 +113,22 @@ static int pouch_ept_cb(struct rpmsg_endpoint *ept,
 
     rx_frames++;
     LOG_DBG("rx %u: %zu bytes, hdr 0x%02x", rx_frames, len, ((const uint8_t *) data)[0]);
+
+#if defined(CONFIG_POUCH_SERIAL_FW_RELAY)
+    /* Stall while the firmware relay is backed up. Not returning from this
+     * callback leaves the receive buffer unreturned, so the host's write(2)
+     * blocks and the backpressure reaches the broker. Without it a fast link
+     * delivers a whole component faster than the relay drains and the downlink
+     * heap-allocates itself to death. The transmit thread keeps draining the
+     * firmware channel meanwhile, which is what clears the pressure.
+     */
+    for (uint32_t waited = 0;
+         pouch_serial_fw_pressure() && waited < CONFIG_POUCH_RPMSG_RSC_DEVICE_RX_STALL_MS;
+         waited += 2)
+    {
+        k_sleep(K_MSEC(2));
+    }
+#endif
 
     int err = pouch_serial_device_recv(data, len);
     if (err)

--- a/src/transport/CMakeLists.txt
+++ b/src/transport/CMakeLists.txt
@@ -10,6 +10,7 @@ pouch_config_enabled(_pouch_gateway CONFIG_POUCH_GATEWAY)
 pouch_config_enabled(_pouch_transport_serial CONFIG_POUCH_TRANSPORT_SERIAL)
 pouch_config_enabled(_pouch_transport_serial_broker CONFIG_POUCH_TRANSPORT_SERIAL_BROKER)
 pouch_config_enabled(_pouch_transport_serial_device CONFIG_POUCH_TRANSPORT_SERIAL_DEVICE)
+pouch_config_enabled(_pouch_serial_fw_relay CONFIG_POUCH_SERIAL_FW_RELAY)
 
 # The device-side endpoints are only used by the transports that speak the
 # endpoint protocol: the GATT peripheral and the serial device. Builds without
@@ -108,5 +109,11 @@ if(_pouch_transport_serial)
         target_sources(${_pouch_target} PRIVATE
             serial/device.c
         )
+
+        if (_pouch_serial_fw_relay)
+            target_sources(${_pouch_target} PRIVATE
+                ${_pouch_transport_root}/endpoints/device/fw.c
+            )
+        endif()
     endif()
 endif()

--- a/src/transport/endpoints/device/endpoints.h
+++ b/src/transport/endpoints/device/endpoints.h
@@ -12,3 +12,5 @@ extern const struct pouch_endpoint pouch_device_endpoint_device_cert;
 extern const struct pouch_endpoint pouch_device_endpoint_server_cert;
 extern const struct pouch_endpoint pouch_device_endpoint_uplink;
 extern const struct pouch_endpoint pouch_device_endpoint_downlink;
+extern const struct pouch_endpoint pouch_device_endpoint_fw;
+extern const struct pouch_endpoint pouch_device_endpoint_fw_status;

--- a/src/transport/endpoints/device/fw.c
+++ b/src/transport/endpoints/device/fw.c
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include <pouch/port.h>
+#include <pouch/transport/serial/fw.h>
+#include <pouch/types.h>
+
+#include "endpoints.h"
+
+POUCH_LOG_REGISTER(pouch_fw_relay, CONFIG_POUCH_COMMON_LOG_LEVEL);
+
+/*
+ * Device-side firmware relay.
+ *
+ * The application writes image bytes in from its OTA component callback; the
+ * serial firmware channel drains them out. Only CONFIG_POUCH_SERIAL_FW_BUF_SIZE
+ * bytes of the image are ever resident - writes block while the buffer is full,
+ * which is what throttles the OTA download to the speed of the serial link.
+ *
+ * A relay is framed as one serial transfer: a header describing the image
+ * followed by the image bytes. When no update is in flight the endpoint reports
+ * an immediately-empty transfer so the broker's poll costs two frames.
+ */
+
+/*
+ * The buffer only has to cover the gap between the downlink filling it and the
+ * firmware channel draining it. The broker collects this channel concurrently
+ * with the downlink that feeds it, so the two run at the same time and the
+ * image is never resident.
+ */
+#ifndef CONFIG_POUCH_SERIAL_FW_BUF_SIZE
+#define CONFIG_POUCH_SERIAL_FW_BUF_SIZE 8192
+#endif
+
+#define MAX_NAME_LEN 32
+
+struct fw_relay
+{
+    pouch_mutex_t lock;
+    pouch_sem_t space; /* given when the drain frees buffer space */
+
+    uint8_t hdr[POUCH_SERIAL_FW_HDR_FIXED_LEN + 2 * MAX_NAME_LEN];
+    size_t hdr_len;
+    size_t hdr_sent; /* bytes of the current chunk's header already sent */
+
+    uint32_t img_size; /* total image size */
+    uint32_t sent;     /* absolute offset of the next byte to send */
+    bool chunk_open;   /* a chunk transfer is in progress */
+
+    uint8_t buf[CONFIG_POUCH_SERIAL_FW_BUF_SIZE];
+    size_t head; /* write index */
+    size_t tail; /* read index */
+    size_t used;
+
+    bool active;   /* a relay has been announced */
+    bool complete; /* the application has written the last byte */
+
+    bool status_valid;
+    enum pouch_serial_fw_status status;
+};
+
+static struct fw_relay relay;
+static bool inited;
+static pouch_serial_fw_status_cb_t status_cb;
+
+static void relay_init_once(void)
+{
+    if (!inited)
+    {
+        pouch_mutex_init(&relay.lock);
+        pouch_sem_init(&relay.space, 0, 1);
+        inited = true;
+    }
+}
+
+static void put_le32(uint8_t *dst, uint32_t v)
+{
+    dst[0] = (uint8_t) (v & 0xff);
+    dst[1] = (uint8_t) ((v >> 8) & 0xff);
+    dst[2] = (uint8_t) ((v >> 16) & 0xff);
+    dst[3] = (uint8_t) ((v >> 24) & 0xff);
+}
+
+int pouch_serial_fw_begin(const char *package,
+                          const char *version,
+                          uint32_t size,
+                          const uint8_t sha256[32])
+{
+    if (!package || !version || !sha256 || size == 0)
+    {
+        return -EINVAL;
+    }
+
+    size_t pkg_len = strlen(package);
+    size_t ver_len = strlen(version);
+    if (pkg_len > MAX_NAME_LEN || ver_len > MAX_NAME_LEN)
+    {
+        return -EINVAL;
+    }
+
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+
+    if (relay.active)
+    {
+        pouch_mutex_unlock(&relay.lock);
+        return -EBUSY;
+    }
+
+    /* The offset field is rewritten per chunk in fw_send(). */
+    uint8_t *h = relay.hdr;
+    put_le32(&h[0], POUCH_SERIAL_FW_MAGIC);
+    put_le32(&h[4], size);
+    put_le32(&h[8], 0);
+    memcpy(&h[12], sha256, 32);
+    h[44] = (uint8_t) ver_len;
+    h[45] = (uint8_t) pkg_len;
+    memcpy(&h[POUCH_SERIAL_FW_HDR_FIXED_LEN], version, ver_len);
+    memcpy(&h[POUCH_SERIAL_FW_HDR_FIXED_LEN + ver_len], package, pkg_len);
+
+    relay.hdr_len = POUCH_SERIAL_FW_HDR_FIXED_LEN + ver_len + pkg_len;
+    relay.hdr_sent = 0;
+    relay.head = 0;
+    relay.tail = 0;
+    relay.used = 0;
+    relay.img_size = size;
+    relay.sent = 0;
+    relay.chunk_open = false;
+    relay.complete = false;
+    relay.status_valid = false;
+    relay.active = true;
+
+    pouch_mutex_unlock(&relay.lock);
+
+    POUCH_LOG_INF("Firmware relay started: %s %s, %u bytes", package, version, size);
+    return 0;
+}
+
+int pouch_serial_fw_write(const void *buf, size_t len, pouch_timeout_t timeout)
+{
+    const uint8_t *src = buf;
+    size_t written = 0;
+
+    if (!buf)
+    {
+        return -EINVAL;
+    }
+
+    relay_init_once();
+
+    while (written < len)
+    {
+        pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+
+        if (!relay.active)
+        {
+            pouch_mutex_unlock(&relay.lock);
+            return -EPIPE;
+        }
+
+        size_t space = sizeof(relay.buf) - relay.used;
+        size_t n = len - written;
+        if (n > space)
+        {
+            n = space;
+        }
+
+        for (size_t i = 0; i < n; i++)
+        {
+            relay.buf[relay.head] = src[written + i];
+            relay.head = (relay.head + 1) % sizeof(relay.buf);
+        }
+        relay.used += n;
+        written += n;
+
+        pouch_mutex_unlock(&relay.lock);
+
+        if (written < len)
+        {
+            /* Buffer is full - wait for the serial channel to drain some. */
+            if (pouch_sem_take(&relay.space, timeout) != 0)
+            {
+                return written > 0 ? (int) written : -EAGAIN;
+            }
+        }
+    }
+
+    return (int) written;
+}
+
+void pouch_serial_fw_end(void)
+{
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+    relay.complete = true;
+    pouch_mutex_unlock(&relay.lock);
+    POUCH_LOG_DBG("Firmware relay: image complete");
+}
+
+void pouch_serial_fw_abort(void)
+{
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+    relay.active = false;
+    relay.chunk_open = false;
+    relay.complete = false;
+    relay.used = 0;
+    relay.head = 0;
+    relay.tail = 0;
+    relay.sent = 0;
+    relay.hdr_sent = 0;
+    pouch_mutex_unlock(&relay.lock);
+    POUCH_LOG_WRN("Firmware relay aborted");
+}
+
+bool pouch_serial_fw_active(void)
+{
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+    bool active = relay.active;
+    pouch_mutex_unlock(&relay.lock);
+    return active;
+}
+
+bool pouch_serial_fw_pressure(void)
+{
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+    bool full = relay.active && (relay.used >= (sizeof(relay.buf) / 2));
+    pouch_mutex_unlock(&relay.lock);
+    return full;
+}
+
+bool pouch_serial_fw_status_get(enum pouch_serial_fw_status *status)
+{
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+    bool valid = relay.status_valid;
+    if (valid && status)
+    {
+        *status = relay.status;
+    }
+    pouch_mutex_unlock(&relay.lock);
+    return valid;
+}
+
+void pouch_serial_fw_status_callback_set(pouch_serial_fw_status_cb_t cb)
+{
+    status_cb = cb;
+}
+
+/* --- serial endpoint: firmware stream (device -> broker) --- */
+
+static int fw_start(struct pouch_bearer *bearer)
+{
+    relay_init_once();
+    return 0;
+}
+
+static enum pouch_result fw_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    uint8_t *out = dst;
+    size_t cap = *dst_len;
+    size_t produced = 0;
+
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+
+    /* No relay in flight: an empty transfer tells the broker there is nothing
+     * to collect, which is the normal answer and costs two frames.
+     */
+    if (!relay.active)
+    {
+        pouch_mutex_unlock(&relay.lock);
+        *dst_len = 0;
+        return POUCH_NO_MORE_DATA;
+    }
+
+    /* A relay is in flight but nothing is buffered yet. Hold the transfer open
+     * and ask to be called again rather than ending it: the broker collects
+     * this channel alongside the downlink that feeds it, so "empty right now"
+     * means "the next downlink block has not been decrypted yet", not "done".
+     * Ending the transfer here would finish the collection before any image
+     * bytes existed.
+     */
+    if (relay.used == 0 && !relay.complete)
+    {
+        pouch_mutex_unlock(&relay.lock);
+        *dst_len = 0;
+        return POUCH_MORE_DATA;
+    }
+
+    if (!relay.chunk_open)
+    {
+        /* Start a chunk: stamp it with the absolute offset it begins at. */
+        put_le32(&relay.hdr[8], relay.sent);
+        relay.hdr_sent = 0;
+        relay.chunk_open = true;
+    }
+
+    while (produced < cap && relay.hdr_sent < relay.hdr_len)
+    {
+        out[produced++] = relay.hdr[relay.hdr_sent++];
+    }
+
+    while (produced < cap && relay.used > 0)
+    {
+        out[produced++] = relay.buf[relay.tail];
+        relay.tail = (relay.tail + 1) % sizeof(relay.buf);
+        relay.used--;
+        relay.sent++;
+    }
+
+    /* The transfer stays open until the whole image has gone out. Running the
+     * buffer dry only means the downlink has not caught up yet - the broker is
+     * collecting this channel alongside the downlink that feeds it, so more
+     * bytes are still coming within this same session.
+     */
+    bool drained = (relay.hdr_sent >= relay.hdr_len) && (relay.used == 0);
+    bool image_done = drained && relay.complete && (relay.sent >= relay.img_size);
+
+    if (image_done)
+    {
+        relay.chunk_open = false;
+        relay.active = false;
+    }
+
+    uint32_t sent_now = relay.sent;
+    uint32_t total = relay.img_size;
+    pouch_mutex_unlock(&relay.lock);
+
+    /* Wake a writer blocked on a full buffer. */
+    pouch_sem_give(&relay.space);
+
+    *dst_len = produced;
+
+    if (image_done)
+    {
+        POUCH_LOG_INF("Firmware relay complete: %u bytes", sent_now);
+        return POUCH_NO_MORE_DATA;
+    }
+
+    if (drained)
+    {
+        POUCH_LOG_DBG("Firmware relay caught up, %u/%u bytes relayed", sent_now, total);
+    }
+
+    return POUCH_MORE_DATA;
+}
+
+const struct pouch_endpoint pouch_device_endpoint_fw = {
+    .start = fw_start,
+    .send = fw_send,
+};
+
+/* --- serial endpoint: apply status (broker -> device) --- */
+
+static int fw_status_start(struct pouch_bearer *bearer)
+{
+    return 0;
+}
+
+static int fw_status_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    const uint8_t *in = buf;
+
+    if (len == 0)
+    {
+        return 0;
+    }
+
+    if (in[0] > POUCH_SERIAL_FW_STATUS_ERROR)
+    {
+        POUCH_LOG_WRN("Unknown firmware apply status %u from broker", in[0]);
+        return -EINVAL;
+    }
+
+    enum pouch_serial_fw_status status = (enum pouch_serial_fw_status) in[0];
+
+    relay_init_once();
+    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
+    relay.status = status;
+    relay.status_valid = true;
+    pouch_mutex_unlock(&relay.lock);
+
+    POUCH_LOG_INF("Firmware apply status from broker: %u", in[0]);
+
+    /* Called with the lock released: the handler re-arms a rejected update,
+     * which comes straight back into pouch_serial_fw_begin().
+     */
+    if (status_cb)
+    {
+        status_cb(status);
+    }
+
+    return 0;
+}
+
+const struct pouch_endpoint pouch_device_endpoint_fw_status = {
+    .start = fw_status_start,
+    .recv = fw_status_recv,
+};

--- a/src/transport/serial/channel.c
+++ b/src/transport/serial/channel.c
@@ -131,6 +131,17 @@ int pouch_serial_ch_recv(struct pouch_serial_channel *ch,
                          const void *payload,
                          size_t len)
 {
+    /* A channel id this build knows but has no endpoint for: the peer is using
+     * an optional feature that is not configured here. Ignore the frame rather
+     * than dereferencing the missing endpoint. Channel ids are wire constants
+     * shared by every build, so the id being in range says nothing about
+     * whether both ends implement it.
+     */
+    if (ch->endpoint == NULL)
+    {
+        return -ENODEV;
+    }
+
     if (header->is_data)
     {
         return handle_data(ch, header, payload, len);
@@ -145,6 +156,12 @@ size_t pouch_serial_ch_frame_get(struct pouch_serial_channel *ch, uint8_t *buf, 
     if (maxlen <= POUCH_SERIAL_HEADER_LEN)
     {
         return -EINVAL;
+    }
+
+    /* Unconfigured channel: nothing to send, ever. See pouch_serial_ch_recv(). */
+    if (ch->endpoint == NULL)
+    {
+        return 0;
     }
 
     if (!pouch_atomic_test_and_clear_bit(&ch->flags, CH_FLAG_PENDING))

--- a/src/transport/serial/device.c
+++ b/src/transport/serial/device.c
@@ -21,6 +21,10 @@ static struct pouch_serial serial = {
             [POUCH_SERIAL_CH_DEVICE_CERT] = CHANNEL(&pouch_device_endpoint_device_cert),
             [POUCH_SERIAL_CH_DOWNLINK] = CHANNEL(&pouch_device_endpoint_downlink),
             [POUCH_SERIAL_CH_UPLINK] = CHANNEL(&pouch_device_endpoint_uplink),
+#if defined(CONFIG_POUCH_SERIAL_FW_RELAY)
+            [POUCH_SERIAL_CH_FW_STATUS] = CHANNEL(&pouch_device_endpoint_fw_status),
+            [POUCH_SERIAL_CH_FW] = CHANNEL(&pouch_device_endpoint_fw),
+#endif
         },
 };
 

--- a/tests/pouch/rpmsg/exchange/CMakeLists.txt
+++ b/tests/pouch/rpmsg/exchange/CMakeLists.txt
@@ -26,6 +26,10 @@ target_include_directories(app PRIVATE
 # isolation.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 
+# The device channel table only carries the firmware channels when the relay
+# is enabled, and these suites stub those endpoints, so enable it here.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
+
 # Serial transport core + the UART framing under test, plus the shared stub
 # endpoints from the serial exchange test.
 target_sources(app PRIVATE

--- a/tests/pouch/serial/broker/src/test_broker.c
+++ b/tests/pouch/serial/broker/src/test_broker.c
@@ -1154,6 +1154,45 @@ ZTEST(serial_broker, test_invalid_channel_id)
     zassert_equal(err, -EINVAL);
 }
 
+/*
+ * A channel id this build knows but has no endpoint for.
+ *
+ * The broker implements five channels; the firmware-relay ids exist in the
+ * shared enum regardless, so they are in range for the bounds check and reach
+ * the channel layer with a NULL endpoint. That is not hypothetical: the
+ * firmware relay's counterpart broker lives outside this tree, so a device
+ * built with it talks to an in-tree broker that has never heard of it. Without
+ * a guard the first frame on such a channel dereferences NULL.
+ */
+ZTEST(serial_broker, test_unconfigured_channel_is_ignored)
+{
+    uint8_t buf[FRAME_BUF_SIZE];
+
+    struct pouch_serial_header ack = {
+        .is_data = false,
+        .channel = POUCH_SERIAL_CH_FW,
+    };
+    size_t len = build_frame(buf, sizeof(buf), &ack, NULL, 0);
+    zassert_equal(pouch_serial_broker_recv(test_broker, buf, len), -ENODEV);
+
+    static const uint8_t payload[] = {0x01, 0x02};
+    struct pouch_serial_header data = {
+        .is_data = true,
+        .first = true,
+        .channel = POUCH_SERIAL_CH_FW_STATUS,
+    };
+    len = build_frame(buf, sizeof(buf), &data, payload, sizeof(payload));
+    zassert_equal(pouch_serial_broker_recv(test_broker, buf, len), -ENODEV);
+
+    /* Those frames left no response queued, and the broker still runs a normal
+     * session afterwards. */
+    zassert_equal(pouch_serial_broker_frame_get(test_broker, buf, sizeof(buf)),
+                  0,
+                  "unconfigured channel produced a frame");
+
+    advance_to_sync(true, true);
+}
+
 ZTEST(serial_broker, test_malformed_ack_header)
 {
     /*

--- a/tests/pouch/serial/device/CMakeLists.txt
+++ b/tests/pouch/serial/device/CMakeLists.txt
@@ -20,6 +20,10 @@ target_include_directories(app PRIVATE
 # builds serial sources in isolation, define it directly.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 
+# The device channel table only carries the firmware channels when the relay
+# is enabled, and these suites stub those endpoints, so enable it here.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
+
 # Serial transport sources (device side only, no broker)
 target_sources(app PRIVATE
     ${POUCH_DIR}/src/transport/serial/device.c

--- a/tests/pouch/serial/device/src/stub_endpoints.c
+++ b/tests/pouch/serial/device/src/stub_endpoints.c
@@ -256,3 +256,52 @@ const struct pouch_endpoint pouch_device_endpoint_uplink = {
     .send = d_uplink_send,
     .end = d_uplink_end,
 };
+
+/* FW_STATUS: device receives the broker's apply verdict (receiver) */
+
+static int d_fw_status_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    device_stubs.fw_status.rx_len = 0;
+    device_stubs.fw_status.start_count++;
+    return device_stubs.fw_status.start_err;
+}
+
+static int d_fw_status_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    if (device_stubs.fw_status.recv_err != 0)
+    {
+        return device_stubs.fw_status.recv_err;
+    }
+    receiver_push(&device_stubs.fw_status, buf, len);
+    return 0;
+}
+
+/* No end() callback, matching the real pouch_device_endpoint_fw_status. */
+const struct pouch_endpoint pouch_device_endpoint_fw_status = {
+    .start = d_fw_status_start,
+    .recv = d_fw_status_recv,
+};
+
+/* FW: device relays the firmware image to the broker (sender) */
+
+static int d_fw_start(struct pouch_bearer *bearer)
+{
+    device_stubs.fw.bearer = bearer;
+    device_stubs.fw.tx_offset = 0;
+    device_stubs.fw.start_count++;
+    return device_stubs.fw.start_err;
+}
+
+static enum pouch_result d_fw_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.fw, dst, dst_len);
+}
+
+/* No end() callback, matching the real pouch_device_endpoint_fw. */
+const struct pouch_endpoint pouch_device_endpoint_fw = {
+    .start = d_fw_start,
+    .send = d_fw_send,
+};

--- a/tests/pouch/serial/device/src/stub_endpoints.h
+++ b/tests/pouch/serial/device/src/stub_endpoints.h
@@ -60,6 +60,8 @@ struct device_stubs
     struct stub_sender device_cert;
     struct stub_receiver downlink;
     struct stub_sender uplink;
+    struct stub_receiver fw_status;
+    struct stub_sender fw;
 };
 
 extern struct device_stubs device_stubs;

--- a/tests/pouch/serial/device/src/test_device.c
+++ b/tests/pouch/serial/device/src/test_device.c
@@ -212,6 +212,8 @@ static void reset_stubs(void)
     stub_sender_reset(&device_stubs.device_cert);
     stub_receiver_reset(&device_stubs.downlink);
     stub_sender_reset(&device_stubs.uplink);
+    stub_receiver_reset(&device_stubs.fw_status);
+    stub_sender_reset(&device_stubs.fw);
 }
 
 /* ---- Test fixture -------------------------------------------------------- */

--- a/tests/pouch/serial/exchange/CMakeLists.txt
+++ b/tests/pouch/serial/exchange/CMakeLists.txt
@@ -25,6 +25,10 @@ target_include_directories(app PRIVATE
 # builds serial sources in isolation, define it directly.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 
+# The device channel table only carries the firmware channels when the relay
+# is enabled, and these suites stub those endpoints, so enable it here.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
+
 # Serial transport sources (both broker and device)
 target_sources(app PRIVATE
     ${POUCH_DIR}/src/transport/serial/broker.c

--- a/tests/pouch/serial/exchange/src/stub_endpoints.c
+++ b/tests/pouch/serial/exchange/src/stub_endpoints.c
@@ -43,6 +43,8 @@ void stubs_reset(void)
     sender_reset(&device_stubs.device_cert);
     receiver_reset(&device_stubs.downlink);
     sender_reset(&device_stubs.uplink);
+    receiver_reset(&device_stubs.fw_status);
+    sender_reset(&device_stubs.fw);
 
     receiver_reset(&broker_stubs.info);
     sender_reset(&broker_stubs.server_cert);
@@ -453,4 +455,44 @@ const struct pouch_endpoint pouch_device_endpoint_uplink = {
     .start = d_uplink_start,
     .send = d_uplink_send,
     .end = d_uplink_end,
+};
+
+/* FW_STATUS: device receives the broker's apply verdict (receiver) */
+
+static int d_fw_status_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return receiver_start_helper(&device_stubs.fw_status);
+}
+
+static int d_fw_status_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    return receiver_push(&device_stubs.fw_status, buf, len);
+}
+
+/* No end() callback, matching the real pouch_device_endpoint_fw_status. */
+const struct pouch_endpoint pouch_device_endpoint_fw_status = {
+    .start = d_fw_status_start,
+    .recv = d_fw_status_recv,
+};
+
+/* FW: device relays the firmware image to the broker (sender) */
+
+static int d_fw_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return sender_start_helper(&device_stubs.fw);
+}
+
+static enum pouch_result d_fw_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.fw, dst, dst_len);
+}
+
+/* No end() callback, matching the real pouch_device_endpoint_fw. */
+const struct pouch_endpoint pouch_device_endpoint_fw = {
+    .start = d_fw_start,
+    .send = d_fw_send,
 };

--- a/tests/pouch/serial/exchange/src/stub_endpoints.h
+++ b/tests/pouch/serial/exchange/src/stub_endpoints.h
@@ -62,6 +62,8 @@ struct device_stubs
     struct stub_sender device_cert;
     struct stub_receiver downlink;
     struct stub_sender uplink;
+    struct stub_receiver fw_status;
+    struct stub_sender fw;
 };
 
 extern struct broker_stubs broker_stubs;

--- a/tests/pouch/serial/fw/CMakeLists.txt
+++ b/tests/pouch/serial/fw/CMakeLists.txt
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(serial_fw_test)
+
+set(POUCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../..)
+
+target_include_directories(app PRIVATE
+    ${POUCH_DIR}/include
+    ${POUCH_DIR}/port/include
+    ${POUCH_DIR}/port/zephyr/include
+    ${POUCH_DIR}/src
+)
+
+# The relay's log macro needs CONFIG_POUCH_COMMON_LOG_LEVEL, normally provided
+# by Kconfig; define it directly since this builds the relay in isolation.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_COMMON_LOG_LEVEL=3)
+
+# The firmware relay under test. The port primitives it uses come from the
+# pouch module's own build, as they do for the other serial test suites.
+target_sources(app PRIVATE
+    ${POUCH_DIR}/src/transport/endpoints/device/fw.c
+)
+
+target_sources(app PRIVATE src/test_fw.c)

--- a/tests/pouch/serial/fw/prj.conf
+++ b/tests/pouch/serial/fw/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/pouch/serial/fw/src/test_fw.c
+++ b/tests/pouch/serial/fw/src/test_fw.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Device-side firmware relay.
+ *
+ * The relay is driven from both ends: the application writes image bytes in
+ * through the public API, and the broker drains them out through the serial
+ * firmware endpoint. These tests drive the endpoint vtables directly, so no
+ * serial core is involved.
+ *
+ * The case that matters most is the last one: an image the host rejects has to
+ * be restartable from the apply verdict, because that verdict is the only
+ * notification the device ever gets.
+ */
+
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/ztest.h>
+
+#include <errno.h>
+#include <string.h>
+
+#include <pouch/transport/serial/fw.h>
+
+#include "transport/endpoints/device/endpoints.h"
+
+#define IMG_SIZE 256
+
+static uint8_t image[IMG_SIZE];
+static const uint8_t hash[32] = {0xaa, 0xbb, 0xcc};
+
+/* Verdicts seen by the registered callback. */
+static enum pouch_serial_fw_status seen[8];
+static int seen_count;
+
+static void record_status(enum pouch_serial_fw_status status)
+{
+    if (seen_count < (int) ARRAY_SIZE(seen))
+    {
+        seen[seen_count] = status;
+    }
+    seen_count++;
+}
+
+/** Deliver an apply verdict the way the broker's FW_STATUS frame would. */
+static int deliver_status(uint8_t status)
+{
+    return pouch_device_endpoint_fw_status.recv(NULL, &status, 1);
+}
+
+/**
+ * Drain the firmware endpoint until it reports the transfer finished.
+ *
+ * Returns the total number of bytes collected, header included, or a negative
+ * value if the endpoint kept asking to be called again - which means the relay
+ * never finished, the bug that would show up as a stalled update.
+ */
+static int drain_relay(uint8_t *out, size_t out_size)
+{
+    size_t total = 0;
+
+    zassert_ok(pouch_device_endpoint_fw.start(NULL));
+
+    for (int i = 0; i < 64; i++)
+    {
+        size_t len = out_size - total;
+        enum pouch_result result = pouch_device_endpoint_fw.send(NULL, &out[total], &len);
+
+        zassert_not_equal(result, POUCH_ERROR, "relay reported an error while draining");
+        total += len;
+
+        if (result == POUCH_NO_MORE_DATA)
+        {
+            return (int) total;
+        }
+    }
+
+    return -EAGAIN;
+}
+
+static void before(void *f)
+{
+    ARG_UNUSED(f);
+
+    /* Leave no relay in flight for the next test. */
+    pouch_serial_fw_abort();
+    pouch_serial_fw_status_callback_set(NULL);
+
+    seen_count = 0;
+    memset(seen, 0, sizeof(seen));
+
+    for (size_t i = 0; i < sizeof(image); i++)
+    {
+        image[i] = (uint8_t) i;
+    }
+}
+
+ZTEST_SUITE(serial_fw, NULL, NULL, before, NULL, NULL);
+
+/* ---- the apply verdict ---------------------------------------------------- */
+
+ZTEST(serial_fw, test_status_reaches_the_callback)
+{
+    pouch_serial_fw_status_callback_set(record_status);
+
+    zassert_ok(deliver_status(POUCH_SERIAL_FW_STATUS_HASH_FAIL));
+
+    zassert_equal(seen_count, 1, "callback was not invoked");
+    zassert_equal(seen[0], POUCH_SERIAL_FW_STATUS_HASH_FAIL);
+
+    enum pouch_serial_fw_status polled;
+    zassert_true(pouch_serial_fw_status_get(&polled));
+    zassert_equal(polled, POUCH_SERIAL_FW_STATUS_HASH_FAIL);
+}
+
+ZTEST(serial_fw, test_unknown_status_is_rejected)
+{
+    pouch_serial_fw_status_callback_set(record_status);
+
+    zassert_equal(deliver_status(0xff), -EINVAL);
+    zassert_equal(seen_count, 0, "callback ran for an unknown status");
+}
+
+ZTEST(serial_fw, test_empty_status_frame_ignored)
+{
+    pouch_serial_fw_status_callback_set(record_status);
+
+    zassert_ok(pouch_device_endpoint_fw_status.recv(NULL, "", 0));
+    zassert_equal(seen_count, 0);
+}
+
+/* ---- relaying an image ---------------------------------------------------- */
+
+ZTEST(serial_fw, test_relay_carries_header_and_image)
+{
+    uint8_t out[512];
+
+    zassert_ok(pouch_serial_fw_begin("main", "1.2.3", IMG_SIZE, hash));
+    zassert_true(pouch_serial_fw_active());
+
+    zassert_equal(pouch_serial_fw_write(image, sizeof(image), POUCH_NO_WAIT), IMG_SIZE);
+    pouch_serial_fw_end();
+
+    int total = drain_relay(out, sizeof(out));
+    zassert_true(total > 0, "relay never completed (%d)", total);
+
+    size_t hdr_len = POUCH_SERIAL_FW_HDR_FIXED_LEN + strlen("1.2.3") + strlen("main");
+    zassert_equal((size_t) total, hdr_len + IMG_SIZE, "unexpected relay length");
+
+    /* Header: magic, total size, and the offset this chunk starts at. */
+    zassert_equal(sys_get_le32(&out[0]), POUCH_SERIAL_FW_MAGIC);
+    zassert_equal(sys_get_le32(&out[4]), IMG_SIZE);
+    zassert_equal(sys_get_le32(&out[8]), 0, "first chunk should start at offset 0");
+    zassert_mem_equal(&out[12], hash, sizeof(hash));
+
+    zassert_mem_equal(&out[hdr_len], image, IMG_SIZE, "image bytes were not relayed intact");
+    zassert_false(pouch_serial_fw_active(), "relay still active after the image was drained");
+}
+
+ZTEST(serial_fw, test_begin_rejects_a_second_relay)
+{
+    zassert_ok(pouch_serial_fw_begin("main", "1.2.3", IMG_SIZE, hash));
+    zassert_equal(pouch_serial_fw_begin("main", "1.2.4", IMG_SIZE, hash), -EBUSY);
+}
+
+ZTEST(serial_fw, test_abort_releases_the_relay)
+{
+    zassert_ok(pouch_serial_fw_begin("main", "1.2.3", IMG_SIZE, hash));
+    pouch_serial_fw_abort();
+
+    zassert_false(pouch_serial_fw_active());
+    zassert_ok(pouch_serial_fw_begin("main", "1.2.3", IMG_SIZE, hash));
+}
+
+/* ---- the retry path ------------------------------------------------------- */
+
+/*
+ * Restarting a rejected image from inside the verdict callback.
+ *
+ * This is the whole recovery path for a rejected update: the device has already
+ * told the cloud to stop offering the component, and the OTA manifest that
+ * would re-offer it arrives only once per connection, so if the relay cannot be
+ * restarted from here the update never retries. The callback runs on the serial
+ * receive path, so it has to be able to re-enter this module.
+ */
+static int retry_err;
+static int retry_count;
+
+static void retry_on_reject(enum pouch_serial_fw_status status)
+{
+    record_status(status);
+
+    if (status == POUCH_SERIAL_FW_STATUS_OK)
+    {
+        return;
+    }
+
+    retry_count++;
+    pouch_serial_fw_abort();
+    retry_err = pouch_serial_fw_begin("main", "1.2.3", IMG_SIZE, hash);
+}
+
+ZTEST(serial_fw, test_rejected_image_can_be_restarted_from_the_callback)
+{
+    uint8_t out[512];
+
+    pouch_serial_fw_status_callback_set(retry_on_reject);
+
+    zassert_ok(pouch_serial_fw_begin("main", "1.2.3", IMG_SIZE, hash));
+    zassert_equal(pouch_serial_fw_write(image, sizeof(image), POUCH_NO_WAIT), IMG_SIZE);
+    pouch_serial_fw_end();
+    zassert_true(drain_relay(out, sizeof(out)) > 0);
+
+    /* The host verifies the image and reports back that it did not take it. */
+    zassert_ok(deliver_status(POUCH_SERIAL_FW_STATUS_HASH_FAIL));
+
+    zassert_equal(retry_count, 1, "the verdict did not trigger a retry");
+    zassert_ok(retry_err, "restarting the relay from the callback failed (%d)", retry_err);
+    zassert_true(pouch_serial_fw_active(), "the retry left no relay armed");
+
+    /* The retry relays the whole image again, from the start. */
+    zassert_equal(pouch_serial_fw_write(image, sizeof(image), POUCH_NO_WAIT), IMG_SIZE);
+    pouch_serial_fw_end();
+
+    int total = drain_relay(out, sizeof(out));
+    size_t hdr_len = POUCH_SERIAL_FW_HDR_FIXED_LEN + strlen("1.2.3") + strlen("main");
+
+    zassert_equal((size_t) total, hdr_len + IMG_SIZE, "the retry did not resend the whole image");
+    zassert_equal(sys_get_le32(&out[8]), 0, "the retry should restart at offset 0");
+    zassert_mem_equal(&out[hdr_len], image, IMG_SIZE);
+}
+
+ZTEST(serial_fw, test_accepted_image_is_not_restarted)
+{
+    uint8_t out[512];
+
+    pouch_serial_fw_status_callback_set(retry_on_reject);
+    retry_count = 0;
+
+    zassert_ok(pouch_serial_fw_begin("main", "1.2.3", IMG_SIZE, hash));
+    zassert_equal(pouch_serial_fw_write(image, sizeof(image), POUCH_NO_WAIT), IMG_SIZE);
+    pouch_serial_fw_end();
+    zassert_true(drain_relay(out, sizeof(out)) > 0);
+
+    zassert_ok(deliver_status(POUCH_SERIAL_FW_STATUS_OK));
+
+    zassert_equal(retry_count, 0, "an accepted image was retried");
+    zassert_false(pouch_serial_fw_active());
+}

--- a/tests/pouch/serial/fw/testcase.yaml
+++ b/tests/pouch/serial/fw/testcase.yaml
@@ -1,0 +1,9 @@
+tests:
+  pouch.serial.fw:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+    tags: test_framework


### PR DESCRIPTION
A core that remoteproc loads from the host filesystem at every boot has no flash
of its own to write an update into, but it is still the authenticated Pouch
endpoint. It downloads its own image through Pouch OTA and streams the plaintext
to the host over two serial channels; the host verifies the SHA-256 from the
manifest, installs alongside the previous image and restarts the core.

Gated on `CONFIG_POUCH_SERIAL_FW_RELAY`, default n — the relay buffer is 8 KB of
static RAM that only remoteproc-loaded cores can use. The channel ids stay
unconditional so every build agrees on the wire format.

Validated end to end on an FRDM-IMX95 against production Golioth: the relayed
image arrives byte-identical to the cloud artifact, and the rejection path
retries three times and then lets the cloud re-offer, all within one boot.

Stack:
1. #304 `transport/rpmsg` — device-side transport
2. #349 `transport/rpmsg-broker` — the Go gateway
3. **this PR** `transport/rpmsg-ota` — MCU-mediated firmware relay
4. `transport/rpmsg-signed-url` — signed-URL firmware delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qt7dZyVifxnMVfSHJT1neN