### PR TITLE
transport: signed-URL firmware delivery for the rpmsg stack

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -31,6 +31,10 @@ jobs:
       actions: write
     uses: ./.github/workflows/test-build-gateway.yml
     secrets: inherit
+  trigger-go:
+    name: Run Go Gateway Tests
+    uses: ./.github/workflows/test-go.yml
+    secrets: inherit
   trigger-twister:
     name: Run Twister
     permissions:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,6 +30,14 @@ jobs:
             example: rpmsg_device
             board: imx95_evk/mimx9596/m7
             no_sysbuild: true
+          # The same sample with the signed-URL handoff off, so the relay-only
+          # configuration keeps building: the two are independent, and only
+          # this entry compiles the fallback path on its own.
+          - manifest: west-zephyr.yml
+            example: rpmsg_device
+            board: imx95_evk/mimx9596/m7
+            no_sysbuild: true
+            extra_args: -DCONFIG_EXAMPLE_FW_SIGNED_URL=n
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:
@@ -63,7 +71,9 @@ jobs:
             SYSBUILD_FLAG="--sysbuild"
           fi
 
-          west build ${SYSBUILD_FLAG} -p -b ${{ matrix.board }} pouch/examples/zephyr/${{ matrix.example }}
+          west build ${SYSBUILD_FLAG} -p -b ${{ matrix.board }} \
+            pouch/examples/zephyr/${{ matrix.example }} \
+            -- ${{ matrix.extra_args }}
 
   build-esp-idf:
     strategy:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -1,0 +1,48 @@
+name: "Test: Go Gateway"
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Vet, build and test the Go gateway
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: examples/linux/rpmsg_gateway
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: examples/linux/rpmsg_gateway/go.mod
+          cache-dependency-path: examples/linux/rpmsg_gateway/go.sum
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      # The gateway runs on the Linux core of the SoC the device sits on, which
+      # is arm64 rather than the runner's architecture.
+      - name: Build for the target
+        run: GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/pouch-rpmsg-gateway
+
+      - name: Test
+        run: go test ./...

--- a/examples/linux/rpmsg_gateway/README.md
+++ b/examples/linux/rpmsg_gateway/README.md
@@ -101,8 +101,12 @@ stop offering the component when it handed the URL over.
 
 Signing needs a clock, and the device has none, so we report ours on the TIME
 channel before the certificate phases. **The gateway's own clock therefore has
-to be right** — NTP, or every URL the device signs falls outside its validity
-window and the cloud refuses it.
+to be right** — run NTP. The device stamps each URL "not before now", and
+Golioth refuses a not-before in the future with no tolerance whatsoever:
+measured against production, five seconds fast is already a 401. The clock we
+report is backdated a few seconds to absorb the ordinary case of being a moment
+ahead, but a host that is properly wrong cannot be rescued from here, and the
+symptom is every update silently falling back to the relay.
 
 **Relay** (`-firmware`). The device downloads the image through Pouch itself and
 streams the plaintext to us over the FW channel, and we verify the SHA-256

--- a/examples/linux/rpmsg_gateway/README.md
+++ b/examples/linux/rpmsg_gateway/README.md
@@ -99,14 +99,30 @@ runs in the background and its verdict goes out on the next session, one
 `-interval` later. The device is waiting for exactly that: it told the cloud to
 stop offering the component when it handed the URL over.
 
-Signing needs a clock, and the device has none, so we report ours on the TIME
-channel before the certificate phases. **The gateway's own clock therefore has
-to be right** — run NTP. The device stamps each URL "not before now", and
-Golioth refuses a not-before in the future with no tolerance whatsoever:
-measured against production, five seconds fast is already a 401. The clock we
-report is backdated a few seconds to absorb the ordinary case of being a moment
-ahead, but a host that is properly wrong cannot be rescued from here, and the
-symptom is every update silently falling back to the relay.
+Signing needs a clock, and the device has none, so we report one on the TIME
+channel before the certificate phases. The device stamps each URL "not before
+now" with whatever we give it, and Golioth refuses a not-before in the future
+with no tolerance whatsoever: measured against production, five seconds ahead is
+already a 401.
+
+What matters is therefore not whether this host's clock is right, but whether
+the stamp is one the server will accept — so we report **the server's** clock,
+not ours. It is learned from the `Date` header of responses we are already
+making, including error responses, so it costs no extra request and is
+re-learned every session rather than fixed at startup. A host running twenty
+seconds fast still produces working URLs.
+
+Two things it does not do. The estimate is good to about a second, since `Date`
+has one-second resolution and the round trip adds a little, so the reported
+clock is additionally backdated a few seconds. And before the first response
+there is nothing to correct by, so the very first session falls back to the
+local clock. Run NTP anyway: a badly wrong host clock breaks certificate
+validity windows and log timestamps regardless, and the gateway warns when it
+notices.
+
+Without this, the failure is invisible. A refused URL makes the device fall back
+to relaying, so the update still succeeds and only this gateway's log says
+why.
 
 **Relay** (`-firmware`). The device downloads the image through Pouch itself and
 streams the plaintext to us over the FW channel, and we verify the SHA-256

--- a/examples/linux/rpmsg_gateway/README.md
+++ b/examples/linux/rpmsg_gateway/README.md
@@ -63,11 +63,70 @@ The broker drives a fixed verb sequence, skipping whatever is already done:
 | 2 DEVICE_CERT | device → gateway | the device's leaf, forwarded to `/.g/device-cert` |
 | 3 DOWNLINK | gateway → device | the cloud's reply |
 | 4 UPLINK | device → gateway | the outbound pouch, posted to `/.g/pouch` |
+| 5 FW_STATUS | gateway → device | what became of an image we were handed |
+| 6 FW | device → gateway | a firmware image relayed through the device |
+| 7 TIME | gateway → device | our wall clock, for a device that has none |
+| 8 FW_URL | device → gateway | a signed URL for an artifact we should fetch |
 
 INFO carries a flags byte and the serial of the server certificate the device
 holds. If that serial matches the chain we would push, the SERVER_CERT phase is
 skipped; if the flags say the cloud already has the device's certificate, so is
-DEVICE_CERT.
+DEVICE_CERT. A second flag says the device can be handed firmware as a signed
+URL; without it we neither push the time nor poll for a URL, so a device built
+without those channels is never left waiting on one.
+
+Channels 5 through 8 are all optional. Leaving their endpoints unset leaves the
+channels unconfigured, which is what a gateway that does not apply firmware
+wants, and the device tolerates that because an unconfigured channel is ignored
+rather than dereferenced.
+
+## Firmware updates
+
+The device this gateway serves is loaded from the host filesystem by remoteproc
+at every boot, so it has no flash of its own and cannot apply its own update. It
+is still the authenticated Pouch endpoint, so the cloud offers updates to it and
+it asks us to install one. It can ask in two ways.
+
+**Signed URL** (`-signed-url`). The device signs a URL for its own artifact with
+its private key and hands us that. We fetch the image over HTTPS, check it
+against the size and SHA-256 the manifest carried, and install it. The signature
+is the only credential involved: it covers one artifact, expires in about ninety
+seconds, and is not ours — we present no identity of our own to the artifact
+host. No image byte crosses the rpmsg link.
+
+Because an artifact takes longer to fetch than a session lasts, the download
+runs in the background and its verdict goes out on the next session, one
+`-interval` later. The device is waiting for exactly that: it told the cloud to
+stop offering the component when it handed the URL over.
+
+Signing needs a clock, and the device has none, so we report ours on the TIME
+channel before the certificate phases. **The gateway's own clock therefore has
+to be right** — NTP, or every URL the device signs falls outside its validity
+window and the cloud refuses it.
+
+**Relay** (`-firmware`). The device downloads the image through Pouch itself and
+streams the plaintext to us over the FW channel, and we verify the SHA-256
+before installing. It works without any cloud feature, at the cost of moving
+every byte twice and holding the whole image in memory here. The device falls
+back to this when a signed URL is refused.
+
+Either way, `-firmware-dir` says where a verified image lands and `-remoteproc`
+points at the core to restart onto it. The restart happens after the session
+ends: the device is owed its verdict first, and taking the core down mid-session
+drops the link out from under the exchange still running on it.
+`-firmware-reject` reports a hash failure for an image that actually verified,
+which is the only convenient way to exercise the device's retry path.
+
+Signed URLs additionally require the feature to be enabled for the Golioth
+project, and the CA that issued the device certificate to be uploaded to it. A
+403 from the artifact host is what either omission looks like from here.
+
+> [!CAUTION]
+> With `-signed-url` this process fetches a URL the device chose. The device is
+> the trust boundary — it is on the same die, and it is the only thing holding a
+> key — but the URL is still checked rather than trusted: `https` only, bounded
+> in length, no redirect off `https`, and the response is read only as far as
+> the size the manifest promised.
 
 ## Layout
 
@@ -76,7 +135,7 @@ DEVICE_CERT.
 | `internal/serial` | The Pouch Serial protocol: header codec, channel state machine, broker verb loop |
 | `internal/link` | Frame I/O over an rpmsg character device |
 | `internal/cloud` | The `/.g/*` HTTP contract and upstream mTLS |
-| `internal/gateway` | Session wiring: endpoints, provisioning decisions, the pump |
+| `internal/gateway` | Session wiring: endpoints, provisioning decisions, the pump, firmware |
 | `cmd/pouch-rpmsg-gateway` | The daemon |
 
 `internal/serial` is a port of `src/transport/serial/` from this repo. Its tests

--- a/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
+++ b/examples/linux/rpmsg_gateway/cmd/pouch-rpmsg-gateway/main.go
@@ -39,6 +39,14 @@ func main() {
 			"remoteproc node to apply firmware through, e.g. /sys/class/remoteproc/remoteproc1")
 		fwReject = flag.Bool("firmware-reject", false,
 			"report a hash failure for images that verify, to exercise the device's retry path")
+		signedURL = flag.Bool("signed-url", false,
+			"fetch firmware from a URL the device signs, instead of having it relayed")
+		dlDir = flag.String("download-dir", "",
+			"where to download signed-URL artifacts (default: -firmware-dir, else a temp dir)")
+		dlTimeout = flag.Duration("download-timeout", 10*time.Minute,
+			"how long one artifact download may take")
+		caFile = flag.String("ca", "",
+			"PEM bundle trusted for artifact downloads, in addition to the system roots")
 		verbose = flag.Bool("v", false, "debug logging")
 	)
 	flag.Parse()
@@ -90,7 +98,7 @@ func main() {
 		c = cloud.New(*server, *timeout)
 	}
 
-	gw := gateway.New(l, c, link.MaxFrame, log)
+	gw := gateway.New(ctx, l, c, link.MaxFrame, log)
 	var fwOpts *gateway.FirmwareOptions
 
 	// applied is set when an image lands on disk. The core is restarted after
