### PR TITLE
Gateway: Ensure downlink is always closed

### DIFF
--- a/src/gateway/downlink.c
+++ b/src/gateway/downlink.c
@@ -130,6 +130,14 @@ void pouch_gateway_downlink_end_cb(int status, void *arg)
                 downlink->data_available_cb(downlink->cb_arg);
             }
         }
+        return;
+    }
+
+    if (downlink->last_block == NULL)
+    {
+        // We never received the last block (or likely any data at all).
+        // Pass an empty dummy last block down to let the normal end-of-downlink mechanism run:
+        pouch_gateway_downlink_block_cb(NULL, 0, true, downlink);
     }
 }
 

--- a/src/gateway/uplink.c
+++ b/src/gateway/uplink.c
@@ -41,8 +41,16 @@ struct pouch_gateway_uplink
     void *end_cb_arg;
 };
 
-static void cleanup_uplink(struct pouch_gateway_uplink *uplink)
+static void end_uplink(struct pouch_gateway_uplink *uplink, int err)
 {
+    if (uplink->downlink)
+    {
+        pouch_gateway_downlink_end_cb(err, uplink->downlink);
+    }
+
+    uplink->end_cb(uplink->end_cb_arg,
+                   err ? POUCH_GATEWAY_UPLINK_ERROR_CLOUD : POUCH_GATEWAY_UPLINK_SUCCESS);
+
     struct pouch_buf *block;
 
     if (uplink->drain_block != NULL)
@@ -148,16 +156,14 @@ static void send_uplink_via_cloud(struct pouch_gateway_uplink *uplink)
     if (uplink->total_len == 0)
     {
         POUCH_LOG_DBG("No uplink data to send");
-        uplink->end_cb(uplink->end_cb_arg, POUCH_GATEWAY_UPLINK_SUCCESS);
-        cleanup_uplink(uplink);
+        end_uplink(uplink, 0);
         return;
     }
 
     if (!IS_ENABLED(CONFIG_POUCH_GATEWAY_CLOUD))
     {
         POUCH_LOG_INF("Cloud disabled, discarding %zu bytes of peripheral data", uplink->total_len);
-        uplink->end_cb(uplink->end_cb_arg, POUCH_GATEWAY_UPLINK_SUCCESS);
-        cleanup_uplink(uplink);
+        end_uplink(uplink, 0);
         return;
     }
 
@@ -172,22 +178,11 @@ static void send_uplink_via_cloud(struct pouch_gateway_uplink *uplink)
     if (err)
     {
         POUCH_LOG_ERR("Cloud forward failed: %d", err);
-        if (uplink->downlink)
-        {
-            pouch_gateway_downlink_end_cb(err, uplink->downlink);
-        }
-        uplink->end_cb(uplink->end_cb_arg, POUCH_GATEWAY_UPLINK_ERROR_CLOUD);
-    }
-    else
-    {
-        if (uplink->downlink)
-        {
-            pouch_gateway_downlink_end_cb(0, uplink->downlink);
-        }
-        uplink->end_cb(uplink->end_cb_arg, POUCH_GATEWAY_UPLINK_SUCCESS);
+        end_uplink(uplink, err);
+        return;
     }
 
-    cleanup_uplink(uplink);
+    end_uplink(uplink, 0);
 }
 
 int pouch_gateway_uplink_write(struct pouch_gateway_uplink *uplink,


### PR DESCRIPTION
While working on multi pouch sessions, I found that the gateway would leave the downlink open indefinitely if it never received any segments. This can happen both when there's no uplink data (which short circuits `send_uplink_via_cloud` in gateway/uplink.c) and when the downlink data is empty.

To deal with this without introducing any new API functions, we'll make two changes to the gateway behavior:

1. If the uplink is never started for any reason, we'll call the `pouch_gateway_downlink_end_cb` callback the same way we do after `pouch_gateway_cloud_forward_pouch` ends.
2. When ending the downlink, we'll now pass a synthetic empty last downlink block to `pouch_gateway_downlink_block_cb` to trigger the downlink_get_data machinery the same way the data receive callback would. Doing this instead of adding another "downlink_complete" function ensures that the downlink close processing is always done in the downlink endpoint context instead of running directly in the uplink close context.

I believe this issue is present even without the modified device behavior, we just never send empty uplinks in our applications.