@@ -98,8 +106,16 @@ func main() {
 	// first, and restarting mid-session would take the link down under it.
 	var applied string
 
-	if *firmware || *fwDir != "" || *fwReject || *rproc != "" {
-		opts := &gateway.FirmwareOptions{ForceReject: *fwReject}
+	// install records an image that has landed where the host can boot it. The
+	// two firmware paths differ only in how the bytes got there.
+	install := func(path string) {
+		applied = path
+		log.Info("firmware installed", "path", path)
+	}
+
+	if *firmware || *fwDir != "" || *fwReject || *rproc != "" || *signedURL {
+		opts := &gateway.FirmwareOptions{ForceReject: *fwReject, SignedURL: *signedURL}
+
 		if *fwDir != "" {
 			dir := *fwDir
 			opts.Apply = func(pkg, version string, image []byte) error {
@@ -110,11 +126,55 @@ func main() {
 				if err := os.WriteFile(path, image, 0o644); err != nil {
 					return err
 				}
-				applied = path
-				log.Info("firmware installed", "path", path, "bytes", len(image))
+				install(path)
 				return nil
 			}
 		}
+
+		if *signedURL {
+			httpc, err := gateway.NewHTTPClient(*caFile)
+			if err != nil {
+				log.Error("build artifact HTTP client", "err", err)
+				os.Exit(1)
+			}
+
+			// Downloaded straight into the firmware directory where possible,
+			// so applying is a rename away rather than a second copy.
+			dir := *dlDir
+			if dir == "" {
+				dir = *fwDir
+			}
+			if dir == "" {
+				dir = filepath.Join(os.TempDir(), "pouch-firmware")
+			}
+
+			opts.Downloader = &gateway.Downloader{
+				Client:  httpc,
+				Dir:     dir,
+				Timeout: *dlTimeout,
+				Log:     log,
+			}
+
+			if *fwDir != "" {
+				fwDirCopy, dlDirCopy := *fwDir, dir
+				opts.ApplyFile = func(pkg, version, path string) error {
+					if dlDirCopy == fwDirCopy {
+						install(path)
+						return nil
+					}
+					if err := os.MkdirAll(fwDirCopy, 0o755); err != nil {
+						return err
+					}
+					dst := filepath.Join(fwDirCopy, filepath.Base(path))
+					if err := copyFile(path, dst); err != nil {
+						return err
+					}
+					install(dst)
+					return nil
+				}
+			}
+		}
+
 		gw.Firmware = opts
 		fwOpts = opts
 	}
@@ -148,7 +208,7 @@ func main() {
 			}
 			l = nl
 			closeOnCancel(l)
-			gw = gateway.New(l, c, link.MaxFrame, log)
+			gw = gateway.New(ctx, l, c, link.MaxFrame, log)
 			gw.Firmware = fwOpts
 			log.Info("reattached after firmware apply", "device", *dev)
 		}
@@ -168,16 +228,21 @@ func main() {
 // This is the "host-side apply" half of an MCU-mediated update: the core has no
 // flash of its own, so applying means putting the file where remoteproc loads
 // from and cycling the core.
+// copyFile copies src to dst, replacing whatever was there.
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}
+
 func applyViaRemoteproc(log *slog.Logger, node, image string) error {
 	name := filepath.Base(image)
 	dst := filepath.Join("/lib/firmware", name)
 
 	if dst != image {
-		data, err := os.ReadFile(image)
-		if err != nil {
-			return err
-		}
-		if err := os.WriteFile(dst, data, 0o644); err != nil {
+		if err := copyFile(image, dst); err != nil {
 			return err
 		}
 	}

--- a/examples/linux/rpmsg_gateway/internal/cloud/client.go
+++ b/examples/linux/rpmsg_gateway/internal/cloud/client.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 )
 
@@ -30,6 +31,48 @@ const (
 type Client struct {
 	Address string
 	HTTP    *http.Client
+
+	// The server's clock, as observed from its Date header. It is tracked
+	// because the server is the authority on time for anything it validates:
+	// a device signing an artifact URL stamps it with a not-before, and this
+	// server rejects one in the future outright. Handing the device our own
+	// clock therefore fails whenever we are fast, so we hand it this instead.
+	clockMu     sync.Mutex
+	clockOffset time.Duration
+	clockValid  bool
+}
+
+// ClockOffset returns how far the server's clock runs ahead of ours, and
+// whether one has been observed yet. Add it to a local timestamp to express it
+// on the server's terms.
+func (c *Client) ClockOffset() (time.Duration, bool) {
+	c.clockMu.Lock()
+	defer c.clockMu.Unlock()
+	return c.clockOffset, c.clockValid
+}
+
+// observeClock records the server's clock from one response.
+//
+// sent and received bracket the request, so the instant the server stamped its
+// Date lies somewhere between them. Taking the midpoint removes the round trip
+// from the estimate; what remains is the header's one-second resolution and
+// half the asymmetry of the path.
+func (c *Client) observeClock(resp *http.Response, sent, received time.Time) {
+	date := resp.Header.Get("Date")
+	if date == "" {
+		return
+	}
+	serverTime, err := http.ParseTime(date)
+	if err != nil {
+		return
+	}
+
+	midpoint := sent.Add(received.Sub(sent) / 2)
+
+	c.clockMu.Lock()
+	defer c.clockMu.Unlock()
+	c.clockOffset = serverTime.Sub(midpoint)
+	c.clockValid = true
 }
 
 // New returns a client for address, e.g. "https://gw.golioth.io".
@@ -62,11 +105,16 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 	if client == nil {
 		client = http.DefaultClient
 	}
+	sent := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %w", method, path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	// Before the status check: an error response carries the header too, and a
+	// gateway that cannot reach the cloud yet still wants to learn its clock.
+	c.observeClock(resp, sent, time.Now())
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))

--- a/examples/linux/rpmsg_gateway/internal/cloud/clock_test.go
+++ b/examples/linux/rpmsg_gateway/internal/cloud/clock_test.go
@@ -1,0 +1,97 @@
+package cloud
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// The server's clock is the authority on the timestamps it validates, so the
+// client learns it from responses it is already making rather than trusting the
+// local clock.
+func TestClockOffsetFromDateHeader(t *testing.T) {
+	ahead := 42 * time.Second
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Date", time.Now().Add(ahead).UTC().Format(http.TimeFormat))
+		_, _ = w.Write([]byte("chain"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, 5*time.Second)
+
+	if _, ok := c.ClockOffset(); ok {
+		t.Fatal("reported an offset before any response was seen")
+	}
+
+	if _, err := c.ServerCert(context.Background()); err != nil {
+		t.Fatalf("ServerCert: %v", err)
+	}
+
+	offset, ok := c.ClockOffset()
+	if !ok {
+		t.Fatal("no offset after a response carrying a Date header")
+	}
+
+	// Date has one-second resolution and the round trip adds a little, so the
+	// estimate is good to about a second, not better.
+	if d := offset - ahead; d > 2*time.Second || d < -2*time.Second {
+		t.Errorf("offset %v, want about %v", offset, ahead)
+	}
+}
+
+func TestClockOffsetFromErrorResponse(t *testing.T) {
+	ahead := 30 * time.Second
+
+	// A gateway that cannot authenticate yet still wants to learn the clock:
+	// the header is on the refusal too.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Date", time.Now().Add(ahead).UTC().Format(http.TimeFormat))
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, 5*time.Second)
+
+	if _, err := c.ServerCert(context.Background()); err == nil {
+		t.Fatal("a 401 should still be reported as an error")
+	}
+
+	offset, ok := c.ClockOffset()
+	if !ok {
+		t.Fatal("no offset learned from an error response")
+	}
+	if d := offset - ahead; d > 2*time.Second || d < -2*time.Second {
+		t.Errorf("offset %v, want about %v", offset, ahead)
+	}
+}
+
+func TestClockOffsetIgnoresUnusableDate(t *testing.T) {
+	for _, tc := range []struct{ name, date string }{
+		{"absent", ""},
+		{"unparseable", "not a date"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Go sets Date itself unless it is explicitly suppressed.
+				w.Header()["Date"] = nil
+				if tc.date != "" {
+					w.Header().Set("Date", tc.date)
+				}
+				_, _ = w.Write([]byte("chain"))
+			}))
+			defer srv.Close()
+
+			c := New(srv.URL, 5*time.Second)
+			if _, err := c.ServerCert(context.Background()); err != nil {
+				t.Fatalf("ServerCert: %v", err)
+			}
+
+			if _, ok := c.ClockOffset(); ok {
+				t.Error("claimed an offset from a response with no usable Date")
+			}
+		})
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/gateway/clock_test.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/clock_test.go
@@ -1,0 +1,76 @@
+package gateway
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// fakeCloud supplies a fixed clock offset and nothing else.
+type fakeCloud struct {
+	offset time.Duration
+	known  bool
+}
+
+func (f *fakeCloud) ServerCert(context.Context) ([]byte, error) { return nil, nil }
+func (f *fakeCloud) RegisterDevice(context.Context, []byte) error {
+	return nil
+}
+func (f *fakeCloud) Forward(context.Context, []byte) ([]byte, error) { return nil, nil }
+func (f *fakeCloud) ClockOffset() (time.Duration, bool)              { return f.offset, f.known }
+
+func gatewayWithOffset(offset time.Duration, known bool) *Gateway {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return New(context.Background(), nil, &fakeCloud{offset: offset, known: known}, 496, log)
+}
+
+// The point of the whole mechanism: a host running fast must not produce a
+// stamp the server reads as being in the future, because the server refuses
+// those outright and the device then silently falls back to relaying.
+func TestReportedClockCorrectsAFastHost(t *testing.T) {
+	// Host twenty seconds ahead of the server, which is what the bench board
+	// was doing when every signed URL came back 401.
+	g := gatewayWithOffset(-20*time.Second, true)
+
+	reported := time.Unix(int64(binary.LittleEndian.Uint64(timeRecord(g.serverNow())[4:12])), 0)
+	serverNow := time.Now().Add(-20 * time.Second)
+
+	if !reported.Before(serverNow) {
+		t.Errorf("reported %v is not behind the server's %v; the stamp would be refused",
+			reported, serverNow)
+	}
+	// Corrected, not merely backdated: without the offset the report would sit
+	// a quarter minute ahead of the server rather than just behind it.
+	if serverNow.Sub(reported) > 30*time.Second {
+		t.Errorf("reported %v is needlessly far behind the server's %v", reported, serverNow)
+	}
+}
+
+func TestReportedClockCorrectsASlowHost(t *testing.T) {
+	// A slow host is harmless for validity, but correcting it keeps the far end
+	// of the window where the device expects it.
+	g := gatewayWithOffset(30*time.Second, true)
+
+	reported := time.Unix(int64(binary.LittleEndian.Uint64(timeRecord(g.serverNow())[4:12])), 0)
+	serverNow := time.Now().Add(30 * time.Second)
+
+	if d := serverNow.Sub(reported); d < 0 || d > timeSkewMargin+2*time.Second {
+		t.Errorf("reported %v sits %v from the server's %v, want just under the margin",
+			reported, d, serverNow)
+	}
+}
+
+func TestReportedClockFallsBackToLocal(t *testing.T) {
+	// Nothing observed yet, on the very first session: the local clock is all
+	// there is, and the margin is the only protection.
+	g := gatewayWithOffset(0, false)
+
+	reported := time.Unix(int64(binary.LittleEndian.Uint64(timeRecord(g.serverNow())[4:12])), 0)
+
+	if d := time.Since(reported); d < timeSkewMargin || d > timeSkewMargin+2*time.Second {
+		t.Errorf("reported clock is %v behind local, want about %v", d, timeSkewMargin)
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/gateway/download.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/download.go
@@ -1,0 +1,251 @@
+package gateway
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Downloader fetches an artifact from a URL the device signed.
+//
+// The signature is the only credential involved: it authorizes this one
+// artifact for a short window, so the request carries no identity of ours. That
+// is deliberate - presenting the gateway's client certificate to whatever host
+// serves the artifact would hand our identity to a third party for no benefit.
+type Downloader struct {
+	// Client fetches the artifact. Left nil, a default one is built with the
+	// system roots.
+	Client *http.Client
+	// Dir is where verified artifacts land.
+	Dir string
+	// Timeout bounds one download. A whole-request deadline on the client
+	// would be wrong here: artifacts run to megabytes over links we do not
+	// control, so the bound is applied per download and set generously.
+	Timeout time.Duration
+	Log     *slog.Logger
+}
+
+// NewHTTPClient returns a client suitable for artifact downloads. caFile, if
+// given, is a PEM bundle trusted in addition to the system roots.
+func NewHTTPClient(caFile string) (*http.Client, error) {
+	var roots *x509.CertPool
+
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA bundle: %w", err)
+		}
+		roots, err = x509.SystemCertPool()
+		if err != nil {
+			roots = x509.NewCertPool()
+		}
+		if !roots.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("no certificates found in %s", caFile)
+		}
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    roots,
+			},
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
+		// A redirect out of https would move the artifact, and the signature
+		// that authorizes it, onto a cleartext connection.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.URL.Scheme != "https" {
+				return fmt.Errorf("refusing redirect to %q", req.URL.Scheme)
+			}
+			if len(via) >= 10 {
+				return errors.New("too many redirects")
+			}
+			return nil
+		},
+	}, nil
+}
+
+// downloadResult is what one completed download has to say for itself.
+type downloadResult struct {
+	pkg     string
+	version string
+	path    string
+	verdict FwStatus
+}
+
+// Fetch downloads and verifies one artifact. It reports a verdict rather than
+// an error for anything the device needs to hear about, because the verdict is
+// what goes back over the wire.
+func (d *Downloader) Fetch(ctx context.Context, rec *fwURLRecord) downloadResult {
+	result := downloadResult{pkg: rec.pkg, version: rec.version, verdict: FwStatusError}
+
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rec.url, nil)
+	if err != nil {
+		d.Log.Error("build artifact request", "err", err)
+		return result
+	}
+
+	resp, err := d.Client.Do(req)
+	if err != nil {
+		d.Log.Error("fetch artifact", "err", err)
+		return result
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// 401 or 403 here is the usual sign that the project does not have
+		// signed URLs enabled, or that the device's CA was never uploaded to
+		// it. The device falls back to relaying when it hears this.
+		d.Log.Error("artifact server refused the signed URL",
+			"status", resp.Status, "package", rec.pkg, "version", rec.version)
+		return result
+	}
+
+	if resp.ContentLength >= 0 && resp.ContentLength != int64(rec.size) {
+		d.Log.Error("artifact is not the size the manifest promised",
+			"got", resp.ContentLength, "want", rec.size)
+		return result
+	}
+
+	if err := os.MkdirAll(d.Dir, 0o755); err != nil {
+		d.Log.Error("create download directory", "err", err)
+		return result
+	}
+
+	final := filepath.Join(d.Dir, fmt.Sprintf("%s-%s.elf", rec.pkg, rec.version))
+	partial := final + ".part"
+
+	f, err := os.Create(partial)
+	if err != nil {
+		d.Log.Error("create artifact file", "err", err)
+		return result
+	}
+
+	digest := sha256.New()
+	// One byte past the promised size, so an artifact that is too long is seen
+	// as too long rather than silently truncated to a matching length.
+	n, err := io.Copy(io.MultiWriter(f, digest), io.LimitReader(resp.Body, int64(rec.size)+1))
+	closeErr := f.Close()
+
+	if err != nil || closeErr != nil {
+		d.Log.Error("write artifact", "err", errors.Join(err, closeErr))
+		_ = os.Remove(partial)
+		return result
+	}
+
+	if n != int64(rec.size) {
+		d.Log.Error("artifact is not the size the manifest promised",
+			"got", n, "want", rec.size)
+		_ = os.Remove(partial)
+		return result
+	}
+
+	var got [32]byte
+	copy(got[:], digest.Sum(nil))
+	if got != rec.sha256 {
+		d.Log.Error("artifact does not match the manifest digest",
+			"package", rec.pkg, "version", rec.version)
+		_ = os.Remove(partial)
+		result.verdict = FwStatusHashFail
+		return result
+	}
+
+	if err := os.Rename(partial, final); err != nil {
+		d.Log.Error("install artifact", "err", err)
+		_ = os.Remove(partial)
+		return result
+	}
+
+	d.Log.Info("artifact downloaded and verified",
+		"package", rec.pkg, "version", rec.version, "bytes", n, "path", final)
+
+	result.path = final
+	result.verdict = FwStatusOK
+	return result
+}
+
+// fwDownloads tracks the one download that may be in flight.
+//
+// The download outlives the session that asked for it: artifacts take longer
+// than a session does, and holding the session open would stall the uplink and
+// downlink behind a file transfer. The verdict therefore goes back on a later
+// session, which is what the device's apply-verdict channel is already shaped
+// for.
+type fwDownloads struct {
+	mu       sync.Mutex
+	inflight *fwURLRecord
+	cancel   context.CancelFunc
+	result   *downloadResult
+}
+
+// start begins a download unless the same artifact is already being fetched.
+func (g *Gateway) startDownload(ctx context.Context, rec *fwURLRecord) {
+	g.downloads.mu.Lock()
+	defer g.downloads.mu.Unlock()
+
+	if cur := g.downloads.inflight; cur != nil {
+		if cur.pkg == rec.pkg && cur.version == rec.version {
+			g.log.Debug("already fetching this artifact",
+				"package", rec.pkg, "version", rec.version)
+			return
+		}
+		// The device moved on to a different artifact, so this one is moot.
+		g.log.Info("abandoning the previous artifact",
+			"package", cur.pkg, "version", cur.version)
+		g.downloads.cancel()
+	}
+
+	// Detached from the session context on purpose: the session that carried
+	// the record ends long before the download does.
+	dlCtx, cancel := context.WithCancel(ctx)
+	g.downloads.inflight = rec
+	g.downloads.cancel = cancel
+
+	g.log.Info("fetching artifact on the device's behalf",
+		"package", rec.pkg, "version", rec.version, "bytes", rec.size)
+
+	go func() {
+		res := g.Firmware.Downloader.Fetch(dlCtx, rec)
+		cancel()
+
+		g.downloads.mu.Lock()
+		defer g.downloads.mu.Unlock()
+		g.downloads.inflight = nil
+		g.downloads.cancel = nil
+		g.downloads.result = &res
+	}()
+}
+
+// takeDownloadResult returns a finished download's verdict, once.
+func (g *Gateway) takeDownloadResult() *downloadResult {
+	g.downloads.mu.Lock()
+	defer g.downloads.mu.Unlock()
+
+	res := g.downloads.result
+	g.downloads.result = nil
+	return res
+}
+
+// stopDownloads cancels anything in flight, for shutdown.
+func (g *Gateway) stopDownloads() {
+	g.downloads.mu.Lock()
+	defer g.downloads.mu.Unlock()
+
+	if g.downloads.cancel != nil {
+		g.downloads.cancel()
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/gateway/download_test.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/download_test.go
@@ -1,0 +1,203 @@
+package gateway
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newTestDownloader serves body at the artifact URL and returns a Downloader
+// that trusts the test server, plus the record describing what it claims to be.
+func newTestDownloader(t *testing.T, body []byte, claimed []byte,
+	handler http.HandlerFunc) (*Downloader, *fwURLRecord) {
+	t.Helper()
+
+	if handler == nil {
+		handler = func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(body)
+		}
+	}
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(srv.Certificate())
+
+	d := &Downloader{
+		Client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots},
+			},
+		},
+		Dir:     t.TempDir(),
+		Timeout: 10 * time.Second,
+		Log:     quietLogger(),
+	}
+
+	rec := &fwURLRecord{
+		pkg:     "rpmsg_device",
+		version: "1.0.3",
+		size:    uint32(len(claimed)),
+		sha256:  sha256.Sum256(claimed),
+		url:     srv.URL + "/.u/c/rpmsg_device@1.0.3",
+	}
+	return d, rec
+}
+
+func TestFetchVerifiedArtifact(t *testing.T) {
+	image := []byte("the firmware image, such as it is")
+	d, rec := newTestDownloader(t, image, image, nil)
+
+	res := d.Fetch(context.Background(), rec)
+
+	if res.verdict != FwStatusOK {
+		t.Fatalf("verdict %v, want ok", res.verdict)
+	}
+	got, err := os.ReadFile(res.path)
+	if err != nil {
+		t.Fatalf("read installed artifact: %v", err)
+	}
+	if string(got) != string(image) {
+		t.Errorf("installed artifact does not match what was served")
+	}
+	if filepath.Base(res.path) != "rpmsg_device-1.0.3.elf" {
+		t.Errorf("installed as %q", filepath.Base(res.path))
+	}
+}
+
+func TestFetchCorruptedArtifact(t *testing.T) {
+	image := []byte("the firmware image, such as it is")
+	corrupt := append([]byte(nil), image...)
+	corrupt[0] ^= 0xff
+
+	// Served corrupted, but the record still promises the original digest -
+	// which is the whole point of carrying one.
+	d, rec := newTestDownloader(t, corrupt, image, nil)
+
+	res := d.Fetch(context.Background(), rec)
+
+	if res.verdict != FwStatusHashFail {
+		t.Fatalf("verdict %v, want hash-fail", res.verdict)
+	}
+	if entries, _ := os.ReadDir(d.Dir); len(entries) != 0 {
+		t.Errorf("a failed download left %d files behind", len(entries))
+	}
+}
+
+func TestFetchShortArtifact(t *testing.T) {
+	image := []byte("the firmware image, such as it is")
+
+	// Fewer bytes than promised, and no Content-Length to give it away.
+	d, rec := newTestDownloader(t, nil, image, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Transfer-Encoding", "chunked")
+		_, _ = w.Write(image[:5])
+	})
+
+	res := d.Fetch(context.Background(), rec)
+
+	if res.verdict != FwStatusError {
+		t.Fatalf("verdict %v, want error", res.verdict)
+	}
+	if entries, _ := os.ReadDir(d.Dir); len(entries) != 0 {
+		t.Errorf("a truncated download left %d files behind", len(entries))
+	}
+}
+
+func TestFetchOverlongArtifact(t *testing.T) {
+	image := []byte("the firmware image, such as it is")
+
+	d, rec := newTestDownloader(t, nil, image, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Transfer-Encoding", "chunked")
+		_, _ = w.Write(append(append([]byte(nil), image...), "extra"...))
+	})
+
+	res := d.Fetch(context.Background(), rec)
+
+	// The read is bounded one byte past the promised size, so too-long is seen
+	// as too long rather than silently truncated into a matching digest.
+	if res.verdict != FwStatusError {
+		t.Fatalf("verdict %v, want error", res.verdict)
+	}
+}
+
+func TestFetchRefusedURL(t *testing.T) {
+	image := []byte("the firmware image")
+
+	// What a project without signed URLs enabled, or a CA the cloud does not
+	// know, actually looks like from here.
+	d, rec := newTestDownloader(t, nil, image, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	res := d.Fetch(context.Background(), rec)
+
+	if res.verdict != FwStatusError {
+		t.Fatalf("verdict %v, want error", res.verdict)
+	}
+}
+
+func TestFetchContentLengthMismatch(t *testing.T) {
+	image := []byte("the firmware image, such as it is")
+
+	// The server is honest about a body that is not the promised size, so this
+	// is caught before a byte is written.
+	d, rec := newTestDownloader(t, nil, image, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(image[:10])
+	})
+
+	res := d.Fetch(context.Background(), rec)
+
+	if res.verdict != FwStatusError {
+		t.Fatalf("verdict %v, want error", res.verdict)
+	}
+	if entries, _ := os.ReadDir(d.Dir); len(entries) != 0 {
+		t.Errorf("a rejected download left %d files behind", len(entries))
+	}
+}
+
+func TestFetchCancelled(t *testing.T) {
+	image := []byte("the firmware image, such as it is")
+
+	d, rec := newTestDownloader(t, image, image, func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := d.Fetch(ctx, rec)
+
+	if res.verdict != FwStatusError {
+		t.Fatalf("verdict %v, want error", res.verdict)
+	}
+}
+
+func TestNewHTTPClientRejectsBadCA(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "not-a-ca.pem")
+	if err := os.WriteFile(f, []byte("definitely not PEM"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewHTTPClient(f); err == nil {
+		t.Fatal("accepted a file with no certificates in it")
+	}
+	if _, err := NewHTTPClient(filepath.Join(t.TempDir(), "missing.pem")); err == nil {
+		t.Fatal("accepted a CA bundle that does not exist")
+	}
+	if _, err := NewHTTPClient(""); err != nil {
+		t.Fatalf("system roots should need no file: %v", err)
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/gateway/fwurl.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/fwurl.go
@@ -38,6 +38,20 @@ const (
 	timeMagic     = 0x314D5450 // "PTM1" little endian
 )
 
+// timeSkewMargin backdates the clock we report to the device.
+//
+// The device stamps a signed URL with "not before now", and Golioth rejects a
+// not-before in the future with no tolerance at all - measured against
+// production, five seconds ahead is already a 401. The error is therefore
+// completely asymmetric: a clock we report slightly fast makes every update
+// fail, while one slightly slow costs a few seconds off a ninety-second
+// validity window and nothing else.
+//
+// So lean slow. This does not rescue a host whose clock is properly wrong -
+// nothing local can - but it absorbs the ordinary case of being a moment ahead,
+// plus the time the record spends in transit before it is used.
+const timeSkewMargin = 5 * time.Second
+
 // fwURLRecord is a device's request that we fetch an artifact on its behalf.
 type fwURLRecord struct {
 	pkg     string
@@ -101,10 +115,11 @@ func parseFwURLRecord(b []byte) (*fwURLRecord, error) {
 	return r, nil
 }
 
-// timeRecord encodes the wall clock for a device that has none of its own.
+// timeRecord encodes the wall clock for a device that has none of its own,
+// backdated by timeSkewMargin.
 func timeRecord(now time.Time) []byte {
 	b := make([]byte, timeRecordLen)
 	binary.LittleEndian.PutUint32(b[0:4], timeMagic)
-	binary.LittleEndian.PutUint64(b[4:12], uint64(now.Unix()))
+	binary.LittleEndian.PutUint64(b[4:12], uint64(now.Add(-timeSkewMargin).Unix()))
 	return b
 }

--- a/examples/linux/rpmsg_gateway/internal/gateway/fwurl.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/fwurl.go
@@ -1,0 +1,110 @@
+package gateway
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// The signed-URL record, as src/transport/endpoints/device/fw_url.c writes it.
+//
+//	magic    u32le "PFU1"
+//	size     u32le  artifact size
+//	sha256   [32]   digest of the artifact, from the OTA manifest
+//	ver_len  u8
+//	pkg_len  u8
+//	url_len  u16le
+//	version  [ver_len]
+//	package  [pkg_len]
+//	url      [url_len]
+//
+// Unlike the relay this is never chunked: the record is small and fixed, and
+// the device holds it until we collect the whole thing.
+const (
+	fwURLHdrFixedLen = 44
+	fwURLMagic       = 0x31554650 // "PFU1" little endian
+
+	// The device's own limit is a Kconfig option, typically 1024. This is the
+	// ceiling we will accept from any device, whatever it was built with: a
+	// signed URL runs to roughly 750 bytes, so anything approaching this is
+	// already wrong.
+	fwURLMaxLen = 4096
+)
+
+// The time record we push, matching POUCH_SERIAL_TIME_* in fw_url.h.
+const (
+	timeRecordLen = 12
+	timeMagic     = 0x314D5450 // "PTM1" little endian
+)
+
+// fwURLRecord is a device's request that we fetch an artifact on its behalf.
+type fwURLRecord struct {
+	pkg     string
+	version string
+	size    uint32
+	sha256  [32]byte
+	url     string
+}
+
+func parseFwURLRecord(b []byte) (*fwURLRecord, error) {
+	if len(b) < fwURLHdrFixedLen {
+		return nil, fmt.Errorf("signed-URL record of %d bytes is shorter than its header", len(b))
+	}
+	if magic := binary.LittleEndian.Uint32(b[0:4]); magic != fwURLMagic {
+		return nil, fmt.Errorf("bad signed-URL record magic 0x%08x", magic)
+	}
+
+	r := &fwURLRecord{size: binary.LittleEndian.Uint32(b[4:8])}
+	copy(r.sha256[:], b[8:40])
+
+	verLen, pkgLen := int(b[40]), int(b[41])
+	urlLen := int(binary.LittleEndian.Uint16(b[42:44]))
+
+	if r.size == 0 {
+		return nil, fmt.Errorf("signed-URL record describes an empty artifact")
+	}
+	if urlLen == 0 || urlLen > fwURLMaxLen {
+		return nil, fmt.Errorf("signed-URL record carries a %d byte URL", urlLen)
+	}
+
+	end := fwURLHdrFixedLen + verLen + pkgLen + urlLen
+	if len(b) < end {
+		return nil, fmt.Errorf("signed-URL record truncated in its variable fields")
+	}
+
+	off := fwURLHdrFixedLen
+	r.version = string(b[off : off+verLen])
+	off += verLen
+	r.pkg = string(b[off : off+pkgLen])
+	off += pkgLen
+	r.url = string(b[off : off+urlLen])
+
+	if r.pkg == "" || r.version == "" {
+		return nil, fmt.Errorf("signed-URL record names no package or version")
+	}
+
+	// The device chooses this URL and we fetch it, so it is checked rather than
+	// trusted. Plain HTTP would put the artifact - and the signature that
+	// authorizes it - on the wire in clear.
+	u, err := url.Parse(r.url)
+	if err != nil {
+		return nil, fmt.Errorf("signed-URL record carries an unparseable URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("signed-URL record carries a %q URL, want https", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("signed-URL record carries a URL with no host")
+	}
+
+	return r, nil
+}
+
+// timeRecord encodes the wall clock for a device that has none of its own.
+func timeRecord(now time.Time) []byte {
+	b := make([]byte, timeRecordLen)
+	binary.LittleEndian.PutUint32(b[0:4], timeMagic)
+	binary.LittleEndian.PutUint64(b[4:12], uint64(now.Unix()))
+	return b
+}

--- a/examples/linux/rpmsg_gateway/internal/gateway/fwurl.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/fwurl.go
@@ -38,6 +38,12 @@ const (
 	timeMagic     = 0x314D5450 // "PTM1" little endian
 )
 
+// clockSkewWarn is how far our own clock may sit from the server's before it is
+// worth complaining about. Signed URLs survive it, since the reported clock is
+// corrected, but a host this far out has other problems - certificate validity
+// windows and log timestamps among them.
+const clockSkewWarn = 5 * time.Second
+
 // timeSkewMargin backdates the clock we report to the device.
 //
 // The device stamps a signed URL with "not before now", and Golioth rejects a
@@ -47,9 +53,10 @@ const (
 // fail, while one slightly slow costs a few seconds off a ninety-second
 // validity window and nothing else.
 //
-// So lean slow. This does not rescue a host whose clock is properly wrong -
-// nothing local can - but it absorbs the ordinary case of being a moment ahead,
-// plus the time the record spends in transit before it is used.
+// So lean slow. serverNow already removes the bulk of any error by reporting
+// the server's clock rather than ours; this covers what it cannot, which is the
+// Date header's one-second resolution and the time the record spends in transit
+// before the device signs with it.
 const timeSkewMargin = 5 * time.Second
 
 // fwURLRecord is a device's request that we fetch an artifact on its behalf.
@@ -113,6 +120,40 @@ func parseFwURLRecord(b []byte) (*fwURLRecord, error) {
 	}
 
 	return r, nil
+}
+
+// serverNow is the time to report to the device: our clock expressed on the
+// server's terms.
+//
+// The device stamps a signed URL with "not before now" using whatever clock we
+// give it, and the server refuses a not-before in the future. What matters is
+// therefore not whether our clock is right in the abstract, but whether the
+// stamp is one the server will accept - so the server's own clock is the one to
+// report. It is learned from the Date header of responses we already make, so
+// this costs no extra request, and it is re-learned every session rather than
+// fixed at startup.
+//
+// Until a response has been seen there is nothing to correct by, and the local
+// clock is the only thing available.
+func (g *Gateway) serverNow() time.Time {
+	offset, ok := g.cloud.ClockOffset()
+	if !ok {
+		g.log.Debug("no server clock observed yet, reporting the local one")
+		return time.Now()
+	}
+
+	if offset > clockSkewWarn || offset < -clockSkewWarn {
+		// Rate-limited to once per whole second of drift: sessions are frequent
+		// and a steadily wrong clock would otherwise repeat this forever.
+		if offset.Truncate(time.Second) != g.lastSkewLogged {
+			g.lastSkewLogged = offset.Truncate(time.Second)
+			g.log.Warn("this host's clock disagrees with the server; "+
+				"signed URLs are corrected for it, but the host clock is worth fixing",
+				"behind_server_by", offset.Round(time.Millisecond))
+		}
+	}
+
+	return time.Now().Add(offset)
 }
 
 // timeRecord encodes the wall clock for a device that has none of its own,

--- a/examples/linux/rpmsg_gateway/internal/gateway/fwurl_test.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/fwurl_test.go
@@ -1,0 +1,132 @@
+package gateway
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildRecord assembles a signed-URL record the way the device does, so the
+// parser is tested against the layout rather than against itself.
+func buildRecord(pkg, version, url string, size uint32, digest [32]byte) []byte {
+	b := make([]byte, fwURLHdrFixedLen)
+	binary.LittleEndian.PutUint32(b[0:4], fwURLMagic)
+	binary.LittleEndian.PutUint32(b[4:8], size)
+	copy(b[8:40], digest[:])
+	b[40] = byte(len(version))
+	b[41] = byte(len(pkg))
+	binary.LittleEndian.PutUint16(b[42:44], uint16(len(url)))
+	b = append(b, version...)
+	b = append(b, pkg...)
+	b = append(b, url...)
+	return b
+}
+
+func testDigest() [32]byte {
+	var d [32]byte
+	for i := range d {
+		d[i] = byte(i)
+	}
+	return d
+}
+
+func TestParseFwURLRecord(t *testing.T) {
+	digest := testDigest()
+	url := "https://gw.golioth.io/.u/c/rpmsg_device@1.0.3?nb=1&na=2&cert=x&sig=y"
+	raw := buildRecord("rpmsg_device", "1.0.3", url, 250948, digest)
+
+	rec, err := parseFwURLRecord(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if rec.pkg != "rpmsg_device" {
+		t.Errorf("package %q", rec.pkg)
+	}
+	if rec.version != "1.0.3" {
+		t.Errorf("version %q", rec.version)
+	}
+	if rec.size != 250948 {
+		t.Errorf("size %d", rec.size)
+	}
+	if rec.sha256 != digest {
+		t.Errorf("digest mismatch")
+	}
+	if rec.url != url {
+		t.Errorf("url %q", rec.url)
+	}
+}
+
+func TestParseFwURLRecordRejects(t *testing.T) {
+	digest := testDigest()
+	good := buildRecord("pkg", "1.0.0", "https://example.test/a", 100, digest)
+
+	badMagic := append([]byte(nil), good...)
+	binary.LittleEndian.PutUint32(badMagic[0:4], 0xdeadbeef)
+
+	zeroSize := buildRecord("pkg", "1.0.0", "https://example.test/a", 0, digest)
+
+	// A URL longer than we will accept from any device, whatever it was built
+	// with. The length field says so; the bytes need not be present.
+	hugeURL := append([]byte(nil), good...)
+	binary.LittleEndian.PutUint16(hugeURL[42:44], uint16(fwURLMaxLen+1))
+
+	zeroURL := append([]byte(nil), good...)
+	binary.LittleEndian.PutUint16(zeroURL[42:44], 0)
+
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{"empty", nil},
+		{"short header", good[:20]},
+		{"bad magic", badMagic},
+		{"zero size", zeroSize},
+		{"truncated fields", good[:len(good)-3]},
+		{"url too long", hugeURL},
+		{"url absent", zeroURL},
+		{"plain http", buildRecord("pkg", "1.0.0", "http://example.test/a", 100, digest)},
+		{"not a url", buildRecord("pkg", "1.0.0", "://///", 100, digest)},
+		{"no host", buildRecord("pkg", "1.0.0", "https:///a", 100, digest)},
+		{"no package", buildRecord("", "1.0.0", "https://example.test/a", 100, digest)},
+		{"no version", buildRecord("pkg", "", "https://example.test/a", 100, digest)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseFwURLRecord(tc.raw); err == nil {
+				t.Fatal("accepted a record it should have refused")
+			}
+		})
+	}
+}
+
+func TestParseFwURLRecordRefusesPlainHTTP(t *testing.T) {
+	// Called out separately because it is the one rejection that is about
+	// safety rather than framing: the artifact and the signature that
+	// authorizes it would both travel in clear.
+	raw := buildRecord("pkg", "1.0.0", "http://gw.golioth.io/.u/c/pkg@1.0.0", 100, testDigest())
+
+	_, err := parseFwURLRecord(raw)
+	if err == nil {
+		t.Fatal("accepted a plain-HTTP artifact URL")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Errorf("error %q does not explain the scheme requirement", err)
+	}
+}
+
+func TestTimeRecord(t *testing.T) {
+	now := time.Unix(1757000000, 0)
+	b := timeRecord(now)
+
+	if len(b) != timeRecordLen {
+		t.Fatalf("time record is %d bytes, want %d", len(b), timeRecordLen)
+	}
+	if got := binary.LittleEndian.Uint32(b[0:4]); got != timeMagic {
+		t.Errorf("magic 0x%08x, want 0x%08x", got, timeMagic)
+	}
+	if got := binary.LittleEndian.Uint64(b[4:12]); got != 1757000000 {
+		t.Errorf("seconds %d, want 1757000000", got)
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/gateway/fwurl_test.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/fwurl_test.go
@@ -126,7 +126,14 @@ func TestTimeRecord(t *testing.T) {
 	if got := binary.LittleEndian.Uint32(b[0:4]); got != timeMagic {
 		t.Errorf("magic 0x%08x, want 0x%08x", got, timeMagic)
 	}
-	if got := binary.LittleEndian.Uint64(b[4:12]); got != 1757000000 {
-		t.Errorf("seconds %d, want 1757000000", got)
+
+	// Backdated, never ahead: the device stamps "not before now" onto a signed
+	// URL, and the server refuses a not-before in the future outright.
+	want := uint64(now.Add(-timeSkewMargin).Unix())
+	if got := binary.LittleEndian.Uint64(b[4:12]); got != want {
+		t.Errorf("seconds %d, want %d", got, want)
+	}
+	if got := binary.LittleEndian.Uint64(b[4:12]); got >= uint64(now.Unix()) {
+		t.Errorf("reported clock %d is not behind the real time %d", got, now.Unix())
 	}
 }

--- a/examples/linux/rpmsg_gateway/internal/gateway/session.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/session.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 
@@ -16,9 +17,12 @@ import (
 )
 
 // infoFlagDeviceProvisioned is set by the device once the cloud holds its
-// certificate. The remaining seven bits are unused - the natural place for a
-// future capability exchange.
+// certificate. The remaining bits are the capability exchange.
 const infoFlagDeviceProvisioned = 1 << 0
+
+// infoFlagFwSignedURL is set by a device built with the signed-URL handoff. It
+// is what tells us the time and URL channels exist on the other end.
+const infoFlagFwSignedURL = 1 << 1
 
 // deviceInfo is the CBOR map the device sends on the INFO channel.
 type deviceInfo struct {
@@ -48,10 +52,16 @@ type Gateway struct {
 
 	maxFrame int
 
+	// baseCtx outlives any one session, so a download started by one can
+	// finish after it. Set by New from the process context.
+	baseCtx context.Context
+
 	// Firmware carries MCU-mediated updates when set. relay persists across
-	// sessions because the image arrives a chunk at a time.
-	Firmware *FirmwareOptions
-	relay    fwRelay
+	// sessions because the image arrives a chunk at a time, and downloads
+	// because an artifact takes longer to fetch than a session lasts.
+	Firmware  *FirmwareOptions
+	relay     fwRelay
+	downloads fwDownloads
 
 	// serverCert is fetched once and reused across sessions.
 	certOnce sync.Once
@@ -70,11 +80,20 @@ type FirmwareOptions struct {
 	// ForceReject reports a hash failure for an image that actually verified.
 	// It exists to exercise the device's retry path on demand.
 	ForceReject bool
+
+	// SignedURL accepts a signed artifact URL from the device and fetches the
+	// image ourselves, rather than having it relayed through the device.
+	SignedURL bool
+	// Downloader fetches those artifacts. Required when SignedURL is set.
+	Downloader *Downloader
+	// ApplyFile installs an artifact already on disk. Leaving it nil verifies
+	// and discards, which is what a bring-up run wants.
+	ApplyFile func(pkg, version, path string) error
 }
 
 // New returns a gateway that brokers between link and cloud.
-func New(link Link, cloud Cloud, maxFrame int, log *slog.Logger) *Gateway {
-	return &Gateway{link: link, cloud: cloud, maxFrame: maxFrame, log: log}
+func New(ctx context.Context, link Link, cloud Cloud, maxFrame int, log *slog.Logger) *Gateway {
+	return &Gateway{baseCtx: ctx, link: link, cloud: cloud, maxFrame: maxFrame, log: log}
 }
 
 // serverCert fetches the chain to provision, and the serial number the device
@@ -134,11 +153,14 @@ func (g *Gateway) RunSession(ctx context.Context) error {
 		node.ServerCertProvisioned = len(certSNR) > 0 &&
 			string(info.ServerCertSNR) == string(certSNR)
 		node.DeviceCertProvisioned = info.Flags&infoFlagDeviceProvisioned != 0
+		node.SignedURLCapable = info.Flags&infoFlagFwSignedURL != 0 &&
+			g.Firmware != nil && g.Firmware.SignedURL
 
 		g.log.Info("device info",
 			"flags", info.Flags,
 			"server_cert_provisioned", node.ServerCertProvisioned,
-			"device_cert_provisioned", node.DeviceCertProvisioned)
+			"device_cert_provisioned", node.DeviceCertProvisioned,
+			"signed_url", node.SignedURLCapable)
 	}}
 
 	// SERVER_CERT: push the chain so the device can authenticate the cloud.
@@ -257,6 +279,35 @@ func (g *Gateway) RunSession(ctx context.Context) error {
 		}
 	}
 
+	if g.Firmware != nil && g.Firmware.SignedURL {
+		// The device has no clock of its own, and signs against a validity
+		// window, so it needs ours before it can sign anything.
+		ep.Time = &serial.BufSender{
+			Data: func() []byte { return timeRecord(time.Now()) },
+			Done: func(ok bool) {
+				if ok {
+					g.log.Debug("reported the time to the device")
+				}
+			},
+		}
+
+		ep.FwURL = &serial.BufReceiver{Done: func(data []byte, ok bool) {
+			// An empty transfer is the normal answer: no artifact pending.
+			if !ok || len(data) == 0 {
+				return
+			}
+			rec, err := parseFwURLRecord(data)
+			if err != nil {
+				g.log.Error("signed-URL handoff", "err", err)
+				return
+			}
+			// Started here and finished long after this session ends: an
+			// artifact takes minutes, and holding the session open would stall
+			// the uplink and downlink behind a file transfer.
+			g.startDownload(g.baseCtx, rec)
+		}}
+	}
+
 	broker = serial.NewBroker(ep, g.log,
 		func(ok bool) {
 			finished = true
@@ -268,6 +319,29 @@ func (g *Gateway) RunSession(ctx context.Context) error {
 	)
 
 	broker.Start()
+
+	// A download that finished between sessions is reported now. The device is
+	// waiting on this verdict: it told the cloud to stop offering the component
+	// when it handed the URL over, so nothing else will remind it.
+	if res := g.takeDownloadResult(); res != nil {
+		fwVerdict = res.verdict
+
+		if fwVerdict == FwStatusOK && g.Firmware.ForceReject {
+			g.log.Warn("artifact verified, reporting a hash failure anyway " +
+				"to exercise the device's retry path")
+			fwVerdict = FwStatusHashFail
+		}
+		if fwVerdict == FwStatusOK && g.Firmware.ApplyFile != nil {
+			if err := g.Firmware.ApplyFile(res.pkg, res.version, res.path); err != nil {
+				g.log.Error("apply artifact", "err", err)
+				fwVerdict = FwStatusError
+			}
+		}
+
+		g.log.Info("reporting the artifact verdict",
+			"package", res.pkg, "version", res.version, "verdict", fwVerdict)
+		broker.SendFwStatus()
+	}
 
 	// Pump: drain everything the broker wants to say, then block for a frame.
 	for !finished {

--- a/examples/linux/rpmsg_gateway/internal/gateway/session.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/session.go
@@ -301,6 +301,11 @@ func (g *Gateway) RunSession(ctx context.Context) error {
 				g.log.Error("signed-URL handoff", "err", err)
 				return
 			}
+			// Debug only: the URL carries a short-lived signature, and seeing
+			// the exact bytes the device produced is the only way to tell a
+			// refused signature from a malformed one.
+			g.log.Debug("signed artifact URL", "url", rec.url)
+
 			// Started here and finished long after this session ends: an
 			// artifact takes minutes, and holding the session open would stall
 			// the uplink and downlink behind a file transfer.

--- a/examples/linux/rpmsg_gateway/internal/gateway/session.go
+++ b/examples/linux/rpmsg_gateway/internal/gateway/session.go
@@ -42,6 +42,9 @@ type Cloud interface {
 	ServerCert(ctx context.Context) ([]byte, error)
 	RegisterDevice(ctx context.Context, cert []byte) error
 	Forward(ctx context.Context, uplink []byte) ([]byte, error)
+	// ClockOffset reports how far the server's clock runs ahead of ours, and
+	// whether one has been observed yet.
+	ClockOffset() (time.Duration, bool)
 }
 
 // Gateway brokers sessions for one device.
@@ -62,6 +65,10 @@ type Gateway struct {
 	Firmware  *FirmwareOptions
 	relay     fwRelay
 	downloads fwDownloads
+
+	// lastSkewLogged rate-limits the warning about a wrong local clock to
+	// once per whole second of drift, rather than once per session.
+	lastSkewLogged time.Duration
 
 	// serverCert is fetched once and reused across sessions.
 	certOnce sync.Once
@@ -281,9 +288,9 @@ func (g *Gateway) RunSession(ctx context.Context) error {
 
 	if g.Firmware != nil && g.Firmware.SignedURL {
 		// The device has no clock of its own, and signs against a validity
-		// window, so it needs ours before it can sign anything.
+		// window, so it needs one from us before it can sign anything.
 		ep.Time = &serial.BufSender{
-			Data: func() []byte { return timeRecord(time.Now()) },
+			Data: func() []byte { return timeRecord(g.serverNow()) },
 			Done: func(ok bool) {
 				if ok {
 					g.log.Debug("reported the time to the device")

--- a/examples/linux/rpmsg_gateway/internal/serial/broker.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/broker.go
@@ -13,6 +13,10 @@ type Node struct {
 	// DeviceCertProvisioned is true once the device reports that the cloud has
 	// its certificate, so the DEVICE_CERT step can be skipped.
 	DeviceCertProvisioned bool
+	// SignedURLCapable is true once the device says it can be handed firmware
+	// as a signed URL. Until it does we neither report the time nor poll for a
+	// URL, so a device without those channels is never left waiting on one.
+	SignedURLCapable bool
 }
 
 // Endpoints supplies the five channel implementations. Info, DeviceCert and
@@ -30,6 +34,12 @@ type Endpoints struct {
 	// gateway that does not apply firmware wants.
 	Fw       Receiver
 	FwStatus Sender
+
+	// Time and FwURL carry the signed-URL handoff: we report our clock, the
+	// device hands back a URL for us to fetch. Also optional, and additionally
+	// gated on the device advertising support.
+	Time  Sender
+	FwURL Receiver
 }
 
 // Broker drives one Pouch Serial session against a single device.
@@ -43,10 +53,13 @@ type Broker struct {
 	log      *slog.Logger
 
 	infoRead     bool
+	timeDone     bool
 	syncStarted  bool
 	uplinkDone   bool
 	downlinkDone bool
 	fwDone       bool
+	fwURLStarted bool
+	fwURLDone    bool
 
 	// fwStatusPending is set when a verdict is waiting to go out, and cleared
 	// once it has been delivered. The session does not end while it is set.
@@ -70,6 +83,8 @@ func NewBroker(ep Endpoints, log *slog.Logger, done func(bool), wake func()) *Br
 	b.channels[ChUplink] = channel{id: ChUplink, receiver: ep.Uplink}
 	b.channels[ChFwStatus] = channel{id: ChFwStatus, sender: ep.FwStatus}
 	b.channels[ChFw] = channel{id: ChFw, receiver: ep.Fw}
+	b.channels[ChTime] = channel{id: ChTime, sender: ep.Time}
+	b.channels[ChFwURL] = channel{id: ChFwURL, receiver: ep.FwURL}
 
 	for i := range b.channels {
 		b.channels[i].closed = b.channelClosed
@@ -83,10 +98,13 @@ func (b *Broker) Node() *Node { return &b.node }
 // Start begins a session.
 func (b *Broker) Start() {
 	b.infoRead = false
+	b.timeDone = b.channels[ChTime].sender == nil
 	b.syncStarted = false
 	b.uplinkDone = false
 	b.downlinkDone = false
 	b.fwDone = b.channels[ChFw].receiver == nil
+	b.fwURLStarted = false
+	b.fwURLDone = b.channels[ChFwURL].receiver == nil
 	b.fwStatusPending = false
 	b.next()
 }
@@ -98,6 +116,17 @@ func (b *Broker) next() {
 	case !b.infoRead:
 		b.infoRead = true
 		b.channels[ChInfo].ready()
+
+	// Before anything that depends on it. A device loaded by remoteproc has no
+	// clock of its own, and it signs artifact URLs against a validity window,
+	// so a URL signed before this arrives would be refused by the cloud.
+	case !b.timeDone:
+		b.timeDone = true
+		if !b.node.SignedURLCapable {
+			b.next()
+			return
+		}
+		b.channels[ChTime].ready()
 
 	case !b.node.ServerCertProvisioned:
 		b.channels[ChServerCert].ready()
@@ -117,11 +146,23 @@ func (b *Broker) next() {
 			b.channels[ChFw].ready()
 		}
 
+	// Collected after the downlink rather than alongside it: the manifest that
+	// makes the device announce an artifact arrives on that downlink, so asking
+	// first would usually find nothing and cost a session.
+	case b.downlinkDone && !b.fwURLDone && !b.fwURLStarted:
+		if !b.node.SignedURLCapable {
+			b.fwURLDone = true
+			b.next()
+			return
+		}
+		b.fwURLStarted = true
+		b.channels[ChFwURL].ready()
+
 	// A verdict became available after the firmware transfer closed.
 	case b.fwStatusPending && !b.channels[ChFwStatus].pending && !b.channels[ChFwStatus].open:
 		b.channels[ChFwStatus].ready()
 
-	case b.uplinkDone && b.downlinkDone && b.fwDone && !b.fwStatusPending:
+	case b.uplinkDone && b.downlinkDone && b.fwDone && b.fwURLDone && !b.fwStatusPending:
 		if b.done != nil {
 			b.done(true)
 		}
@@ -139,10 +180,13 @@ func (b *Broker) next() {
 func (b *Broker) channelClosed(ch Channel, success bool) {
 	if !success {
 		b.infoRead = false
+		b.timeDone = false
 		b.syncStarted = false
 		b.uplinkDone = false
 		b.downlinkDone = false
 		b.fwDone = false
+		b.fwURLStarted = false
+		b.fwURLDone = false
 		b.fwStatusPending = false
 		if b.done != nil {
 			b.done(false)
@@ -159,6 +203,8 @@ func (b *Broker) channelClosed(ch Channel, success bool) {
 		b.downlinkDone = true
 	case ChFw:
 		b.fwDone = true
+	case ChFwURL:
+		b.fwURLDone = true
 	case ChFwStatus:
 		b.fwStatusPending = false
 	}

--- a/examples/linux/rpmsg_gateway/internal/serial/exchange_test.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/exchange_test.go
@@ -211,3 +211,115 @@ func TestProvisionedDeviceSkipsCertPhases(t *testing.T) {
 		t.Errorf("device received %d server-cert bytes, want none", gotServerCert.Len())
 	}
 }
+
+// withSignedURL adds the two signed-URL channels to a device, so the exchange
+// covers a device that advertises the capability.
+func (d *device) withSignedURL(timeBuf *bytes.Buffer, urlRecord []byte) *device {
+	d.channels[ChTime] = channel{id: ChTime, receiver: &collector{buf: timeBuf}}
+	d.channels[ChFwURL] = channel{
+		id:     ChFwURL,
+		sender: &BufSender{Data: func() []byte { return urlRecord }},
+	}
+	return d
+}
+
+// signedURLEndpoints builds a provisioning-complete broker with the two
+// signed-URL channels attached. capable mirrors what the device advertised.
+func signedURLEndpoints(b **Broker, capable bool, collected *bytes.Buffer,
+	timePayload []byte) Endpoints {
+	return Endpoints{
+		Info: &BufReceiver{Done: func(d []byte, ok bool) {
+			(*b).Node().SignedURLCapable = capable
+		}},
+		ServerCert: &BufSender{Data: func() []byte { return []byte("server-certificate") },
+			Done: func(ok bool) { (*b).Node().ServerCertProvisioned = ok }},
+		DeviceCert: &BufReceiver{Done: func(d []byte, ok bool) {
+			(*b).Node().DeviceCertProvisioned = ok
+		}},
+		Downlink: &BufSender{Data: func() []byte { return []byte("downlink") }},
+		Uplink:   &BufReceiver{Done: func(d []byte, ok bool) {}},
+		Time:     &BufSender{Data: func() []byte { return timePayload }},
+		FwURL:    &BufReceiver{Done: func(d []byte, ok bool) { collected.Write(d) }},
+	}
+}
+
+func TestSignedURLExchange(t *testing.T) {
+	var serverCert, downlink, timeSeen, collected bytes.Buffer
+
+	record := []byte("a signed URL record")
+	dev := newDevice([]byte("info"), []byte("device-cert"), []byte("uplink"),
+		&serverCert, &downlink).withSignedURL(&timeSeen, record)
+
+	var b *Broker
+	var finished, sessionOK bool
+	b = NewBroker(signedURLEndpoints(&b, true, &collected, []byte("the time")),
+		discardLogger(),
+		func(ok bool) { finished, sessionOK = true, ok },
+		func() {})
+
+	b.Start()
+	pump(t, b, dev, 16)
+
+	if !finished || !sessionOK {
+		t.Fatalf("session finished=%v ok=%v, want both true", finished, sessionOK)
+	}
+	if got := timeSeen.String(); got != "the time" {
+		t.Errorf("device saw time %q, want %q", got, "the time")
+	}
+	if got := collected.String(); got != string(record) {
+		t.Errorf("broker collected %q, want %q", got, record)
+	}
+}
+
+func TestSignedURLSkippedWithoutCapability(t *testing.T) {
+	var serverCert, downlink, collected bytes.Buffer
+
+	// A device built without the handoff: the channel ids exist as wire
+	// constants but nothing is attached to them. A broker that pushed the time
+	// anyway would wait forever for an acknowledgement that never comes.
+	dev := newDevice([]byte("info"), []byte("device-cert"), []byte("uplink"),
+		&serverCert, &downlink)
+
+	var b *Broker
+	var finished, sessionOK bool
+	b = NewBroker(signedURLEndpoints(&b, false, &collected, []byte("the time")),
+		discardLogger(),
+		func(ok bool) { finished, sessionOK = true, ok },
+		func() {})
+
+	b.Start()
+	pump(t, b, dev, 16)
+
+	if !finished || !sessionOK {
+		t.Fatalf("session finished=%v ok=%v, want both true", finished, sessionOK)
+	}
+	if collected.Len() != 0 {
+		t.Errorf("collected %d bytes from a device without the channel", collected.Len())
+	}
+}
+
+func TestSignedURLEmptyHandoff(t *testing.T) {
+	var serverCert, downlink, timeSeen, collected bytes.Buffer
+
+	// The usual answer: no artifact pending, so the device hands back an empty
+	// transfer rather than a record, and the session still completes.
+	dev := newDevice([]byte("info"), []byte("device-cert"), []byte("uplink"),
+		&serverCert, &downlink).withSignedURL(&timeSeen, nil)
+
+	var b *Broker
+	var finished, sessionOK bool
+	b = NewBroker(signedURLEndpoints(&b, true, &collected, []byte("the time")),
+		discardLogger(),
+		func(ok bool) { finished, sessionOK = true, ok },
+		func() {})
+
+	b.Start()
+	pump(t, b, dev, 16)
+
+	if !finished || !sessionOK {
+		t.Fatalf("session finished=%v ok=%v, want both true", finished, sessionOK)
+	}
+	if collected.Len() != 0 {
+		t.Errorf("collected %d bytes from an idle device", collected.Len())
+	}
+}

--- a/examples/linux/rpmsg_gateway/internal/serial/packet.go
+++ b/examples/linux/rpmsg_gateway/internal/serial/packet.go
@@ -22,8 +22,10 @@ const (
 	ChUplink     Channel = 4 // device -> broker: outbound pouches
 	ChFwStatus   Channel = 5 // broker -> device: firmware apply verdict
 	ChFw         Channel = 6 // device -> broker: firmware image relay
+	ChTime       Channel = 7 // broker -> device: wall-clock time
+	ChFwURL      Channel = 8 // device -> broker: signed firmware artifact URL
 
-	ChannelCount Channel = 7
+	ChannelCount Channel = 9
 )
 
 // Direction is encoded in the parity of the channel id: odd ids run

--- a/examples/zephyr/rpmsg_device/CMakeLists.txt
+++ b/examples/zephyr/rpmsg_device/CMakeLists.txt
@@ -31,6 +31,11 @@ target_sources_ifdef(CONFIG_EXAMPLE_FW_SIGNED_URL app PRIVATE src/fw_signed_url.
 # unconditionally. Nothing here calls inet_pton(); the declaration only has to
 # parse. Drop this once Zephyr's arpa/inet.h stops depending on a type it does
 # not define, or once signy stops requiring Zephyr's POSIX clock.
-if(CONFIG_EXAMPLE_FW_SIGNED_URL AND NOT CONFIG_NETWORKING)
+#
+# Keyed on the headers being present rather than on this sample using signy:
+# enabling CONFIG_SIGNY is what puts them there, and that can outlive any one
+# of the options above - a build with the transport support compiled but the
+# sample's signed-URL path switched off still needs this.
+if(CONFIG_POSIX_SYSTEM_INTERFACES AND NOT CONFIG_NETWORKING)
   zephyr_compile_definitions(sa_family_t=net_sa_family_t)
 endif()

--- a/examples/zephyr/rpmsg_device/CMakeLists.txt
+++ b/examples/zephyr/rpmsg_device/CMakeLists.txt
@@ -30,7 +30,8 @@ target_sources_ifdef(CONFIG_EXAMPLE_FW_SIGNED_URL app PRIVATE src/fw_signed_url.
 # arpa/inet.h pulls in zephyr/net/net_ip.h, where net_sa_family_t is defined
 # unconditionally. Nothing here calls inet_pton(); the declaration only has to
 # parse. Drop this once Zephyr's arpa/inet.h stops depending on a type it does
-# not define, or once signy stops requiring Zephyr's POSIX clock.
+# not define, or once signy stops requiring Zephyr's POSIX clock - reported as
+# https://github.com/golioth/signy/issues/18.
 #
 # Keyed on the headers being present rather than on this sample using signy:
 # enabling CONFIG_SIGNY is what puts them there, and that can outlive any one

--- a/examples/zephyr/rpmsg_device/CMakeLists.txt
+++ b/examples/zephyr/rpmsg_device/CMakeLists.txt
@@ -12,6 +12,25 @@ target_sources(app PRIVATE
   src/credentials.c
 )
 
-if(CONFIG_POUCH_SERIAL_FW_RELAY)
-  target_sources(app PRIVATE src/fw_relay.c)
+if(CONFIG_EXAMPLE_FW_RELAY OR CONFIG_EXAMPLE_FW_SIGNED_URL)
+  target_sources(app PRIVATE src/fw_update.c)
+endif()
+
+target_sources_ifdef(CONFIG_EXAMPLE_FW_RELAY app PRIVATE src/fw_relay.c)
+target_sources_ifdef(CONFIG_EXAMPLE_FW_SIGNED_URL app PRIVATE src/fw_signed_url.c)
+
+# Signing needs a wall clock, so signy selects POSIX_TIMERS, which in Zephyr
+# 4.4 requires POSIX_SYSTEM_INTERFACES, which puts include/zephyr/posix on the
+# global include path. mbedTLS then finds <arpa/inet.h> through __has_include()
+# while looking for inet_pton(), and that header declares its functions with
+# sa_family_t - a type only defined when the networking stack is built. A device
+# that speaks Pouch over rpmsg has no IP stack, so x509_crt.c fails to compile.
+#
+# Aliasing the type to the one the networking headers actually define is enough:
+# arpa/inet.h pulls in zephyr/net/net_ip.h, where net_sa_family_t is defined
+# unconditionally. Nothing here calls inet_pton(); the declaration only has to
+# parse. Drop this once Zephyr's arpa/inet.h stops depending on a type it does
+# not define, or once signy stops requiring Zephyr's POSIX clock.
+if(CONFIG_EXAMPLE_FW_SIGNED_URL AND NOT CONFIG_NETWORKING)
+  zephyr_compile_definitions(sa_family_t=net_sa_family_t)
 endif()

--- a/examples/zephyr/rpmsg_device/Kconfig
+++ b/examples/zephyr/rpmsg_device/Kconfig
@@ -4,13 +4,45 @@
 
 mainmenu "Pouch rpmsg device example"
 
+config EXAMPLE_FW_RELAY
+    bool "Relay the firmware image through this core"
+    depends on POUCH_SERIAL_FW_RELAY
+    default y
+    help
+      Download this core's image through Pouch OTA and stream the plaintext to
+      the host over the firmware channel. Works against any host that collects
+      that channel, and is the fallback when a URL cannot be signed.
+
+config EXAMPLE_FW_SIGNED_URL
+    bool "Hand the host a signed URL for the firmware image"
+    depends on POUCH_SERIAL_FW_SIGNED_URL
+    depends on SIGNY
+    default y
+    help
+      Sign a URL for this core's own artifact and let the host fetch the image
+      itself, so no image byte crosses the link. Preferred over the relay where
+      both are available.
+
+      Requires signed URLs to be enabled for the Golioth project and the CA
+      that issued the device certificate to be uploaded to it. A device whose
+      certificate the cloud will not accept falls back to the relay.
+
+config EXAMPLE_SIGNED_URL_BASE
+    string "Base URL for OTA artifacts"
+    depends on EXAMPLE_FW_SIGNED_URL
+    default "https://gw.golioth.io/.u/c/"
+    help
+      The artifact URL is this base followed by "package@version". The manifest
+      does carry a URI field, but the SDK does not decode it today, so the URL
+      is composed here instead.
+
 config EXAMPLE_FW_COMPONENT
     string "OTA component to use for firmware update"
-    depends on POUCH_SERIAL_FW_RELAY
+    depends on EXAMPLE_FW_RELAY || EXAMPLE_FW_SIGNED_URL
     default "rpmsg_device"
     help
       Name of the component in the OTA manifest carrying this core's firmware.
-      The image is relayed to the host, which verifies and applies it through
-      remoteproc - this core has no flash of its own.
+      The host verifies and applies it through remoteproc - this core has no
+      flash of its own.
 
 source "Kconfig.zephyr"

--- a/examples/zephyr/rpmsg_device/README.md
+++ b/examples/zephyr/rpmsg_device/README.md
@@ -86,6 +86,52 @@ or `ble_gatt` examples for the filesystem-based provisioning pattern
 
 [pki]: https://docs.golioth.io/connectivity/credentials/
 
+## Firmware updates
+
+This core has no flash of its own - the host loads it through remoteproc at
+every boot - so it cannot apply an update itself. It is still the authenticated
+Pouch endpoint, so the cloud offers the update to it and it arranges for the
+host to install one. There are two ways to arrange that, and the sample builds
+both, preferring the first:
+
+**Signed URL** (`CONFIG_EXAMPLE_FW_SIGNED_URL`). This core signs a URL for its
+own artifact with the device key and hands the host that; the host fetches the
+image itself. No image byte crosses the link and nothing is buffered here. The
+signature is made with a key that never leaves this core, is valid for one
+artifact, and expires in about ninety seconds, so the host gains the ability to
+fetch that one file and nothing else. Signing needs a wall clock, which this
+core does not have - the host reports its own on the time channel, and being
+told the time is also how this core knows the host speaks the protocol at all.
+
+**Relay** (`CONFIG_EXAMPLE_FW_RELAY`). This core downloads its image through
+Pouch OTA and streams the plaintext out over the firmware channel, and the host
+verifies the SHA-256 from the manifest before installing. It works against any
+host that collects that channel, at the cost of an 8 KB buffer here and moving
+every byte twice. It is the fallback when a URL cannot be signed, and when a
+signed URL is refused - the sample retries an update three times and switches to
+the relay after a signed-URL attempt comes back rejected.
+
+Either way the host reports what it did on the apply verdict channel, which is
+the only notification this core gets: the cloud is told to stop offering the
+component as soon as the image is handed over, and the manifest that would
+otherwise re-offer it arrives once per connection.
+
+Signed URLs additionally require, on the cloud side:
+
+- The feature enabled for the project. It is off by default and available to
+  Teams and Enterprise organizations.
+- The CA that issued this device's certificate [uploaded to the project][pki],
+  since the certificate travels in the URL and the cloud verifies the signature
+  against it.
+
+> [!CAUTION]
+> The embedded placeholder credentials below are self-signed, so the cloud will
+> refuse any URL they sign and every update falls back to the relay. Signed-URL
+> updates need a real device certificate.
+
+The host side of both mechanisms is the gateway in
+[`examples/linux/rpmsg_gateway`](../../linux/rpmsg_gateway).
+
 ## Tuning notes
 
 The board config carries settings that were not obvious and are worth keeping if

--- a/examples/zephyr/rpmsg_device/boards/imx95_evk_mimx9596_m7.conf
+++ b/examples/zephyr/rpmsg_device/boards/imx95_evk_mimx9596_m7.conf
@@ -65,6 +65,18 @@ CONFIG_POUCH_SERIAL_FW_BUF_SIZE=32768
 CONFIG_GOLIOTH=y
 CONFIG_GOLIOTH_OTA=y
 
+# Preferred over the relay: this core signs a URL for its own artifact and the
+# host fetches the image, so no image byte crosses the link and none of it is
+# buffered here. The relay above stays enabled as the fallback for a host that
+# does not collect the URL channel, or a project without signed URLs.
+CONFIG_POUCH_SERIAL_FW_SIGNED_URL=y
+CONFIG_SIGNY=y
+
+# A real Golioth device certificate is around 385 bytes of DER, which base64
+# encodes to 514 characters plus a terminator - over signy's 512-byte default,
+# which makes signy_init() fail with -EINVAL before a single URL is signed.
+CONFIG_SIGNY_MAX_CERT_SIZE=1024
+
 # Keep the M7 console (LPUART3) for logs.
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/examples/zephyr/rpmsg_device/src/credentials.c
+++ b/examples/zephyr/rpmsg_device/src/credentials.c
@@ -28,7 +28,15 @@ static const uint8_t device_crt[] = {
 #include "device_crt.der.inc"
 };
 
-static psa_key_id_t import_raw_pk(const uint8_t *private_key, size_t size)
+/*
+ * A PSA key carries one permitted algorithm and one usage mask, so the same key
+ * material has to be imported once per purpose: deriving the Pouch session key,
+ * and - where signed-URL updates are built in - signing.
+ */
+static psa_key_id_t import_raw_pk(const uint8_t *private_key,
+                                  size_t size,
+                                  psa_algorithm_t alg,
+                                  psa_key_usage_t usage)
 {
     mbedtls_pk_context pk;
     mbedtls_pk_init(&pk);
@@ -43,9 +51,9 @@ static psa_key_id_t import_raw_pk(const uint8_t *private_key, size_t size)
 
     psa_key_attributes_t attrs = PSA_KEY_ATTRIBUTES_INIT;
 
-    psa_set_key_algorithm(&attrs, PSA_ALG_ECDH);
+    psa_set_key_algorithm(&attrs, alg);
     psa_set_key_type(&attrs, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
-    psa_set_key_usage_flags(&attrs, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_usage_flags(&attrs, usage);
 
     psa_key_id_t key_id;
     err = mbedtls_pk_import_into_psa(&pk, &attrs, &key_id);
@@ -61,8 +69,18 @@ static psa_key_id_t import_raw_pk(const uint8_t *private_key, size_t size)
 
 psa_key_id_t load_private_key(void)
 {
-    return import_raw_pk(device_key, sizeof(device_key));
+    return import_raw_pk(device_key, sizeof(device_key), PSA_ALG_ECDH, PSA_KEY_USAGE_DERIVE);
 }
+
+#if defined(CONFIG_EXAMPLE_FW_SIGNED_URL)
+psa_key_id_t load_signing_key(void)
+{
+    return import_raw_pk(device_key,
+                         sizeof(device_key),
+                         PSA_ALG_ECDSA(PSA_ALG_SHA_256),
+                         PSA_KEY_USAGE_SIGN_HASH);
+}
+#endif
 
 int load_certificate(struct pouch_cert *cert)
 {

--- a/examples/zephyr/rpmsg_device/src/credentials.h
+++ b/examples/zephyr/rpmsg_device/src/credentials.h
@@ -16,6 +16,19 @@
  */
 psa_key_id_t load_private_key(void);
 
+#if defined(CONFIG_EXAMPLE_FW_SIGNED_URL)
+/**
+ * Import the embedded device private key again, for signing.
+ *
+ * A PSA key permits one algorithm, and the key that derives the Pouch session
+ * key cannot also sign, so signed-URL updates need their own import of the same
+ * material.
+ *
+ * @return The assigned PSA key ID, or PSA_KEY_ID_NULL on failure.
+ */
+psa_key_id_t load_signing_key(void);
+#endif
+
 /**
  * Point @p cert at the embedded device certificate.
  *

--- a/examples/zephyr/rpmsg_device/src/fw_backend.h
+++ b/examples/zephyr/rpmsg_device/src/fw_backend.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <pouch/transport/serial/fw.h>
+
+/**
+ * An update the cloud has offered and this core has not finished acting on.
+ *
+ * The manifest's strings only live for the duration of the manifest handler,
+ * but an update the host rejects has to be restarted long after that, so the
+ * dispatcher keeps a copy and hands it to whichever backend is in use.
+ */
+struct fw_pending
+{
+    char version[POUCH_SERIAL_FW_MAX_NAME_LEN + 1];
+    uint8_t hash[32];
+    size_t size;
+};
+
+/*
+ * The two ways this core can be updated. Both end in the host restarting it
+ * with a new image; they differ in who moves the bytes.
+ */
+
+#if defined(CONFIG_EXAMPLE_FW_RELAY)
+/** Download the image through Pouch and stream the plaintext to the host. */
+int fw_relay_start(const struct fw_pending *pending);
+/** Abandon a relay in progress, so a later offer can start cleanly. */
+void fw_relay_abort(void);
+/** Feed the relay one block of the component, from the OTA callback. */
+void fw_relay_receive(const void *data, size_t offset, size_t len, bool is_last);
+#endif
+
+#if defined(CONFIG_EXAMPLE_FW_SIGNED_URL)
+/** True once a URL can actually be signed: credentials loaded, clock set. */
+bool fw_signed_url_ready(void);
+/** Hand the host a signed URL for the artifact and let it fetch the image. */
+int fw_signed_url_start(const struct fw_pending *pending);
+/** Withdraw a handoff that has not been collected yet. */
+void fw_signed_url_abort(void);
+#endif

--- a/examples/zephyr/rpmsg_device/src/fw_relay.c
+++ b/examples/zephyr/rpmsg_device/src/fw_relay.c
@@ -3,14 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * MCU-mediated firmware update.
- *
- * This core has no flash of its own - the host loads it through remoteproc at
- * every boot - so it cannot apply an update itself. It is still the
- * authenticated Pouch endpoint, so it downloads its own image through Pouch OTA
- * and streams the plaintext out to the host over the serial firmware channel.
- * The host verifies the SHA-256 from the manifest, installs the image next to
- * the previous one, and restarts this core.
+ * Relay backend: download the image through Pouch OTA and stream the plaintext
+ * out to the host over the serial firmware channel. The host verifies the
+ * SHA-256 from the manifest, installs the image next to the previous one, and
+ * restarts this core.
  *
  * Only a block-sized buffer of RAM is used: relaying blocks while the outgoing
  * buffer is full, which throttles the download to the speed of the link.
@@ -19,47 +15,23 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fw_relay, LOG_LEVEL_INF);
 
-#include <zephyr/init.h>
 #include <zephyr/kernel.h>
-
-#include <string.h>
 
 #include <golioth/ota.h>
 #include <pouch/transport/serial/fw.h>
 
-#include <app_version.h>
+#include "fw_backend.h"
 
 #define FW_COMPONENT CONFIG_EXAMPLE_FW_COMPONENT
 
-/* pouch_serial_fw_begin() rejects names longer than this. */
-#define FW_VERSION_MAX 32
-
-/* How many times to re-offer an image the host rejects before giving up. A
- * rejection is usually a corrupt transfer, which a retry fixes; a genuinely bad
- * image would otherwise retry every session forever.
- */
-#define FW_MAX_ATTEMPTS 3
-
 static bool relaying;
 
-/*
- * The image currently being relayed. The manifest's strings only live for the
- * duration of the manifest handler, but a rejected image has to be restarted
- * long after that, so keep a copy.
- */
-static struct
+int fw_relay_start(const struct fw_pending *pending)
 {
-    char version[FW_VERSION_MAX + 1];
-    uint8_t hash[32];
-    size_t size;
-    bool valid;
-    int attempts;
-} pending;
-
-static int relay_start(void)
-{
-    int err =
-        pouch_serial_fw_begin(FW_COMPONENT, pending.version, (uint32_t) pending.size, pending.hash);
+    int err = pouch_serial_fw_begin(FW_COMPONENT,
+                                    pending->version,
+                                    (uint32_t) pending->size,
+                                    pending->hash);
     if (err)
     {
         LOG_ERR("Failed to start firmware relay: %d", err);
@@ -71,10 +43,16 @@ static int relay_start(void)
     return 0;
 }
 
+void fw_relay_abort(void)
+{
+    pouch_serial_fw_abort();
+    relaying = false;
+}
+
 /* Runs on the downlink decrypt work queue. Blocking here is deliberate: it is
  * the backpressure that stops the cloud outrunning the serial link.
  */
-static void fw_receive(const void *data, size_t offset, size_t len, bool is_last)
+void fw_relay_receive(const void *data, size_t offset, size_t len, bool is_last)
 {
     if (!relaying)
     {
@@ -112,107 +90,3 @@ static void fw_receive(const void *data, size_t offset, size_t len, bool is_last
         golioth_ota_mark_updating(FW_COMPONENT);
     }
 }
-
-GOLIOTH_OTA_COMPONENT(fw, FW_COMPONENT, APP_VERSION_STRING, fw_receive);
-
-static void fw_manifest(const struct golioth_ota_manifest_component *components, size_t num)
-{
-    for (size_t i = 0; i < num; i++)
-    {
-        const struct golioth_ota_manifest_component *c = &components[i];
-
-        if (strcmp(c->name, FW_COMPONENT) != 0)
-        {
-            continue;
-        }
-
-        if (strcmp(c->target, APP_VERSION_STRING) == 0)
-        {
-            LOG_DBG("Already running %s", c->target);
-            continue;
-        }
-
-        LOG_INF("Update available: %s -> %s (%zu bytes)", c->current, c->target, c->size);
-
-        if (strlen(c->target) > FW_VERSION_MAX)
-        {
-            LOG_ERR("Target version %s is too long to relay", c->target);
-            continue;
-        }
-
-        strcpy(pending.version, c->target);
-        memcpy(pending.hash, c->target_hash, sizeof(pending.hash));
-        pending.size = c->size;
-        pending.attempts = 1;
-        pending.valid = true;
-
-        if (relay_start() != 0)
-        {
-            pending.valid = false;
-        }
-    }
-}
-
-GOLIOTH_OTA_MANIFEST_HANDLER(fw_manifest);
-
-/*
- * The host's verdict on an image we relayed.
- *
- * This is the only place a rejection can be acted on. By the time it arrives
- * the device has called golioth_ota_mark_updating(), which tells the cloud to
- * stop offering the component, and the OTA manifest that would otherwise
- * re-offer it is delivered once per connection - so a device that waits for
- * another manifest after a rejection never retries. Re-arming the download from
- * here is what makes a retry possible at all.
- */
-static void fw_apply_status(enum pouch_serial_fw_status status)
-{
-    if (status == POUCH_SERIAL_FW_STATUS_OK)
-    {
-        LOG_INF("Host installed %s; awaiting restart", pending.version);
-        pending.valid = false;
-        return;
-    }
-
-    LOG_WRN("Host rejected the image (status %d)", status);
-
-    if (!pending.valid)
-    {
-        return;
-    }
-
-    if (pending.attempts >= FW_MAX_ATTEMPTS)
-    {
-        LOG_ERR("Giving up on %s after %d attempts", pending.version, pending.attempts);
-        pending.valid = false;
-        relaying = false;
-        /* Leaving the component "updating" would stop the cloud sending any
-         * component at all, not just this one.
-         */
-        golioth_ota_mark_idle(FW_COMPONENT);
-        return;
-    }
-
-    /* Nothing is in flight after a verdict, but a relay abandoned mid-image
-     * would still be active - clear it either way so begin() can restart.
-     */
-    pouch_serial_fw_abort();
-    relaying = false;
-
-    pending.attempts++;
-    LOG_INF("Retrying %s (attempt %d/%d)", pending.version, pending.attempts, FW_MAX_ATTEMPTS);
-
-    if (relay_start() != 0)
-    {
-        pending.valid = false;
-        golioth_ota_mark_idle(FW_COMPONENT);
-    }
-}
-
-static int fw_relay_init(void)
-{
-    pouch_serial_fw_status_callback_set(fw_apply_status);
-    return 0;
-}
-
-SYS_INIT(fw_relay_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/examples/zephyr/rpmsg_device/src/fw_signed_url.c
+++ b/examples/zephyr/rpmsg_device/src/fw_signed_url.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Signed-URL backend: sign a URL for this core's own artifact and hand it to
+ * the host, which fetches the image itself. No image byte crosses the link and
+ * nothing is buffered here.
+ *
+ * The signature is what makes this safe to hand over: it is made with the
+ * device key, which never leaves this core, and it is valid only for one
+ * artifact and only for a short window. The host gains the ability to fetch
+ * that one file, and nothing else.
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(fw_signed_url, LOG_LEVEL_INF);
+
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+
+#include <stdio.h>
+#include <time.h>
+
+#include <golioth/ota.h>
+#include <pouch/transport/serial/fw_url.h>
+#include <signy/signy.h>
+
+#include "credentials.h"
+#include "fw_backend.h"
+
+#define FW_COMPONENT CONFIG_EXAMPLE_FW_COMPONENT
+
+/* Base plus "package@version": both names are bounded by the wire format. */
+#define URL_MAX (sizeof(CONFIG_EXAMPLE_SIGNED_URL_BASE) + 2 * POUCH_SERIAL_FW_MAX_NAME_LEN + 2)
+
+static bool signy_ready;
+
+bool fw_signed_url_ready(void)
+{
+    /* A signature carries the window it is valid for, so an unset clock
+     * produces one the cloud will refuse. The host reports its own time on the
+     * time channel, and only a host that implements this handoff does - so this
+     * is also the test for whether there is anyone to hand a URL to.
+     */
+    return signy_ready && pouch_serial_time_synced();
+}
+
+int fw_signed_url_start(const struct fw_pending *pending)
+{
+    char url[URL_MAX];
+
+    int n = snprintk(url,
+                     sizeof(url),
+                     "%s%s@%s",
+                     CONFIG_EXAMPLE_SIGNED_URL_BASE,
+                     FW_COMPONENT,
+                     pending->version);
+    if (n < 0 || n >= (int) sizeof(url))
+    {
+        LOG_ERR("Artifact URL does not fit");
+        return -ENOMEM;
+    }
+
+    int err = pouch_serial_fw_url_begin(FW_COMPONENT,
+                                        pending->version,
+                                        (uint32_t) pending->size,
+                                        pending->hash,
+                                        url);
+    if (err)
+    {
+        LOG_ERR("Failed to announce the artifact: %d", err);
+        return err;
+    }
+
+    LOG_INF("Announced %s for the host to fetch", url);
+
+    /* The image never comes through Pouch, so the component is not marked for
+     * download. It is marked updating: the cloud has to stop offering it while
+     * the host works, and the result comes back as an apply verdict.
+     */
+    golioth_ota_mark_updating(FW_COMPONENT);
+    return 0;
+}
+
+void fw_signed_url_abort(void)
+{
+    pouch_serial_fw_url_abort();
+}
+
+static void set_clock(int64_t unix_seconds)
+{
+    struct timespec ts = {
+        .tv_sec = (time_t) unix_seconds,
+        .tv_nsec = 0,
+    };
+
+    if (clock_settime(CLOCK_REALTIME, &ts) != 0)
+    {
+        LOG_ERR("Failed to set the clock from the host");
+        return;
+    }
+
+    LOG_DBG("Clock set from the host: %lld", (long long) unix_seconds);
+}
+
+static int fw_signed_url_init(void)
+{
+    struct pouch_cert cert;
+
+    pouch_serial_time_callback_set(set_clock);
+
+    psa_key_id_t key = load_signing_key();
+    if (key == PSA_KEY_ID_NULL)
+    {
+        LOG_ERR("No signing key; signed-URL updates are unavailable");
+        return 0;
+    }
+
+    if (load_certificate(&cert) != 0)
+    {
+        LOG_ERR("No device certificate; signed-URL updates are unavailable");
+        return 0;
+    }
+
+    int err = signy_init(key, cert.buffer, cert.size);
+    if (err != 0)
+    {
+        /* -EINVAL here is most often the encoded certificate overflowing
+         * CONFIG_SIGNY_MAX_CERT_SIZE, which the default does for a real
+         * Golioth device certificate.
+         */
+        LOG_ERR("Failed to initialize signy: %d", err);
+        return 0;
+    }
+
+    pouch_serial_fw_url_signer_set(signy_sign_url);
+    signy_ready = true;
+
+    LOG_INF("Signed-URL updates available once the host reports its time");
+    return 0;
+}
+
+SYS_INIT(fw_signed_url_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/examples/zephyr/rpmsg_device/src/fw_update.c
+++ b/examples/zephyr/rpmsg_device/src/fw_update.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Host-mediated firmware update.
+ *
+ * This core has no flash of its own - the host loads it through remoteproc at
+ * every boot - so it cannot apply an update itself. It is still the
+ * authenticated Pouch endpoint, so it is the one the cloud offers updates to,
+ * and it arranges for the host to install one.
+ *
+ * There are two ways to arrange that, and this file chooses between them per
+ * attempt. Handing the host a signed URL is preferred: the host fetches the
+ * image directly and no byte of it crosses the link. Relaying the image through
+ * this core works everywhere, and is the fallback when a URL cannot be signed
+ * or when the host would not accept one.
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(fw_update, LOG_LEVEL_INF);
+
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+
+#include <string.h>
+
+#include <golioth/ota.h>
+#include <pouch/transport/serial/fw.h>
+
+#include <app_version.h>
+
+#include "fw_backend.h"
+
+#define FW_COMPONENT CONFIG_EXAMPLE_FW_COMPONENT
+
+/*
+ * How many times to re-offer an image the host rejects before giving up. A
+ * rejection is usually a corrupt transfer, which a retry fixes; a genuinely bad
+ * image would otherwise retry every session forever.
+ */
+#define FW_MAX_ATTEMPTS 3
+
+enum fw_mode
+{
+    FW_MODE_NONE,
+    FW_MODE_SIGNED_URL,
+    FW_MODE_RELAY,
+};
+
+static struct
+{
+    struct fw_pending image;
+    enum fw_mode mode;
+    int attempts;
+    bool valid;
+    /* Set when a signed-URL attempt came back rejected. The next attempt falls
+     * back to the relay: the likely causes - signed URLs not enabled for the
+     * project, or a certificate authority the cloud does not know - are not
+     * things a second signature would fix.
+     */
+    bool url_rejected;
+} update;
+
+static enum fw_mode pick_mode(void)
+{
+#if defined(CONFIG_EXAMPLE_FW_SIGNED_URL)
+    if (!update.url_rejected && fw_signed_url_ready())
+    {
+        return FW_MODE_SIGNED_URL;
+    }
+#endif
+
+#if defined(CONFIG_EXAMPLE_FW_RELAY)
+    return FW_MODE_RELAY;
+#else
+    return FW_MODE_NONE;
+#endif
+}
+
+static int start_attempt(void)
+{
+    update.mode = pick_mode();
+
+    switch (update.mode)
+    {
+#if defined(CONFIG_EXAMPLE_FW_SIGNED_URL)
+        case FW_MODE_SIGNED_URL:
+            LOG_INF("Handing the host a signed URL for %s", update.image.version);
+            return fw_signed_url_start(&update.image);
+#endif
+#if defined(CONFIG_EXAMPLE_FW_RELAY)
+        case FW_MODE_RELAY:
+            LOG_INF("Relaying %s through this core", update.image.version);
+            return fw_relay_start(&update.image);
+#endif
+        default:
+            LOG_ERR("No way to deliver %s to the host", update.image.version);
+            return -ENOTSUP;
+    }
+}
+
+/* Stop whatever the current attempt left in flight. */
+static void abort_attempt(void)
+{
+    switch (update.mode)
+    {
+#if defined(CONFIG_EXAMPLE_FW_SIGNED_URL)
+        case FW_MODE_SIGNED_URL:
+            fw_signed_url_abort();
+            break;
+#endif
+#if defined(CONFIG_EXAMPLE_FW_RELAY)
+        case FW_MODE_RELAY:
+            fw_relay_abort();
+            break;
+#endif
+        default:
+            break;
+    }
+
+    update.mode = FW_MODE_NONE;
+}
+
+/* Runs on the downlink decrypt work queue. Only the relay ever sees data here:
+ * a signed-URL handoff never marks the component for download, so the cloud
+ * sends none.
+ */
+static void fw_receive(const void *data, size_t offset, size_t len, bool is_last)
+{
+#if defined(CONFIG_EXAMPLE_FW_RELAY)
+    fw_relay_receive(data, offset, len, is_last);
+#else
+    ARG_UNUSED(data);
+    ARG_UNUSED(offset);
+    ARG_UNUSED(len);
+    ARG_UNUSED(is_last);
+#endif
+}
+
+GOLIOTH_OTA_COMPONENT(fw, FW_COMPONENT, APP_VERSION_STRING, fw_receive);
+
+static void fw_manifest(const struct golioth_ota_manifest_component *components, size_t num)
+{
+    for (size_t i = 0; i < num; i++)
+    {
+        const struct golioth_ota_manifest_component *c = &components[i];
+
+        if (strcmp(c->name, FW_COMPONENT) != 0)
+        {
+            continue;
+        }
+
+        if (strcmp(c->target, APP_VERSION_STRING) == 0)
+        {
+            LOG_DBG("Already running %s", c->target);
+            continue;
+        }
+
+        LOG_INF("Update available: %s -> %s (%zu bytes)", c->current, c->target, c->size);
+
+        if (strlen(c->target) > POUCH_SERIAL_FW_MAX_NAME_LEN)
+        {
+            LOG_ERR("Target version %s is too long to deliver", c->target);
+            continue;
+        }
+
+        strcpy(update.image.version, c->target);
+        memcpy(update.image.hash, c->target_hash, sizeof(update.image.hash));
+        update.image.size = c->size;
+        update.attempts = 1;
+        update.url_rejected = false;
+        update.valid = true;
+
+        if (start_attempt() != 0)
+        {
+            update.valid = false;
+            update.mode = FW_MODE_NONE;
+        }
+    }
+}
+
+GOLIOTH_OTA_MANIFEST_HANDLER(fw_manifest);
+
+/*
+ * The host's verdict on an image we handed it.
+ *
+ * This is the only place a rejection can be acted on. By the time it arrives
+ * the device has called golioth_ota_mark_updating(), which tells the cloud to
+ * stop offering the component, and the OTA manifest that would otherwise
+ * re-offer it is delivered once per connection - so a device that waits for
+ * another manifest after a rejection never retries. Re-arming from here is what
+ * makes a retry possible at all.
+ */
+static void fw_apply_status(enum pouch_serial_fw_status status)
+{
+    if (status == POUCH_SERIAL_FW_STATUS_OK)
+    {
+        LOG_INF("Host installed %s; awaiting restart", update.image.version);
+        update.valid = false;
+        update.mode = FW_MODE_NONE;
+        return;
+    }
+
+    LOG_WRN("Host rejected the image (status %d)", status);
+
+    if (!update.valid)
+    {
+        return;
+    }
+
+    if (update.mode == FW_MODE_SIGNED_URL)
+    {
+        /* Not something a fresh signature would fix, so the retry - if there is
+         * one - goes through the relay instead.
+         */
+        LOG_WRN("Signed-URL delivery was refused; falling back to the relay");
+        update.url_rejected = true;
+    }
+
+    if (update.attempts >= FW_MAX_ATTEMPTS)
+    {
+        LOG_ERR("Giving up on %s after %d attempts", update.image.version, update.attempts);
+        abort_attempt();
+        update.valid = false;
+        /* Leaving the component "updating" would stop the cloud sending any
+         * component at all, not just this one.
+         */
+        golioth_ota_mark_idle(FW_COMPONENT);
+        return;
+    }
+
+    /* Nothing is in flight after a verdict, but an attempt abandoned mid-image
+     * would still be active - clear it either way so the next can start.
+     */
+    abort_attempt();
+
+    update.attempts++;
+    LOG_INF("Retrying %s (attempt %d/%d)", update.image.version, update.attempts, FW_MAX_ATTEMPTS);
+
+    if (start_attempt() != 0)
+    {
+        update.valid = false;
+        update.mode = FW_MODE_NONE;
+        golioth_ota_mark_idle(FW_COMPONENT);
+    }
+}
+
+static int fw_update_init(void)
+{
+    pouch_serial_fw_status_callback_set(fw_apply_status);
+    return 0;
+}
+
+SYS_INIT(fw_update_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/include/pouch/transport/serial/common.h
+++ b/include/pouch/transport/serial/common.h
@@ -17,6 +17,8 @@ enum pouch_serial_channel_id
     POUCH_SERIAL_CH_UPLINK,      /**< Device -> Broker: outbound pouches */
     POUCH_SERIAL_CH_FW_STATUS,   /**< Broker -> Device: firmware apply result */
     POUCH_SERIAL_CH_FW,          /**< Device -> Broker: firmware image relay */
+    POUCH_SERIAL_CH_TIME,        /**< Broker -> Device: wall-clock time */
+    POUCH_SERIAL_CH_FW_URL,      /**< Device -> Broker: signed firmware artifact URL */
 
     POUCH_SERIAL_CHANNEL_COUNT,
 };

--- a/include/pouch/transport/serial/fw.h
+++ b/include/pouch/transport/serial/fw.h
@@ -37,6 +37,14 @@
 /** Magic at the head of a firmware chunk: "PFW2", little endian. */
 #define POUCH_SERIAL_FW_MAGIC 0x32574650UL
 
+/*
+ * The verdict below - the status enum, pouch_serial_fw_status_get() and the
+ * callback - is not the relay's alone. It is reported by the host for any image
+ * it was handed, however it was handed over, so a device that uses the signed-URL
+ * handoff in <pouch/transport/serial/fw_url.h> and never relays a byte still
+ * reads its result here.
+ */
+
 /** Firmware apply result reported by the broker. */
 enum pouch_serial_fw_status
 {

--- a/include/pouch/transport/serial/fw.h
+++ b/include/pouch/transport/serial/fw.h
@@ -31,6 +31,14 @@
  * remaining bytes only arrive on the next session's downlink.
  */
 
+/**
+ * Longest package or version name a firmware record carries.
+ *
+ * The length fields on the wire are single bytes, and this matches the Golioth
+ * OTA defaults, so a longer name could not be described anyway.
+ */
+#define POUCH_SERIAL_FW_MAX_NAME_LEN 32
+
 /** Size of the fixed part of the firmware chunk header. */
 #define POUCH_SERIAL_FW_HDR_FIXED_LEN 46
 

--- a/include/pouch/transport/serial/fw_url.h
+++ b/include/pouch/transport/serial/fw_url.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <pouch/transport/serial/fw.h>
+
+/*
+ * Signed-URL firmware handoff.
+ *
+ * A core with no flash of its own can have the host apply an update for it, and
+ * the relay in <pouch/transport/serial/fw.h> does that by pulling the image
+ * through this core and pushing the plaintext back out. That costs a buffer, and
+ * it moves every byte twice over a link the host is already on.
+ *
+ * The alternative is to move the authority instead of the bytes. This core holds
+ * the device key, so it can sign a URL for its own artifact and hand that to the
+ * host; the host fetches the image directly and reports back on the shared
+ * verdict channel. Nothing is buffered here and no image byte crosses the link.
+ *
+ * The signature is produced by a signer the application installs, rather than by
+ * this module: signing means a key, and this library does not own the
+ * application's key material. The signature is also made late, when the host is
+ * already collecting the record, because a signed URL is valid for a short
+ * window and one signed at announcement time may expire before it is asked for.
+ */
+
+/** Magic at the head of a signed-URL record: "PFU1", little endian. */
+#define POUCH_SERIAL_FW_URL_MAGIC 0x31554650UL
+
+/** Size of the fixed part of a signed-URL record. */
+#define POUCH_SERIAL_FW_URL_HDR_FIXED_LEN 44
+
+/** Magic at the head of a time record: "PTM1", little endian. */
+#define POUCH_SERIAL_TIME_MAGIC 0x314D5450UL
+
+/** Size of a time record. */
+#define POUCH_SERIAL_TIME_LEN 12
+
+/**
+ * Sign a URL.
+ *
+ * Deliberately the shape of signy_sign_url(), so an application using that
+ * library can install it directly.
+ *
+ * @param url            The URL to sign.
+ * @param url_len        Length of @p url.
+ * @param signed_url     Buffer for the signed URL.
+ * @param signed_url_len Size of @p signed_url.
+ * @param olen           Set to the length written to @p signed_url.
+ *
+ * @return 0 on success, or a negative error code.
+ */
+typedef int (*pouch_serial_fw_url_sign_t)(const char *url,
+                                          size_t url_len,
+                                          char *signed_url,
+                                          size_t signed_url_len,
+                                          size_t *olen);
+
+/**
+ * Install the signer used for artifact URLs.
+ *
+ * Without one, an announced artifact is never handed over: the record is held
+ * and re-attempted, and the host simply sees nothing to collect.
+ *
+ * @param sign  Signer, or NULL to remove the current one.
+ */
+void pouch_serial_fw_url_signer_set(pouch_serial_fw_url_sign_t sign);
+
+/**
+ * Announce an artifact for the host to fetch.
+ *
+ * Call once, from the OTA manifest handler. @p url is the unsigned artifact
+ * URL; it is signed when the host collects it, not here.
+ *
+ * The image is never downloaded through Pouch, so do not mark the component for
+ * download. Mark it updating instead: the cloud has to stop offering it while
+ * the host works, and the result arrives as an apply verdict.
+ *
+ * @param package  Component/package name, at most 32 bytes.
+ * @param version  Target version string, at most 32 bytes.
+ * @param size     Artifact size in bytes.
+ * @param sha256   SHA-256 of the artifact, 32 bytes.
+ * @param url      Unsigned artifact URL.
+ *
+ * @return 0 on success, -EBUSY if a handoff is already pending, -EINVAL on bad input.
+ */
+int pouch_serial_fw_url_begin(const char *package,
+                              const char *version,
+                              uint32_t size,
+                              const uint8_t sha256[32],
+                              const char *url);
+
+/**
+ * Withdraw the pending handoff.
+ *
+ * Returns the module to idle so a later offer can start cleanly.
+ */
+void pouch_serial_fw_url_abort(void);
+
+/**
+ * Check whether an artifact is announced and not yet handed over.
+ */
+bool pouch_serial_fw_url_active(void);
+
+/**
+ * Called when the broker reports its wall-clock time.
+ *
+ * Invoked from the serial receive path with no lock held. A core loaded by
+ * remoteproc typically has no clock of its own, and a signed URL carries the
+ * window it is valid for, so the handler is where that clock gets set.
+ *
+ * @param unix_seconds  Seconds since the Unix epoch, UTC.
+ */
+typedef void (*pouch_serial_time_cb_t)(int64_t unix_seconds);
+
+/**
+ * Register a handler for the broker's wall-clock time.
+ *
+ * @param cb  Handler, or NULL to remove the current one.
+ */
+void pouch_serial_time_callback_set(pouch_serial_time_cb_t cb);
+
+/**
+ * Check whether the broker has reported its time since boot.
+ *
+ * Doubles as the test for whether the host speaks this protocol at all: only a
+ * broker that implements the signed-URL handoff pushes the time, so a device
+ * that has not been told the time has no host to hand a URL to.
+ */
+bool pouch_serial_time_synced(void);

--- a/port/zephyr/transport/serial/Kconfig
+++ b/port/zephyr/transport/serial/Kconfig
@@ -61,6 +61,41 @@ config POUCH_SERIAL_FW_BUF_SIZE
 
 endif # POUCH_SERIAL_FW_RELAY
 
+menuconfig POUCH_SERIAL_FW_SIGNED_URL
+    bool "Signed-URL firmware handoff"
+    depends on POUCH_TRANSPORT_SERIAL_DEVICE
+    select POUCH_SERIAL_FW_STATUS
+    help
+        Hand the broker a signed URL for this core's own firmware artifact and
+        let it fetch the image itself, for cores that remoteproc loads from the
+        host filesystem and so have no flash of their own. This core stays the
+        authenticated endpoint - it holds the key that signs the URL - but no
+        image byte crosses the link and nothing is buffered here, which is what
+        distinguishes this from POUCH_SERIAL_FW_RELAY. The two are independent;
+        a device may enable both and choose per update.
+
+        Off by default. The channel ids exist unconditionally so that every
+        build agrees on the wire format.
+
+        Requires a broker that pushes its wall-clock time and collects the URL
+        channel; the in-tree broker does neither. On the cloud side it requires
+        signed URLs to be enabled for the project, and the CA that issued the
+        device certificate to be uploaded to it.
+
+if POUCH_SERIAL_FW_SIGNED_URL
+
+config POUCH_SERIAL_FW_URL_MAX_LEN
+    int "Maximum signed URL length"
+    default 1024
+    help
+        Bytes reserved for the signed URL. A signed URL carries the validity
+        window, the device certificate and the signature on top of the artifact
+        location, so it is far longer than the URL that goes in: roughly 750
+        bytes for a 385-byte certificate. Must be at least as large as the
+        signer's own maximum, or a URL it produces will be refused as too long.
+
+endif # POUCH_SERIAL_FW_SIGNED_URL
+
 menuconfig POUCH_RPMSG_RSC_DEVICE
     bool "Pouch rpmsg device transport adapter (resource table)"
     depends on POUCH_TRANSPORT_SERIAL_DEVICE

--- a/port/zephyr/transport/serial/Kconfig
+++ b/port/zephyr/transport/serial/Kconfig
@@ -21,9 +21,18 @@ config POUCH_TRANSPORT_SERIAL_DEVICE
         runs on the node device and communicates with a gateway running the
         broker implementation.
 
+config POUCH_SERIAL_FW_STATUS
+    bool
+    depends on POUCH_TRANSPORT_SERIAL_DEVICE
+    help
+        The apply verdict channel: the host reports what became of an image it
+        was handed. Shared by every mechanism that hands one over, and selected
+        by each of them, so a device that enables two still carries one copy.
+
 menuconfig POUCH_SERIAL_FW_RELAY
     bool "MCU-mediated firmware relay"
     depends on POUCH_TRANSPORT_SERIAL_DEVICE
+    select POUCH_SERIAL_FW_STATUS
     help
         Relay this core's own firmware image to the broker over the Pouch
         Serial firmware channels, for cores that remoteproc loads from the

--- a/src/transport/CMakeLists.txt
+++ b/src/transport/CMakeLists.txt
@@ -11,6 +11,7 @@ pouch_config_enabled(_pouch_transport_serial CONFIG_POUCH_TRANSPORT_SERIAL)
 pouch_config_enabled(_pouch_transport_serial_broker CONFIG_POUCH_TRANSPORT_SERIAL_BROKER)
 pouch_config_enabled(_pouch_transport_serial_device CONFIG_POUCH_TRANSPORT_SERIAL_DEVICE)
 pouch_config_enabled(_pouch_serial_fw_relay CONFIG_POUCH_SERIAL_FW_RELAY)
+pouch_config_enabled(_pouch_serial_fw_status CONFIG_POUCH_SERIAL_FW_STATUS)
 
 # The device-side endpoints are only used by the transports that speak the
 # endpoint protocol: the GATT peripheral and the serial device. Builds without
@@ -109,6 +110,12 @@ if(_pouch_transport_serial)
         target_sources(${_pouch_target} PRIVATE
             serial/device.c
         )
+
+        if (_pouch_serial_fw_status)
+            target_sources(${_pouch_target} PRIVATE
+                ${_pouch_transport_root}/endpoints/device/fw_status.c
+            )
+        endif()
 
         if (_pouch_serial_fw_relay)
             target_sources(${_pouch_target} PRIVATE

--- a/src/transport/CMakeLists.txt
+++ b/src/transport/CMakeLists.txt
@@ -12,6 +12,7 @@ pouch_config_enabled(_pouch_transport_serial_broker CONFIG_POUCH_TRANSPORT_SERIA
 pouch_config_enabled(_pouch_transport_serial_device CONFIG_POUCH_TRANSPORT_SERIAL_DEVICE)
 pouch_config_enabled(_pouch_serial_fw_relay CONFIG_POUCH_SERIAL_FW_RELAY)
 pouch_config_enabled(_pouch_serial_fw_status CONFIG_POUCH_SERIAL_FW_STATUS)
+pouch_config_enabled(_pouch_serial_fw_signed_url CONFIG_POUCH_SERIAL_FW_SIGNED_URL)
 
 # The device-side endpoints are only used by the transports that speak the
 # endpoint protocol: the GATT peripheral and the serial device. Builds without
@@ -120,6 +121,12 @@ if(_pouch_transport_serial)
         if (_pouch_serial_fw_relay)
             target_sources(${_pouch_target} PRIVATE
                 ${_pouch_transport_root}/endpoints/device/fw.c
+            )
+        endif()
+
+        if (_pouch_serial_fw_signed_url)
+            target_sources(${_pouch_target} PRIVATE
+                ${_pouch_transport_root}/endpoints/device/fw_url.c
             )
         endif()
     endif()

--- a/src/transport/endpoints/device/endpoints.h
+++ b/src/transport/endpoints/device/endpoints.h
@@ -14,3 +14,5 @@ extern const struct pouch_endpoint pouch_device_endpoint_uplink;
 extern const struct pouch_endpoint pouch_device_endpoint_downlink;
 extern const struct pouch_endpoint pouch_device_endpoint_fw;
 extern const struct pouch_endpoint pouch_device_endpoint_fw_status;
+extern const struct pouch_endpoint pouch_device_endpoint_fw_url;
+extern const struct pouch_endpoint pouch_device_endpoint_time;

--- a/src/transport/endpoints/device/fw.c
+++ b/src/transport/endpoints/device/fw.c
@@ -12,6 +12,7 @@
 #include <pouch/types.h>
 
 #include "endpoints.h"
+#include "fw_internal.h"
 
 POUCH_LOG_REGISTER(pouch_fw_relay, CONFIG_POUCH_COMMON_LOG_LEVEL);
 
@@ -38,14 +39,12 @@ POUCH_LOG_REGISTER(pouch_fw_relay, CONFIG_POUCH_COMMON_LOG_LEVEL);
 #define CONFIG_POUCH_SERIAL_FW_BUF_SIZE 8192
 #endif
 
-#define MAX_NAME_LEN 32
-
 struct fw_relay
 {
     pouch_mutex_t lock;
     pouch_sem_t space; /* given when the drain frees buffer space */
 
-    uint8_t hdr[POUCH_SERIAL_FW_HDR_FIXED_LEN + 2 * MAX_NAME_LEN];
+    uint8_t hdr[POUCH_SERIAL_FW_HDR_FIXED_LEN + 2 * POUCH_SERIAL_FW_MAX_NAME_LEN];
     size_t hdr_len;
     size_t hdr_sent; /* bytes of the current chunk's header already sent */
 
@@ -60,14 +59,10 @@ struct fw_relay
 
     bool active;   /* a relay has been announced */
     bool complete; /* the application has written the last byte */
-
-    bool status_valid;
-    enum pouch_serial_fw_status status;
 };
 
 static struct fw_relay relay;
 static bool inited;
-static pouch_serial_fw_status_cb_t status_cb;
 
 static void relay_init_once(void)
 {
@@ -77,14 +72,6 @@ static void relay_init_once(void)
         pouch_sem_init(&relay.space, 0, 1);
         inited = true;
     }
-}
-
-static void put_le32(uint8_t *dst, uint32_t v)
-{
-    dst[0] = (uint8_t) (v & 0xff);
-    dst[1] = (uint8_t) ((v >> 8) & 0xff);
-    dst[2] = (uint8_t) ((v >> 16) & 0xff);
-    dst[3] = (uint8_t) ((v >> 24) & 0xff);
 }
 
 int pouch_serial_fw_begin(const char *package,
@@ -99,7 +86,7 @@ int pouch_serial_fw_begin(const char *package,
 
     size_t pkg_len = strlen(package);
     size_t ver_len = strlen(version);
-    if (pkg_len > MAX_NAME_LEN || ver_len > MAX_NAME_LEN)
+    if (pkg_len > POUCH_SERIAL_FW_MAX_NAME_LEN || ver_len > POUCH_SERIAL_FW_MAX_NAME_LEN)
     {
         return -EINVAL;
     }
@@ -115,9 +102,9 @@ int pouch_serial_fw_begin(const char *package,
 
     /* The offset field is rewritten per chunk in fw_send(). */
     uint8_t *h = relay.hdr;
-    put_le32(&h[0], POUCH_SERIAL_FW_MAGIC);
-    put_le32(&h[4], size);
-    put_le32(&h[8], 0);
+    pouch_serial_put_le32(&h[0], POUCH_SERIAL_FW_MAGIC);
+    pouch_serial_put_le32(&h[4], size);
+    pouch_serial_put_le32(&h[8], 0);
     memcpy(&h[12], sha256, 32);
     h[44] = (uint8_t) ver_len;
     h[45] = (uint8_t) pkg_len;
@@ -133,10 +120,12 @@ int pouch_serial_fw_begin(const char *package,
     relay.sent = 0;
     relay.chunk_open = false;
     relay.complete = false;
-    relay.status_valid = false;
     relay.active = true;
 
     pouch_mutex_unlock(&relay.lock);
+
+    /* Any verdict still held belongs to the previous image. */
+    pouch_serial_fw_status_reset();
 
     POUCH_LOG_INF("Firmware relay started: %s %s, %u bytes", package, version, size);
     return 0;
@@ -237,24 +226,6 @@ bool pouch_serial_fw_pressure(void)
     return full;
 }
 
-bool pouch_serial_fw_status_get(enum pouch_serial_fw_status *status)
-{
-    relay_init_once();
-    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
-    bool valid = relay.status_valid;
-    if (valid && status)
-    {
-        *status = relay.status;
-    }
-    pouch_mutex_unlock(&relay.lock);
-    return valid;
-}
-
-void pouch_serial_fw_status_callback_set(pouch_serial_fw_status_cb_t cb)
-{
-    status_cb = cb;
-}
-
 /* --- serial endpoint: firmware stream (device -> broker) --- */
 
 static int fw_start(struct pouch_bearer *bearer)
@@ -299,7 +270,7 @@ static enum pouch_result fw_send(struct pouch_bearer *bearer, void *dst, size_t 
     if (!relay.chunk_open)
     {
         /* Start a chunk: stamp it with the absolute offset it begins at. */
-        put_le32(&relay.hdr[8], relay.sent);
+        pouch_serial_put_le32(&relay.hdr[8], relay.sent);
         relay.hdr_sent = 0;
         relay.chunk_open = true;
     }
@@ -357,52 +328,4 @@ static enum pouch_result fw_send(struct pouch_bearer *bearer, void *dst, size_t 
 const struct pouch_endpoint pouch_device_endpoint_fw = {
     .start = fw_start,
     .send = fw_send,
-};
-
-/* --- serial endpoint: apply status (broker -> device) --- */
-
-static int fw_status_start(struct pouch_bearer *bearer)
-{
-    return 0;
-}
-
-static int fw_status_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
-{
-    const uint8_t *in = buf;
-
-    if (len == 0)
-    {
-        return 0;
-    }
-
-    if (in[0] > POUCH_SERIAL_FW_STATUS_ERROR)
-    {
-        POUCH_LOG_WRN("Unknown firmware apply status %u from broker", in[0]);
-        return -EINVAL;
-    }
-
-    enum pouch_serial_fw_status status = (enum pouch_serial_fw_status) in[0];
-
-    relay_init_once();
-    pouch_mutex_lock(&relay.lock, POUCH_FOREVER);
-    relay.status = status;
-    relay.status_valid = true;
-    pouch_mutex_unlock(&relay.lock);
-
-    POUCH_LOG_INF("Firmware apply status from broker: %u", in[0]);
-
-    /* Called with the lock released: the handler re-arms a rejected update,
-     * which comes straight back into pouch_serial_fw_begin().
-     */
-    if (status_cb)
-    {
-        status_cb(status);
-    }
-
-    return 0;
-}
-
-const struct pouch_endpoint pouch_device_endpoint_fw_status = {
-    .start = fw_status_start,
-    .recv = fw_status_recv,
 };

--- a/src/transport/endpoints/device/fw_internal.h
+++ b/src/transport/endpoints/device/fw_internal.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * Longest package or version name a firmware record carries.
+ *
+ * Matches the Golioth OTA defaults (GOLIOTH_OTA_MAX_PACKAGE_NAME_LEN and
+ * GOLIOTH_OTA_MAX_VERSION_LEN), and the length fields on the wire are single
+ * bytes, so a longer name could not be described anyway.
+ */
+#define POUCH_SERIAL_FW_MAX_NAME_LEN 32
+
+/** Write a 32-bit value to the wire, little endian. */
+static inline void pouch_serial_put_le32(uint8_t *dst, uint32_t v)
+{
+    dst[0] = (uint8_t) (v & 0xff);
+    dst[1] = (uint8_t) ((v >> 8) & 0xff);
+    dst[2] = (uint8_t) ((v >> 16) & 0xff);
+    dst[3] = (uint8_t) ((v >> 24) & 0xff);
+}
+
+/** Write a 16-bit value to the wire, little endian. */
+static inline void pouch_serial_put_le16(uint8_t *dst, uint16_t v)
+{
+    dst[0] = (uint8_t) (v & 0xff);
+    dst[1] = (uint8_t) ((v >> 8) & 0xff);
+}
+
+/**
+ * Discard any verdict held from an earlier image.
+ *
+ * Called when a new image is announced, so that pouch_serial_fw_status_get()
+ * keeps meaning "the verdict for the image announced most recently" whichever
+ * mechanism announced it.
+ */
+void pouch_serial_fw_status_reset(void);

--- a/src/transport/endpoints/device/fw_internal.h
+++ b/src/transport/endpoints/device/fw_internal.h
@@ -7,15 +7,6 @@
 
 #include <stdint.h>
 
-/**
- * Longest package or version name a firmware record carries.
- *
- * Matches the Golioth OTA defaults (GOLIOTH_OTA_MAX_PACKAGE_NAME_LEN and
- * GOLIOTH_OTA_MAX_VERSION_LEN), and the length fields on the wire are single
- * bytes, so a longer name could not be described anyway.
- */
-#define POUCH_SERIAL_FW_MAX_NAME_LEN 32
-
 /** Write a 32-bit value to the wire, little endian. */
 static inline void pouch_serial_put_le32(uint8_t *dst, uint32_t v)
 {

--- a/src/transport/endpoints/device/fw_status.c
+++ b/src/transport/endpoints/device/fw_status.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+
+#include <pouch/port.h>
+#include <pouch/transport/serial/fw.h>
+#include <pouch/types.h>
+
+#include "endpoints.h"
+#include "fw_internal.h"
+
+POUCH_LOG_REGISTER(pouch_fw_status, CONFIG_POUCH_COMMON_LOG_LEVEL);
+
+/*
+ * Device-side apply verdict.
+ *
+ * The host is the only party that knows what became of an image it was handed,
+ * and this is the channel it says so on. It is shared by every mechanism that
+ * hands an image over - the relay that streams the bytes through this core, and
+ * the signed URL that has the host fetch them itself - so it lives apart from
+ * either, and a device that enables only one of them still pays for only one.
+ */
+
+static struct
+{
+    pouch_mutex_t lock;
+    bool inited;
+    bool valid;
+    enum pouch_serial_fw_status status;
+} verdict;
+
+static pouch_serial_fw_status_cb_t status_cb;
+
+static void status_init_once(void)
+{
+    if (!verdict.inited)
+    {
+        pouch_mutex_init(&verdict.lock);
+        verdict.inited = true;
+    }
+}
+
+void pouch_serial_fw_status_reset(void)
+{
+    status_init_once();
+    pouch_mutex_lock(&verdict.lock, POUCH_FOREVER);
+    verdict.valid = false;
+    pouch_mutex_unlock(&verdict.lock);
+}
+
+bool pouch_serial_fw_status_get(enum pouch_serial_fw_status *status)
+{
+    status_init_once();
+    pouch_mutex_lock(&verdict.lock, POUCH_FOREVER);
+    bool valid = verdict.valid;
+    if (valid && status)
+    {
+        *status = verdict.status;
+    }
+    pouch_mutex_unlock(&verdict.lock);
+    return valid;
+}
+
+void pouch_serial_fw_status_callback_set(pouch_serial_fw_status_cb_t cb)
+{
+    status_cb = cb;
+}
+
+/* --- serial endpoint: apply status (broker -> device) --- */
+
+static int fw_status_start(struct pouch_bearer *bearer)
+{
+    status_init_once();
+    return 0;
+}
+
+static int fw_status_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    const uint8_t *in = buf;
+
+    if (len == 0)
+    {
+        return 0;
+    }
+
+    if (in[0] > POUCH_SERIAL_FW_STATUS_ERROR)
+    {
+        POUCH_LOG_WRN("Unknown firmware apply status %u from broker", in[0]);
+        return -EINVAL;
+    }
+
+    enum pouch_serial_fw_status status = (enum pouch_serial_fw_status) in[0];
+
+    status_init_once();
+    pouch_mutex_lock(&verdict.lock, POUCH_FOREVER);
+    verdict.status = status;
+    verdict.valid = true;
+    pouch_mutex_unlock(&verdict.lock);
+
+    POUCH_LOG_INF("Firmware apply status from broker: %u", in[0]);
+
+    /* Called with the lock released: the handler re-arms a rejected update,
+     * which comes straight back into the module that announced it.
+     */
+    if (status_cb)
+    {
+        status_cb(status);
+    }
+
+    return 0;
+}
+
+const struct pouch_endpoint pouch_device_endpoint_fw_status = {
+    .start = fw_status_start,
+    .recv = fw_status_recv,
+};

--- a/src/transport/endpoints/device/fw_url.c
+++ b/src/transport/endpoints/device/fw_url.c
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include <pouch/port.h>
+#include <pouch/transport/serial/fw_url.h>
+#include <pouch/types.h>
+
+#include "endpoints.h"
+#include "fw_internal.h"
+
+POUCH_LOG_REGISTER(pouch_fw_url, CONFIG_POUCH_COMMON_LOG_LEVEL);
+
+/*
+ * Device-side signed-URL handoff.
+ *
+ * The application announces an artifact; this module hands the host a record
+ * describing it, with a freshly signed URL the host can fetch it from. The
+ * record is small and fixed, so unlike the relay there is no ring buffer and no
+ * backpressure - the whole thing is built once and streamed out.
+ */
+
+#ifndef CONFIG_POUCH_SERIAL_FW_URL_MAX_LEN
+#define CONFIG_POUCH_SERIAL_FW_URL_MAX_LEN 1024
+#endif
+
+/*
+ * The unsigned URL is a base plus "package@version". Signing expands it by the
+ * timestamps, the encoded certificate and the signature, which is why the
+ * signed buffer is sized separately and much larger.
+ */
+#define UNSIGNED_URL_MAX 192
+
+#define REC_MAX                                                           \
+    (POUCH_SERIAL_FW_URL_HDR_FIXED_LEN + 2 * POUCH_SERIAL_FW_MAX_NAME_LEN \
+     + CONFIG_POUCH_SERIAL_FW_URL_MAX_LEN)
+
+struct fw_url
+{
+    pouch_mutex_t lock;
+
+    char url[UNSIGNED_URL_MAX]; /* unsigned, kept for re-signing */
+    uint8_t rec[REC_MAX];
+    size_t names_len; /* fixed header + version + package, set by begin() */
+    size_t rec_len;   /* whole record, set once signed */
+    size_t rec_sent;
+
+    bool active;    /* announced, not yet handed over */
+    bool signed_ok; /* rec holds a signed record for this transfer */
+};
+
+static struct fw_url handoff;
+static bool inited;
+static pouch_serial_fw_url_sign_t signer;
+
+static struct
+{
+    pouch_serial_time_cb_t cb;
+    uint8_t buf[POUCH_SERIAL_TIME_LEN];
+    size_t len;
+    bool synced;
+} wallclock;
+
+static void init_once(void)
+{
+    if (!inited)
+    {
+        pouch_mutex_init(&handoff.lock);
+        inited = true;
+    }
+}
+
+static uint32_t get_le32(const uint8_t *src)
+{
+    return (uint32_t) src[0] | ((uint32_t) src[1] << 8) | ((uint32_t) src[2] << 16)
+        | ((uint32_t) src[3] << 24);
+}
+
+void pouch_serial_fw_url_signer_set(pouch_serial_fw_url_sign_t sign)
+{
+    signer = sign;
+}
+
+int pouch_serial_fw_url_begin(const char *package,
+                              const char *version,
+                              uint32_t size,
+                              const uint8_t sha256[32],
+                              const char *url)
+{
+    if (!package || !version || !sha256 || !url || size == 0)
+    {
+        return -EINVAL;
+    }
+
+    size_t pkg_len = strlen(package);
+    size_t ver_len = strlen(version);
+    size_t url_len = strlen(url);
+
+    if (pkg_len == 0 || ver_len == 0 || url_len == 0)
+    {
+        return -EINVAL;
+    }
+
+    if (pkg_len > POUCH_SERIAL_FW_MAX_NAME_LEN || ver_len > POUCH_SERIAL_FW_MAX_NAME_LEN
+        || url_len >= sizeof(handoff.url))
+    {
+        return -EINVAL;
+    }
+
+    init_once();
+    pouch_mutex_lock(&handoff.lock, POUCH_FOREVER);
+
+    if (handoff.active)
+    {
+        pouch_mutex_unlock(&handoff.lock);
+        return -EBUSY;
+    }
+
+    /* The URL length is only known once signed, so it is filled in then. */
+    uint8_t *h = handoff.rec;
+    pouch_serial_put_le32(&h[0], POUCH_SERIAL_FW_URL_MAGIC);
+    pouch_serial_put_le32(&h[4], size);
+    memcpy(&h[8], sha256, 32);
+    h[40] = (uint8_t) ver_len;
+    h[41] = (uint8_t) pkg_len;
+    pouch_serial_put_le16(&h[42], 0);
+    memcpy(&h[POUCH_SERIAL_FW_URL_HDR_FIXED_LEN], version, ver_len);
+    memcpy(&h[POUCH_SERIAL_FW_URL_HDR_FIXED_LEN + ver_len], package, pkg_len);
+
+    handoff.names_len = POUCH_SERIAL_FW_URL_HDR_FIXED_LEN + ver_len + pkg_len;
+    memcpy(handoff.url, url, url_len + 1);
+
+    handoff.rec_len = 0;
+    handoff.rec_sent = 0;
+    handoff.signed_ok = false;
+    handoff.active = true;
+
+    pouch_mutex_unlock(&handoff.lock);
+
+    /* Any verdict still held belongs to the previous image. */
+    pouch_serial_fw_status_reset();
+
+    POUCH_LOG_INF("Firmware handoff announced: %s %s, %u bytes", package, version, size);
+    return 0;
+}
+
+void pouch_serial_fw_url_abort(void)
+{
+    init_once();
+    pouch_mutex_lock(&handoff.lock, POUCH_FOREVER);
+    handoff.active = false;
+    handoff.signed_ok = false;
+    handoff.rec_len = 0;
+    handoff.rec_sent = 0;
+    pouch_mutex_unlock(&handoff.lock);
+    POUCH_LOG_WRN("Firmware handoff withdrawn");
+}
+
+bool pouch_serial_fw_url_active(void)
+{
+    init_once();
+    pouch_mutex_lock(&handoff.lock, POUCH_FOREVER);
+    bool active = handoff.active;
+    pouch_mutex_unlock(&handoff.lock);
+    return active;
+}
+
+/*
+ * Sign the pending URL into the record. Called with the lock held.
+ *
+ * Signing happens here rather than in begin() because a signed URL is valid for
+ * a short window: one signed when the manifest arrived may well have expired by
+ * the time the host asks for it, and the host may not ask for several sessions.
+ */
+static bool sign_pending(void)
+{
+    if (!signer)
+    {
+        POUCH_LOG_WRN("No URL signer installed, cannot hand off firmware");
+        return false;
+    }
+
+    char *dst = (char *) &handoff.rec[handoff.names_len];
+    size_t cap = sizeof(handoff.rec) - handoff.names_len;
+    size_t olen = 0;
+
+    int err = signer(handoff.url, strlen(handoff.url), dst, cap, &olen);
+    if (err != 0)
+    {
+        POUCH_LOG_WRN("Failed to sign artifact URL: %d", err);
+        return false;
+    }
+
+    if (olen == 0 || olen > CONFIG_POUCH_SERIAL_FW_URL_MAX_LEN || olen > cap)
+    {
+        POUCH_LOG_WRN("Signed URL does not fit the record: %zu bytes", olen);
+        return false;
+    }
+
+    pouch_serial_put_le16(&handoff.rec[42], (uint16_t) olen);
+    handoff.rec_len = handoff.names_len + olen;
+    handoff.rec_sent = 0;
+    handoff.signed_ok = true;
+    return true;
+}
+
+/* --- serial endpoint: signed artifact URL (device -> broker) --- */
+
+static int fw_url_start(struct pouch_bearer *bearer)
+{
+    init_once();
+    pouch_mutex_lock(&handoff.lock, POUCH_FOREVER);
+
+    if (handoff.active && !handoff.signed_ok)
+    {
+        /* A failure here is not an error the session should carry: the host is
+         * simply told there is nothing to collect, and the record stays pending
+         * so the next poll signs it again. Returning an error would fail the
+         * whole session over a clock that is not set yet.
+         */
+        (void) sign_pending();
+    }
+
+    pouch_mutex_unlock(&handoff.lock);
+    return 0;
+}
+
+static enum pouch_result fw_url_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    uint8_t *out = dst;
+    size_t cap = *dst_len;
+    size_t produced = 0;
+
+    init_once();
+    pouch_mutex_lock(&handoff.lock, POUCH_FOREVER);
+
+    /* Nothing announced, or nothing signable yet: an empty transfer says so,
+     * and costs the host two frames.
+     */
+    if (!handoff.active || !handoff.signed_ok)
+    {
+        pouch_mutex_unlock(&handoff.lock);
+        *dst_len = 0;
+        return POUCH_NO_MORE_DATA;
+    }
+
+    while (produced < cap && handoff.rec_sent < handoff.rec_len)
+    {
+        out[produced++] = handoff.rec[handoff.rec_sent++];
+    }
+
+    bool done = handoff.rec_sent >= handoff.rec_len;
+    if (done)
+    {
+        /* Handed over. The host owns the fetch from here, and reports back on
+         * the verdict channel.
+         */
+        handoff.active = false;
+        handoff.signed_ok = false;
+    }
+
+    pouch_mutex_unlock(&handoff.lock);
+
+    *dst_len = produced;
+
+    if (done)
+    {
+        POUCH_LOG_INF("Signed artifact URL handed to the host");
+        return POUCH_NO_MORE_DATA;
+    }
+
+    return POUCH_MORE_DATA;
+}
+
+const struct pouch_endpoint pouch_device_endpoint_fw_url = {
+    .start = fw_url_start,
+    .send = fw_url_send,
+};
+
+/* --- serial endpoint: wall-clock time (broker -> device) --- */
+
+void pouch_serial_time_callback_set(pouch_serial_time_cb_t cb)
+{
+    wallclock.cb = cb;
+}
+
+bool pouch_serial_time_synced(void)
+{
+    return wallclock.synced;
+}
+
+static int time_start(struct pouch_bearer *bearer)
+{
+    wallclock.len = 0;
+    return 0;
+}
+
+static int time_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    /* Anything longer than a time record is not one; keep what fits and let the
+     * length check in time_end() reject it.
+     */
+    size_t space = sizeof(wallclock.buf) - wallclock.len;
+    size_t n = len < space ? len : space;
+
+    memcpy(&wallclock.buf[wallclock.len], buf, n);
+    wallclock.len += n;
+
+    return 0;
+}
+
+static void time_end(struct pouch_bearer *bearer, bool success)
+{
+    if (!success || wallclock.len != POUCH_SERIAL_TIME_LEN)
+    {
+        POUCH_LOG_DBG("Ignoring malformed time record (%zu bytes)", wallclock.len);
+        return;
+    }
+
+    if (get_le32(&wallclock.buf[0]) != POUCH_SERIAL_TIME_MAGIC)
+    {
+        POUCH_LOG_WRN("Ignoring time record with bad magic");
+        return;
+    }
+
+    int64_t seconds = 0;
+    for (int i = 7; i >= 0; i--)
+    {
+        seconds = (seconds << 8) | wallclock.buf[4 + i];
+    }
+
+    wallclock.synced = true;
+
+    POUCH_LOG_INF("Broker reported time: %lld", (long long) seconds);
+
+    if (wallclock.cb)
+    {
+        wallclock.cb(seconds);
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_time = {
+    .start = time_start,
+    .end = time_end,
+    .recv = time_recv,
+};

--- a/src/transport/endpoints/device/info.c
+++ b/src/transport/endpoints/device/info.c
@@ -16,6 +16,11 @@
 enum info_flags
 {
     INFO_FLAG_PROVISIONED = (1 << 0),
+    /* Tells the broker this device can be handed firmware as a signed URL, so
+     * that a broker which supports it knows to push the time and collect the
+     * URL channel, and one which does not is unaffected.
+     */
+    INFO_FLAG_FW_SIGNED_URL = (1 << 1),
 };
 
 static struct
@@ -42,6 +47,10 @@ static int build_info_data(void)
     // TODO: Set the Provisioned flag once we have the functionality to know whether provisioning
     // has taken place.
     enum info_flags flags = 0;
+
+#if defined(CONFIG_POUCH_SERIAL_FW_SIGNED_URL)
+    flags |= INFO_FLAG_FW_SIGNED_URL;
+#endif
 
     struct pouch_gatt_info cbor = {
         .pouch_gatt_info_flags = flags,

--- a/src/transport/serial/device.c
+++ b/src/transport/serial/device.c
@@ -21,8 +21,10 @@ static struct pouch_serial serial = {
             [POUCH_SERIAL_CH_DEVICE_CERT] = CHANNEL(&pouch_device_endpoint_device_cert),
             [POUCH_SERIAL_CH_DOWNLINK] = CHANNEL(&pouch_device_endpoint_downlink),
             [POUCH_SERIAL_CH_UPLINK] = CHANNEL(&pouch_device_endpoint_uplink),
-#if defined(CONFIG_POUCH_SERIAL_FW_RELAY)
+#if defined(CONFIG_POUCH_SERIAL_FW_STATUS)
             [POUCH_SERIAL_CH_FW_STATUS] = CHANNEL(&pouch_device_endpoint_fw_status),
+#endif
+#if defined(CONFIG_POUCH_SERIAL_FW_RELAY)
             [POUCH_SERIAL_CH_FW] = CHANNEL(&pouch_device_endpoint_fw),
 #endif
         },

--- a/src/transport/serial/device.c
+++ b/src/transport/serial/device.c
@@ -27,6 +27,10 @@ static struct pouch_serial serial = {
 #if defined(CONFIG_POUCH_SERIAL_FW_RELAY)
             [POUCH_SERIAL_CH_FW] = CHANNEL(&pouch_device_endpoint_fw),
 #endif
+#if defined(CONFIG_POUCH_SERIAL_FW_SIGNED_URL)
+            [POUCH_SERIAL_CH_TIME] = CHANNEL(&pouch_device_endpoint_time),
+            [POUCH_SERIAL_CH_FW_URL] = CHANNEL(&pouch_device_endpoint_fw_url),
+#endif
         },
 };
 

--- a/tests/pouch/rpmsg/exchange/CMakeLists.txt
+++ b/tests/pouch/rpmsg/exchange/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 # The device channel table only carries the firmware channels when the relay
 # is enabled, and these suites stub those endpoints, so enable it here.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_STATUS=1)
 
 # Serial transport core + the UART framing under test, plus the shared stub
 # endpoints from the serial exchange test.

--- a/tests/pouch/rpmsg/exchange/CMakeLists.txt
+++ b/tests/pouch/rpmsg/exchange/CMakeLists.txt
@@ -30,6 +30,7 @@ target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 # is enabled, and these suites stub those endpoints, so enable it here.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_STATUS=1)
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_SIGNED_URL=1)
 
 # Serial transport core + the UART framing under test, plus the shared stub
 # endpoints from the serial exchange test.

--- a/tests/pouch/serial/broker/src/test_broker.c
+++ b/tests/pouch/serial/broker/src/test_broker.c
@@ -1184,6 +1184,25 @@ ZTEST(serial_broker, test_unconfigured_channel_is_ignored)
     len = build_frame(buf, sizeof(buf), &data, payload, sizeof(payload));
     zassert_equal(pouch_serial_broker_recv(test_broker, buf, len), -ENODEV);
 
+    /* The signed-URL channels are unconfigured here too: the in-tree broker
+     * neither reports its clock nor collects a URL. A device that has them
+     * enabled must not be able to disturb a broker that has not.
+     */
+    struct pouch_serial_header url_ack = {
+        .is_data = false,
+        .channel = POUCH_SERIAL_CH_FW_URL,
+    };
+    len = build_frame(buf, sizeof(buf), &url_ack, NULL, 0);
+    zassert_equal(pouch_serial_broker_recv(test_broker, buf, len), -ENODEV);
+
+    struct pouch_serial_header time_data = {
+        .is_data = true,
+        .first = true,
+        .channel = POUCH_SERIAL_CH_TIME,
+    };
+    len = build_frame(buf, sizeof(buf), &time_data, payload, sizeof(payload));
+    zassert_equal(pouch_serial_broker_recv(test_broker, buf, len), -ENODEV);
+
     /* Those frames left no response queued, and the broker still runs a normal
      * session afterwards. */
     zassert_equal(pouch_serial_broker_frame_get(test_broker, buf, sizeof(buf)),

--- a/tests/pouch/serial/device/CMakeLists.txt
+++ b/tests/pouch/serial/device/CMakeLists.txt
@@ -23,6 +23,7 @@ target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 # The device channel table only carries the firmware channels when the relay
 # is enabled, and these suites stub those endpoints, so enable it here.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_STATUS=1)
 
 # Serial transport sources (device side only, no broker)
 target_sources(app PRIVATE

--- a/tests/pouch/serial/device/CMakeLists.txt
+++ b/tests/pouch/serial/device/CMakeLists.txt
@@ -24,6 +24,7 @@ target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 # is enabled, and these suites stub those endpoints, so enable it here.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_STATUS=1)
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_SIGNED_URL=1)
 
 # Serial transport sources (device side only, no broker)
 target_sources(app PRIVATE

--- a/tests/pouch/serial/device/src/stub_endpoints.c
+++ b/tests/pouch/serial/device/src/stub_endpoints.c
@@ -305,3 +305,65 @@ const struct pouch_endpoint pouch_device_endpoint_fw = {
     .start = d_fw_start,
     .send = d_fw_send,
 };
+
+/* TIME: device receives the broker's wall clock (receiver) */
+
+static int d_time_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    device_stubs.time.rx_len = 0;
+    device_stubs.time.start_count++;
+    return device_stubs.time.start_err;
+}
+
+static int d_time_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    if (device_stubs.time.recv_err != 0)
+    {
+        return device_stubs.time.recv_err;
+    }
+    receiver_push(&device_stubs.time, buf, len);
+    return 0;
+}
+
+static void d_time_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.time.end_success_count++;
+    }
+    else
+    {
+        device_stubs.time.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_time = {
+    .start = d_time_start,
+    .recv = d_time_recv,
+    .end = d_time_end,
+};
+
+/* FW_URL: device hands the broker a signed artifact URL (sender) */
+
+static int d_fw_url_start(struct pouch_bearer *bearer)
+{
+    device_stubs.fw_url.bearer = bearer;
+    device_stubs.fw_url.tx_offset = 0;
+    device_stubs.fw_url.start_count++;
+    return device_stubs.fw_url.start_err;
+}
+
+static enum pouch_result d_fw_url_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.fw_url, dst, dst_len);
+}
+
+/* No end() callback, matching the real pouch_device_endpoint_fw_url. */
+const struct pouch_endpoint pouch_device_endpoint_fw_url = {
+    .start = d_fw_url_start,
+    .send = d_fw_url_send,
+};

--- a/tests/pouch/serial/device/src/stub_endpoints.h
+++ b/tests/pouch/serial/device/src/stub_endpoints.h
@@ -62,6 +62,8 @@ struct device_stubs
     struct stub_sender uplink;
     struct stub_receiver fw_status;
     struct stub_sender fw;
+    struct stub_receiver time;
+    struct stub_sender fw_url;
 };
 
 extern struct device_stubs device_stubs;

--- a/tests/pouch/serial/device/src/test_device.c
+++ b/tests/pouch/serial/device/src/test_device.c
@@ -214,6 +214,8 @@ static void reset_stubs(void)
     stub_sender_reset(&device_stubs.uplink);
     stub_receiver_reset(&device_stubs.fw_status);
     stub_sender_reset(&device_stubs.fw);
+    stub_receiver_reset(&device_stubs.time);
+    stub_sender_reset(&device_stubs.fw_url);
 }
 
 /* ---- Test fixture -------------------------------------------------------- */

--- a/tests/pouch/serial/exchange/CMakeLists.txt
+++ b/tests/pouch/serial/exchange/CMakeLists.txt
@@ -28,6 +28,7 @@ target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 # The device channel table only carries the firmware channels when the relay
 # is enabled, and these suites stub those endpoints, so enable it here.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_STATUS=1)
 
 # Serial transport sources (both broker and device)
 target_sources(app PRIVATE

--- a/tests/pouch/serial/exchange/CMakeLists.txt
+++ b/tests/pouch/serial/exchange/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_LOG_LEVEL=3)
 # is enabled, and these suites stub those endpoints, so enable it here.
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_RELAY=1)
 target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_STATUS=1)
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_SIGNED_URL=1)
 
 # Serial transport sources (both broker and device)
 target_sources(app PRIVATE

--- a/tests/pouch/serial/exchange/src/stub_endpoints.c
+++ b/tests/pouch/serial/exchange/src/stub_endpoints.c
@@ -44,7 +44,9 @@ void stubs_reset(void)
     receiver_reset(&device_stubs.downlink);
     sender_reset(&device_stubs.uplink);
     receiver_reset(&device_stubs.fw_status);
+    receiver_reset(&device_stubs.time);
     sender_reset(&device_stubs.fw);
+    sender_reset(&device_stubs.fw_url);
 
     receiver_reset(&broker_stubs.info);
     sender_reset(&broker_stubs.server_cert);
@@ -495,4 +497,57 @@ static enum pouch_result d_fw_send(struct pouch_bearer *bearer, void *dst, size_
 const struct pouch_endpoint pouch_device_endpoint_fw = {
     .start = d_fw_start,
     .send = d_fw_send,
+};
+
+/* TIME: device receives the broker's wall clock (receiver) */
+
+static int d_time_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return receiver_start_helper(&device_stubs.time);
+}
+
+static int d_time_recv(struct pouch_bearer *bearer, const void *buf, size_t len)
+{
+    (void) bearer;
+    return receiver_push(&device_stubs.time, buf, len);
+}
+
+static void d_time_end(struct pouch_bearer *bearer, bool success)
+{
+    (void) bearer;
+    if (success)
+    {
+        device_stubs.time.end_success_count++;
+    }
+    else
+    {
+        device_stubs.time.end_fail_count++;
+    }
+}
+
+const struct pouch_endpoint pouch_device_endpoint_time = {
+    .start = d_time_start,
+    .recv = d_time_recv,
+    .end = d_time_end,
+};
+
+/* FW_URL: device hands the broker a signed artifact URL (sender) */
+
+static int d_fw_url_start(struct pouch_bearer *bearer)
+{
+    (void) bearer;
+    return sender_start_helper(&device_stubs.fw_url);
+}
+
+static enum pouch_result d_fw_url_send(struct pouch_bearer *bearer, void *dst, size_t *dst_len)
+{
+    (void) bearer;
+    return sender_fill(&device_stubs.fw_url, dst, dst_len);
+}
+
+/* No end() callback, matching the real pouch_device_endpoint_fw_url. */
+const struct pouch_endpoint pouch_device_endpoint_fw_url = {
+    .start = d_fw_url_start,
+    .send = d_fw_url_send,
 };

--- a/tests/pouch/serial/exchange/src/stub_endpoints.h
+++ b/tests/pouch/serial/exchange/src/stub_endpoints.h
@@ -64,6 +64,8 @@ struct device_stubs
     struct stub_sender uplink;
     struct stub_receiver fw_status;
     struct stub_sender fw;
+    struct stub_receiver time;
+    struct stub_sender fw_url;
 };
 
 extern struct broker_stubs broker_stubs;

--- a/tests/pouch/serial/fw/CMakeLists.txt
+++ b/tests/pouch/serial/fw/CMakeLists.txt
@@ -22,6 +22,7 @@ target_compile_definitions(app PRIVATE CONFIG_POUCH_COMMON_LOG_LEVEL=3)
 # pouch module's own build, as they do for the other serial test suites.
 target_sources(app PRIVATE
     ${POUCH_DIR}/src/transport/endpoints/device/fw.c
+    ${POUCH_DIR}/src/transport/endpoints/device/fw_status.c
 )
 
 target_sources(app PRIVATE src/test_fw.c)

--- a/tests/pouch/serial/fw_url/CMakeLists.txt
+++ b/tests/pouch/serial/fw_url/CMakeLists.txt
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(serial_fw_url_test)
+
+set(POUCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../..)
+
+target_include_directories(app PRIVATE
+    ${POUCH_DIR}/include
+    ${POUCH_DIR}/port/include
+    ${POUCH_DIR}/port/zephyr/include
+    ${POUCH_DIR}/src
+)
+
+# The endpoint log macros need CONFIG_POUCH_COMMON_LOG_LEVEL, normally provided
+# by Kconfig; define it directly since this builds the endpoints in isolation.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_COMMON_LOG_LEVEL=3)
+
+# Keep the record small enough that a test can hold a few of them on the stack;
+# the default is 1024, which only matters for what a real signer produces.
+target_compile_definitions(app PRIVATE CONFIG_POUCH_SERIAL_FW_URL_MAX_LEN=256)
+
+# The handoff under test, and the verdict channel it shares with the relay. The
+# port primitives come from the pouch module's own build, as they do for the
+# other serial test suites.
+target_sources(app PRIVATE
+    ${POUCH_DIR}/src/transport/endpoints/device/fw_url.c
+    ${POUCH_DIR}/src/transport/endpoints/device/fw_status.c
+)
+
+target_sources(app PRIVATE src/test_fw_url.c)

--- a/tests/pouch/serial/fw_url/prj.conf
+++ b/tests/pouch/serial/fw_url/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/pouch/serial/fw_url/src/test_fw_url.c
+++ b/tests/pouch/serial/fw_url/src/test_fw_url.c
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2026 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Device-side signed-URL handoff.
+ *
+ * The application announces an artifact through the public API and the broker
+ * collects a record describing it through the serial endpoint. These tests
+ * drive the endpoint vtables directly, so no serial core is involved.
+ *
+ * Two properties matter more than the rest. A signature that cannot be produced
+ * yet - no signer, or a clock that has not been set - must leave the handoff
+ * pending rather than failing the transfer, because the session it would fail
+ * is the one carrying everything else. And a rejected artifact has to be
+ * re-announceable from the apply verdict, which is the only notification the
+ * device ever gets.
+ */
+
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/ztest.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <pouch/transport/serial/fw_url.h>
+
+#include "transport/endpoints/device/endpoints.h"
+
+#define ARTIFACT_SIZE 250948
+#define BASE_URL "https://gw.golioth.io/.u/c/rpmsg_device@1.0.3"
+
+/* What the fake signer appends, standing in for nb/na/cert/sig. */
+#define SIGNATURE_SUFFIX "?nb=1000&na=1090&cert=Y2VydA&sig=c2ln"
+
+static const uint8_t hash[32] = {0xaa, 0xbb, 0xcc, 0xdd};
+
+static int sign_err;             /* what the fake signer returns */
+static size_t sign_len_override; /* non-zero: claim this length instead */
+static int sign_calls;
+
+static int fake_sign(const char *url, size_t url_len, char *out, size_t out_len, size_t *olen)
+{
+    sign_calls++;
+
+    if (sign_err != 0)
+    {
+        return sign_err;
+    }
+
+    if (sign_len_override != 0)
+    {
+        *olen = sign_len_override;
+        return 0;
+    }
+
+    int n = snprintf(out, out_len, "%.*s%s", (int) url_len, url, SIGNATURE_SUFFIX);
+    if (n < 0 || (size_t) n >= out_len)
+    {
+        return -ENOMEM;
+    }
+
+    *olen = (size_t) n;
+    return 0;
+}
+
+/* Verdicts seen by the registered callback. */
+static enum pouch_serial_fw_status seen[8];
+static int seen_count;
+
+static void record_status(enum pouch_serial_fw_status status)
+{
+    if (seen_count < (int) ARRAY_SIZE(seen))
+    {
+        seen[seen_count] = status;
+    }
+    seen_count++;
+}
+
+/** Deliver an apply verdict the way the broker's FW_STATUS frame would. */
+static int deliver_status(uint8_t status)
+{
+    return pouch_device_endpoint_fw_status.recv(NULL, &status, 1);
+}
+
+/**
+ * Collect the URL endpoint until it reports the transfer finished.
+ *
+ * Returns the number of bytes collected, or a negative value if the endpoint
+ * kept asking to be called again - which would stall the broker's session.
+ */
+static int collect_url(uint8_t *out, size_t out_size)
+{
+    size_t total = 0;
+
+    zassert_ok(pouch_device_endpoint_fw_url.start(NULL));
+
+    for (int i = 0; i < 64; i++)
+    {
+        size_t len = out_size - total;
+        enum pouch_result result = pouch_device_endpoint_fw_url.send(NULL, &out[total], &len);
+
+        zassert_not_equal(result, POUCH_ERROR, "handoff reported an error while collecting");
+        total += len;
+
+        if (result == POUCH_NO_MORE_DATA)
+        {
+            return (int) total;
+        }
+    }
+
+    return -EAGAIN;
+}
+
+/** Push a time record through the endpoint the way a broker frame would. */
+static void deliver_time(const uint8_t *rec, size_t len, bool success)
+{
+    zassert_ok(pouch_device_endpoint_time.start(NULL));
+    if (len > 0)
+    {
+        zassert_ok(pouch_device_endpoint_time.recv(NULL, rec, len));
+    }
+    pouch_device_endpoint_time.end(NULL, success);
+}
+
+static void build_time_record(uint8_t rec[POUCH_SERIAL_TIME_LEN], uint32_t magic, int64_t seconds)
+{
+    sys_put_le32(magic, &rec[0]);
+    sys_put_le64((uint64_t) seconds, &rec[4]);
+}
+
+/* Seconds reported to the time callback. */
+static int64_t time_seen;
+static int time_calls;
+
+static void record_time(int64_t seconds)
+{
+    time_seen = seconds;
+    time_calls++;
+}
+
+static void before(void *f)
+{
+    ARG_UNUSED(f);
+
+    /* Leave no handoff pending for the next test. */
+    pouch_serial_fw_url_abort();
+    pouch_serial_fw_url_signer_set(fake_sign);
+    pouch_serial_fw_status_callback_set(NULL);
+    pouch_serial_time_callback_set(NULL);
+
+    sign_err = 0;
+    sign_len_override = 0;
+    sign_calls = 0;
+    seen_count = 0;
+    time_calls = 0;
+    time_seen = 0;
+    memset(seen, 0, sizeof(seen));
+}
+
+ZTEST_SUITE(pouch_serial_fw_url, NULL, NULL, before, NULL, NULL);
+
+ZTEST(pouch_serial_fw_url, test_idle_poll_is_an_empty_transfer)
+{
+    uint8_t buf[64];
+
+    zassert_false(pouch_serial_fw_url_active());
+    zassert_equal(collect_url(buf, sizeof(buf)), 0, "an idle handoff should hand over nothing");
+    zassert_equal(sign_calls, 0, "an idle handoff should not sign anything");
+}
+
+ZTEST(pouch_serial_fw_url, test_announced_artifact_is_handed_over)
+{
+    uint8_t buf[512];
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    zassert_true(pouch_serial_fw_url_active());
+
+    int len = collect_url(buf, sizeof(buf));
+
+    const char *version = "1.0.3";
+    const char *package = "rpmsg_device";
+    size_t ver_len = strlen(version);
+    size_t pkg_len = strlen(package);
+    const char *expect_url = BASE_URL SIGNATURE_SUFFIX;
+    size_t url_len = strlen(expect_url);
+
+    zassert_equal(len,
+                  (int) (POUCH_SERIAL_FW_URL_HDR_FIXED_LEN + ver_len + pkg_len + url_len),
+                  "record length should cover the header, both names and the signed URL");
+
+    zassert_equal(sys_get_le32(&buf[0]), POUCH_SERIAL_FW_URL_MAGIC);
+    zassert_equal(sys_get_le32(&buf[4]), ARTIFACT_SIZE, "artifact size should be on the wire");
+    zassert_mem_equal(&buf[8], hash, sizeof(hash), "the manifest digest should be on the wire");
+    zassert_equal(buf[40], ver_len);
+    zassert_equal(buf[41], pkg_len);
+    zassert_equal(sys_get_le16(&buf[42]), url_len);
+
+    size_t off = POUCH_SERIAL_FW_URL_HDR_FIXED_LEN;
+    zassert_mem_equal(&buf[off], version, ver_len, "version should follow the header");
+    off += ver_len;
+    zassert_mem_equal(&buf[off], package, pkg_len, "package should follow the version");
+    off += pkg_len;
+    zassert_mem_equal(&buf[off], expect_url, url_len, "the signed URL should follow the names");
+
+    zassert_equal(sign_calls, 1, "the URL should be signed exactly once per handoff");
+
+    /* Handed over: the host owns the fetch now, and a second poll finds nothing. */
+    zassert_false(pouch_serial_fw_url_active());
+    zassert_equal(collect_url(buf, sizeof(buf)), 0);
+}
+
+ZTEST(pouch_serial_fw_url, test_record_survives_a_small_collection_buffer)
+{
+    uint8_t whole[512];
+    uint8_t piecemeal[512];
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    int len = collect_url(whole, sizeof(whole));
+    zassert_true(len > 64, "record should be larger than one collection below");
+
+    /* The broker's frames are smaller than the record, so the endpoint has to
+     * be called repeatedly and must produce the same bytes either way.
+     */
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    zassert_ok(pouch_device_endpoint_fw_url.start(NULL));
+
+    size_t total = 0;
+    for (int i = 0; i < 64; i++)
+    {
+        size_t chunk = 16;
+        enum pouch_result result =
+            pouch_device_endpoint_fw_url.send(NULL, &piecemeal[total], &chunk);
+        zassert_not_equal(result, POUCH_ERROR);
+        total += chunk;
+        if (result == POUCH_NO_MORE_DATA)
+        {
+            break;
+        }
+    }
+
+    zassert_equal((int) total, len, "a fragmented collection should carry the same record");
+    zassert_mem_equal(piecemeal, whole, total);
+}
+
+ZTEST(pouch_serial_fw_url, test_unsignable_handoff_stays_pending)
+{
+    uint8_t buf[512];
+
+    sign_err = -EINVAL;
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+
+    /* A signer that cannot sign yet - typically a clock that has not been set -
+     * must not fail the transfer: the session carries the rest of Pouch too.
+     */
+    zassert_equal(collect_url(buf, sizeof(buf)), 0, "a failed signature should hand over nothing");
+    zassert_true(pouch_serial_fw_url_active(), "the handoff should still be pending");
+
+    /* Once signing works, the next poll picks it up. */
+    sign_err = 0;
+    int len = collect_url(buf, sizeof(buf));
+    zassert_true(len > 0, "the handoff should be signed and collected on a later poll");
+    zassert_false(pouch_serial_fw_url_active());
+}
+
+ZTEST(pouch_serial_fw_url, test_handoff_without_a_signer_stays_pending)
+{
+    uint8_t buf[512];
+
+    pouch_serial_fw_url_signer_set(NULL);
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    zassert_equal(collect_url(buf, sizeof(buf)), 0);
+    zassert_true(pouch_serial_fw_url_active());
+}
+
+ZTEST(pouch_serial_fw_url, test_oversized_signature_is_refused)
+{
+    uint8_t buf[512];
+
+    /* A signer that reports more than the record can hold must not be trusted
+     * about the length: the bytes it claims are not there.
+     */
+    sign_len_override = CONFIG_POUCH_SERIAL_FW_URL_MAX_LEN + 1;
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    zassert_equal(collect_url(buf, sizeof(buf)), 0);
+    zassert_true(pouch_serial_fw_url_active());
+}
+
+ZTEST(pouch_serial_fw_url, test_begin_rejects_bad_input)
+{
+    char long_name[POUCH_SERIAL_FW_MAX_NAME_LEN + 2];
+    memset(long_name, 'x', sizeof(long_name) - 1);
+    long_name[sizeof(long_name) - 1] = '\0';
+
+    zassert_equal(pouch_serial_fw_url_begin(NULL, "1.0.3", ARTIFACT_SIZE, hash, BASE_URL), -EINVAL);
+    zassert_equal(pouch_serial_fw_url_begin("pkg", NULL, ARTIFACT_SIZE, hash, BASE_URL), -EINVAL);
+    zassert_equal(pouch_serial_fw_url_begin("pkg", "1.0.3", ARTIFACT_SIZE, NULL, BASE_URL),
+                  -EINVAL);
+    zassert_equal(pouch_serial_fw_url_begin("pkg", "1.0.3", ARTIFACT_SIZE, hash, NULL), -EINVAL);
+    zassert_equal(pouch_serial_fw_url_begin("pkg", "1.0.3", 0, hash, BASE_URL), -EINVAL);
+    zassert_equal(pouch_serial_fw_url_begin("", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL), -EINVAL);
+    zassert_equal(pouch_serial_fw_url_begin(long_name, "1.0.3", ARTIFACT_SIZE, hash, BASE_URL),
+                  -EINVAL,
+                  "a name longer than the wire field should be refused");
+    zassert_equal(pouch_serial_fw_url_begin("pkg", long_name, ARTIFACT_SIZE, hash, BASE_URL),
+                  -EINVAL);
+
+    zassert_false(pouch_serial_fw_url_active(), "no bad input should leave a handoff pending");
+}
+
+ZTEST(pouch_serial_fw_url, test_second_announcement_is_refused)
+{
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    zassert_equal(pouch_serial_fw_url_begin("rpmsg_device", "1.0.4", ARTIFACT_SIZE, hash, BASE_URL),
+                  -EBUSY);
+}
+
+ZTEST(pouch_serial_fw_url, test_abort_releases_the_handoff)
+{
+    uint8_t buf[512];
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    pouch_serial_fw_url_abort();
+
+    zassert_false(pouch_serial_fw_url_active());
+    zassert_equal(collect_url(buf, sizeof(buf)), 0);
+
+    /* And a later offer starts cleanly. */
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.4", ARTIFACT_SIZE, hash, BASE_URL));
+}
+
+ZTEST(pouch_serial_fw_url, test_time_record_is_accepted)
+{
+    uint8_t rec[POUCH_SERIAL_TIME_LEN];
+
+    pouch_serial_time_callback_set(record_time);
+    build_time_record(rec, POUCH_SERIAL_TIME_MAGIC, 1757000000);
+
+    deliver_time(rec, sizeof(rec), true);
+
+    zassert_equal(time_calls, 1, "the handler should see the broker's clock");
+    zassert_equal(time_seen, 1757000000);
+    zassert_true(pouch_serial_time_synced(), "a device told the time knows it has a host");
+}
+
+ZTEST(pouch_serial_fw_url, test_malformed_time_records_are_ignored)
+{
+    uint8_t rec[POUCH_SERIAL_TIME_LEN];
+
+    pouch_serial_time_callback_set(record_time);
+
+    /* Wrong magic. */
+    build_time_record(rec, 0xdeadbeef, 1757000000);
+    deliver_time(rec, sizeof(rec), true);
+
+    /* Too short. */
+    build_time_record(rec, POUCH_SERIAL_TIME_MAGIC, 1757000000);
+    deliver_time(rec, sizeof(rec) - 1, true);
+
+    /* A transfer the broker abandoned. */
+    deliver_time(rec, sizeof(rec), false);
+
+    /* An empty transfer, which is what a broker with no clock would send. */
+    deliver_time(NULL, 0, true);
+
+    zassert_equal(time_calls, 0, "nothing malformed should reach the handler");
+}
+
+ZTEST(pouch_serial_fw_url, test_rejected_artifact_can_be_reannounced_from_the_callback)
+{
+    uint8_t buf[512];
+
+    pouch_serial_fw_status_callback_set(record_status);
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    zassert_true(collect_url(buf, sizeof(buf)) > 0);
+    zassert_false(pouch_serial_fw_url_active(), "handed over, so no longer pending");
+
+    /* The verdict is the only notification the device gets: the cloud was told
+     * to stop offering the component when this was announced. Re-announcing
+     * from inside the handler is what has to work.
+     */
+    zassert_ok(deliver_status(POUCH_SERIAL_FW_STATUS_HASH_FAIL));
+    zassert_equal(seen_count, 1);
+    zassert_equal(seen[0], POUCH_SERIAL_FW_STATUS_HASH_FAIL);
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+    zassert_true(collect_url(buf, sizeof(buf)) > 0, "the retry should be collectable");
+}
+
+ZTEST(pouch_serial_fw_url, test_announcing_clears_a_stale_verdict)
+{
+    enum pouch_serial_fw_status status;
+
+    zassert_ok(deliver_status(POUCH_SERIAL_FW_STATUS_OK));
+    zassert_true(pouch_serial_fw_status_get(&status));
+
+    zassert_ok(pouch_serial_fw_url_begin("rpmsg_device", "1.0.3", ARTIFACT_SIZE, hash, BASE_URL));
+
+    zassert_false(pouch_serial_fw_status_get(&status),
+                  "a new artifact should not inherit the previous one's verdict");
+}

--- a/tests/pouch/serial/fw_url/testcase.yaml
+++ b/tests/pouch/serial/fw_url/testcase.yaml
@@ -1,0 +1,9 @@
+tests:
+  pouch.serial.fw_url:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+    tags: test_framework

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -6,6 +6,14 @@ manifest:
   group-filter: [+babblesim]
 
   projects:
+    # Signs artifact URLs on the device, so the host can fetch an image the
+    # device is entitled to without holding any credential of its own. Used by
+    # the rpmsg_device example; see examples/zephyr/rpmsg_device/README.md.
+    - name: signy
+      path: modules/lib/signy
+      revision: v0.2.0
+      url: https://github.com/golioth/signy.git
+
     - name: zephyr
       revision: v4.4.0
       url: https://github.com/zephyrproject-rtos/zephyr


### PR DESCRIPTION
A flashless core has the host apply its updates. The relay in #350 does that by
pulling the image through Pouch and pushing the plaintext back out — every byte
crosses the on-die link twice, and an 8 KB buffer sits in MCU RAM to cover the
gap between the two directions.

This moves the authority instead of the bytes. The MCU holds the device key, so
it signs a URL for its own artifact with [`signy`][signy] and hands the host
that; the host fetches the image itself, verifies size and SHA-256 against the
manifest, installs it and restarts the core. Nothing is buffered on the MCU and
no image byte crosses the link.

Background: [Signed URLs for Embedded Devices][blog1] and [Signed URLs on
ESP32][blog2].

[signy]: https://github.com/golioth/signy
[blog1]: https://blog.golioth.io/signed-urls-for-embedded-devices/
[blog2]: https://blog.golioth.io/signed-urls-on-esp32/

## What is here

- **Verdict split out of the relay** so a second delivery mechanism can report
  results without carrying the relay's buffer.
- **Two channels**: `TIME` (7, host → device) and `FW_URL` (8, device → host),
  plus an INFO capability bit so a host that does not implement them never
  pushes to a device that cannot answer.
- **Device endpoints** behind `CONFIG_POUCH_SERIAL_FW_SIGNED_URL`, default n and
  independent of the relay. Signing is done through a callback the application
  installs, so `src/transport` never depends on the signing library.
- **Example** builds both mechanisms and chooses per attempt, falling back to
  the relay when a signed URL is refused.
- **Gateway** fetches the artifact in the background and reports the verdict on
  the next session; `-signed-url`, `-download-dir`, `-download-timeout`, `-ca`.
- **CI**: a Go job (nothing built the gateway before) and a second imx95 entry
  with the handoff off, so the relay-only configuration keeps compiling.

## Three decisions worth reviewing

**Signing is lazy.** A signed URL is valid for ~90 s and the host may not
collect for several sessions, so the signature is made when the transfer opens,
not when the artifact is announced.

**Endpoints never fail a transfer.** No signer, no clock yet, an over-long
signature: all produce an empty transfer with the handoff still pending. An
error would fail the whole session, which is also carrying the uplink and
downlink.

**Time gets its own channel.** The MCU has no wall clock. The verdict channel is
silent until there is a verdict, INFO runs the wrong way, and the certificate
channels stop once provisioned — so none of them can carry it. Being told the
time doubles as the device's evidence that the host speaks this protocol.

## Known wart

signy needs a wall clock, which pulls in Zephyr's POSIX timers, which puts the
POSIX headers on the include path, at which point mbedTLS finds an
`<arpa/inet.h>` that declares its functions with `sa_family_t` — a type only
defined when the networking stack is built. A Pouch device over rpmsg has no IP
stack, so `x509_crt.c` fails to compile. The example aliases the type so the
declaration parses; nothing calls `inet_pton()`. Reported upstream as golioth/signy#18: the library reads the clock itself, and
on Zephyr 4.4 every route to `clock_gettime()` reaches `POSIX_SYSTEM_INTERFACES`,
so letting the application supply the time is the fix that actually removes the
constraint.

## Testing

- 219 ztest cases pass on native_sim, 13 of them a new `pouch.serial.fw_url`
  suite covering the record layout, lazy signing, the unsignable-stays-pending
  path, and re-announcing from the verdict callback.
- Go tests for record parsing, the downloader against `httptest` (verified,
  corrupted, short, over-long, refused, length mismatch, cancelled), and three
  signed-URL exchanges through the broker state machine.
- imx95_evk/mimx9596/m7 builds in three configurations: both mechanisms, relay
  only, and native_sim.
- **Validated on an FRDM-IMX95 against production Golioth.** Device reports
  1.0.1, cloud offers 1.0.3, device signs the URL, gateway downloads and
  verifies 126580 bytes in about a second, verdict `ok`, core restarted, and the
  cloud then sees the device reporting 1.0.3. The relay fallback was exercised
  too, in the run where the signature was refused: device took the verdict,
  switched mechanism, and the update still completed.

## One finding worth knowing

Golioth enforces the not-before stamp with **no clock-skew tolerance at all**.
Signing URLs locally at a range of offsets against production:

| `nb` offset | Result |
|---|---|
| +0s | 200 |
| +5s | 401 |
| +20s | 401 |
| +60s | 401 |

The bench board's clock was twenty seconds fast, so every signed URL came back
401 — and because the device falls back to relaying, the update still succeeded
and the failure was invisible in everything except the gateway log.

So the gateway reports **the server's** clock to the device rather than its own.
The offset comes from the `Date` header of responses it already makes, including
the error responses seen before it can authenticate, so it costs no extra
request and is re-learned every session rather than fixed at startup. Gating the
feature on the two clocks agreeing was the alternative and is worse: it makes
the degradation loud but still gives up signed URLs over something correctable.

A few seconds of backdating remains on top, covering what correction cannot —
the header's one-second resolution and the transit time before the device signs.
A host that disagrees with the server is warned about anyway, since a wrong
local clock breaks certificate validity windows and log timestamps regardless.

Verified on hardware with the board's clock set **45 seconds fast**, far beyond
anything a fixed margin could absorb:

```
WARN  this host's clock disagrees with the server; signed URLs are corrected
      for it, but the host clock is worth fixing  behind_server_by=-43.857s
INFO  artifact downloaded and verified  package=rpmsg_device version=1.0.3
      bytes=126580
INFO  core restarted on the new image  firmware=rpmsg_device-1.0.3.elf
```

Stack:
1. #304 `transport/rpmsg` — device-side transport
2. #349 `transport/rpmsg-broker` — the Go gateway
3. #350 `transport/rpmsg-ota` — MCU-mediated firmware relay
4. **this PR** `transport/rpmsg-signed-url` — signed-URL firmware delivery

Refs #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qt7dZyVifxnMVfSHJT1neN


